### PR TITLE
Add CD workflow for dev and main deployments

### DIFF
--- a/.gitea/workflows/cd.yml
+++ b/.gitea/workflows/cd.yml
@@ -1,0 +1,115 @@
+name: FunPot Core CD
+
+on:
+  push:
+    branches: ["main", "dev"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ${{ secrets.REGISTRY_IMAGE }}
+
+jobs:
+  publish-and-deploy:
+    name: Deploy to ${{ matrix.environment }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.gitea.com/runner-images:ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - environment: development
+            branch: dev
+            image_tags: "dev"
+            webhook_secret: DEV_DEPLOY_WEBHOOK_URL
+          - environment: production
+            branch: main
+            image_tags: "prod latest"
+            webhook_secret: PROD_DEPLOY_WEBHOOK_URL
+    if: startsWith(github.ref, 'refs/heads/') && github.ref_name == matrix.branch
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate registry configuration
+        shell: bash
+        env:
+          REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          missing=()
+          if [ -z "${IMAGE_NAME:-}" ]; then
+            missing+=("REGISTRY_IMAGE")
+          fi
+          if [ -z "${REGISTRY_USERNAME:-}" ]; then
+            missing+=("REGISTRY_USERNAME")
+          fi
+          if [ -z "${REGISTRY_PASSWORD:-}" ]; then
+            missing+=("REGISTRY_PASSWORD")
+          fi
+          if [ ${#missing[@]} -ne 0 ]; then
+            printf 'Missing required secrets: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Log in to container registry
+        shell: bash
+        env:
+          REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -n "${REGISTRY_URL:-}" ]; then
+            echo "$REGISTRY_PASSWORD" | docker login "$REGISTRY_URL" --username "$REGISTRY_USERNAME" --password-stdin
+          else
+            echo "$REGISTRY_PASSWORD" | docker login --username "$REGISTRY_USERNAME" --password-stdin
+          fi
+
+      - name: Build and push image
+        id: publish
+        shell: bash
+        env:
+          EXTRA_TAGS: ${{ matrix.image_tags }}
+        run: |
+          set -euo pipefail
+          image_name="${IMAGE_NAME}"
+          sha_tag="$image_name:${GITHUB_SHA}"
+          mapfile -t tags < <(printf '%s\n' "$sha_tag")
+          if [ -n "${EXTRA_TAGS:-}" ]; then
+            for tag in $EXTRA_TAGS; do
+              tags+=("$image_name:$tag")
+            done
+          fi
+          build_args=()
+          for tag in "${tags[@]}"; do
+            build_args+=("-t" "$tag")
+          done
+          docker build "${build_args[@]}" .
+          for tag in "${tags[@]}"; do
+            docker push "$tag"
+          done
+          printf 'image=%s\n' "$sha_tag" >> "$GITHUB_OUTPUT"
+          printf 'tags=%s\n' "${tags[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger deployment webhook
+        shell: bash
+        env:
+          DEPLOY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
+          WEBHOOK_SECRET_NAME: ${{ matrix.webhook_secret }}
+          IMAGE: ${{ steps.publish.outputs.image }}
+          ALL_TAGS: ${{ steps.publish.outputs.tags }}
+          TARGET_ENV: ${{ matrix.environment }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEPLOY_WEBHOOK_URL:-}" ]; then
+            printf 'Secret %s is not configured.\n' "$WEBHOOK_SECRET_NAME" >&2
+            exit 1
+          fi
+          curl -fsS -X POST "$DEPLOY_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "{\"image\":\"$IMAGE\",\"environment\":\"$TARGET_ENV\",\"git_sha\":\"${GITHUB_SHA}\",\"tags\":\"$ALL_TAGS\"}"

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -95,6 +95,11 @@ approximate sequencing, and validation criteria.
 - Exit Criteria: service meets SLO under projected load, observability alerts
   configured, runbooks updated.
 
+### Operational Automation
+- [x] Ship CD workflow that publishes per-branch images and triggers webhook-based
+  deploys for `dev` and `main` environments.
+- [ ] Add automated post-deployment smoke tests for webhook-driven rollouts.
+
 ## Cross-Cutting Workstreams
 - Security reviews, secrets rotation, and compliance updates each milestone.
 - Database migrations versioned and peer-reviewed.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -70,3 +70,32 @@ provided.
 
 As subsequent milestones introduce persistence, authentication, and domain
 modules, extend this guide with database and queue dependencies.
+
+## Continuous Delivery
+The repository ships with an automated CD workflow defined in
+`.gitea/workflows/cd.yml`. The pipeline runs on pushes to `dev` and `main`, as
+well as manual `workflow_dispatch` invocations, and performs the following:
+
+1. Logs into the configured container registry.
+2. Builds the application image and pushes environment-specific tags.
+   - `dev` branch: publishes `${REGISTRY_IMAGE}:${GITHUB_SHA}` and
+     `${REGISTRY_IMAGE}:dev`.
+   - `main` branch: publishes `${REGISTRY_IMAGE}:${GITHUB_SHA}` along with
+     `${REGISTRY_IMAGE}:prod` and `${REGISTRY_IMAGE}:latest`.
+3. Calls an HTTP webhook to trigger the deployment in the corresponding
+   environment without relying on SSH access.
+
+### Required secrets
+Configure the following repository secrets before enabling the workflow:
+
+- `REGISTRY_IMAGE` – fully qualified image reference, e.g.
+  `registry.example.com/funpot/core`.
+- `REGISTRY_USERNAME` / `REGISTRY_PASSWORD` – credentials with push access.
+- `REGISTRY_URL` – optional registry host (omit for Docker Hub).
+- `DEV_DEPLOY_WEBHOOK_URL` – HTTPS endpoint that accepts a POST request to
+  deploy the dev environment.
+- `PROD_DEPLOY_WEBHOOK_URL` – HTTPS endpoint for the production deployment.
+
+Each webhook receives a JSON payload that includes the freshly built image tag,
+target environment label, Git SHA, and the list of pushed tags. Use those
+fields to orchestrate the rollout on your hosting platform of choice.


### PR DESCRIPTION
## Summary
- add a CD workflow that publishes environment-specific image tags for dev and production and triggers webhook deployments
- document the new workflow configuration and secrets in the local setup guide
- record the automation milestone in the implementation plan

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f49e2c36b8832c8e2c2bc98a5f7aca