### PR TITLE
Dockerize CI smoke test

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: FunPot Core CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Validate formatting
+        run: |
+          fmt_out=$(gofmt -l .)
+          if [ -n "$fmt_out" ]; then
+            echo "The following files need gofmt:" >&2
+            echo "$fmt_out" >&2
+            exit 1
+          fi
+
+      - name: Verify modules
+        run: go mod tidy
+
+      - name: Check module diff
+        run: |
+          if [ -n "$(git status --short go.mod go.sum)" ]; then
+            echo "go.mod or go.sum changed after go mod tidy. Run go mod tidy locally." >&2
+            git diff -- go.mod go.sum >&2
+            exit 1
+          fi
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build Docker image
+        run: docker build -t funpot-core:ci .
+
+      - name: Smoke test container
+        run: |
+          container_id=$(docker run -d -p 8080:8080 -e FUNPOT_ENV=ci funpot-core:ci)
+          trap 'docker logs "$container_id"; docker rm -f "$container_id" >/dev/null 2>&1' EXIT
+          for attempt in 1 2 3; do
+            if curl --fail --silent http://localhost:8080/healthz > /dev/null; then
+              break
+            fi
+            sleep 2
+          done
+          curl --fail http://localhost:8080/readyz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.22 AS build
+WORKDIR /app
+
+# Leverage caching by copying go.mod and go.sum first
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the application source
+COPY . .
+
+# Build the server binary for Linux
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/funpot ./cmd/server
+
+FROM debian:bookworm-slim AS runtime
+
+RUN useradd --system --uid 10001 --home /app --shell /sbin/nologin funpot && \
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=build /bin/funpot /usr/local/bin/funpot
+
+ENV FUNPOT_ENV=production \
+    FUNPOT_SERVER_ADDRESS=:8080
+
+EXPOSE 8080
+USER funpot
+
+ENTRYPOINT ["/usr/local/bin/funpot"]

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -39,6 +39,14 @@ Update this table whenever you introduce a new configuration surface.
 go run ./cmd/server
 ```
 
+Alternatively, you can build and run the container image defined in the
+repository `Dockerfile`:
+
+```bash
+docker build -t funpot-core:dev .
+docker run --rm -p 8080:8080 --env-file .env funpot-core:dev
+```
+
 On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /healthz` – liveness probe returning the current timestamp.
 - `GET /readyz` – readiness probe (currently always ready).


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for building the FunPot core service image
- extend the Gitea workflow to build the Docker image and smoke-test health endpoints
- document how to build and run the service via Docker for local development

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df8d8e845c832cb1d1754c1e0fa7ee