### PR TITLE
Simplify CD workflow for webhook-only deployments

### DIFF
--- a/.gitea/workflows/cd.yml
+++ b/.gitea/workflows/cd.yml
@@ -1,0 +1,51 @@
+name: FunPot Core CD
+
+on:
+  push:
+    branches: ["main", "dev"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  notify-deploy:
+    name: Deploy to ${{ matrix.environment }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - environment: development
+            branch: dev
+            webhook_secret: DEV_DEPLOY_WEBHOOK_URL
+          - environment: production
+            branch: main
+            webhook_secret: PROD_DEPLOY_WEBHOOK_URL
+    if: startsWith(github.ref, 'refs/heads/') && github.ref_name == matrix.branch
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure webhook secret is configured
+        shell: bash
+        env:
+          DEPLOY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
+          WEBHOOK_SECRET_NAME: ${{ matrix.webhook_secret }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEPLOY_WEBHOOK_URL:-}" ]; then
+            printf 'Secret %s is not configured.\n' "$WEBHOOK_SECRET_NAME" >&2
+            exit 1
+          fi
+
+      - name: Trigger deployment webhook
+        shell: bash
+        env:
+          DEPLOY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
+          TARGET_ENV: ${{ matrix.environment }}
+        run: |
+          set -euo pipefail
+          payload=$(printf '{"environment":"%s","branch":"%s","git_sha":"%s","repository":"%s"}' \
+            "$TARGET_ENV" "$GITHUB_REF_NAME" "$GITHUB_SHA" "$GITHUB_REPOSITORY")
+          curl -fsS -X POST "$DEPLOY_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$payload"

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -95,6 +95,11 @@ approximate sequencing, and validation criteria.
 - Exit Criteria: service meets SLO under projected load, observability alerts
   configured, runbooks updated.
 
+### Operational Automation
+- [x] Ship CD workflow that notifies environment-specific webhooks for `dev`
+  and `main` deployments without relying on a container registry.
+- [ ] Add automated post-deployment smoke tests for webhook-driven rollouts.
+
 ## Cross-Cutting Workstreams
 - Security reviews, secrets rotation, and compliance updates each milestone.
 - Database migrations versioned and peer-reviewed.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -70,3 +70,29 @@ provided.
 
 As subsequent milestones introduce persistence, authentication, and domain
 modules, extend this guide with database and queue dependencies.
+
+## Continuous Delivery
+The repository ships with an automated CD workflow defined in
+`.gitea/workflows/cd.yml`. The pipeline runs on pushes to `dev` and `main`, as
+well as manual `workflow_dispatch` invocations, and performs the following:
+
+1. Determines which environment corresponds to the branch (`dev` → development,
+   `main` → production).
+2. Sends an HTTPS POST request to the configured deployment webhook with the
+   target environment, branch name, commit SHA, and repository identifier.
+
+The webhook consumer is responsible for building and rolling out the
+application (for example, by pulling the latest sources and running a local
+Docker build). This keeps the workflow registry-free for teams that prefer to
+build images on the deployment host.
+
+### Required secrets
+Configure the following repository secrets before enabling the workflow:
+
+- `DEV_DEPLOY_WEBHOOK_URL` – HTTPS endpoint that accepts a POST request to
+  deploy the dev environment.
+- `PROD_DEPLOY_WEBHOOK_URL` – HTTPS endpoint for the production deployment.
+
+Each webhook receives a JSON payload with the keys `environment`, `branch`,
+`git_sha`, and `repository`. Use those fields to orchestrate the rollout on your
+hosting platform of choice.


### PR DESCRIPTION
## Summary
- streamline the CD workflow to skip registry authentication and simply notify the dev and main deployment webhooks
- document the webhook-only deployment model and required secrets in the local setup guide
- update the operational automation milestone to reflect the registry-free CD process

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f49e2c36b8832c8e2c2bc98a5f7aca