### PR TITLE
chore: update Go version to 1.22.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/funpot/funpot-go-core
 
-go 1.23.0
+go 1.22
 
-toolchain go1.24.3
+toolchain go1.22.2
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary
- set the module's go directive to 1.22
- pin the toolchain directive to go1.22.2 so local builds use that patch release

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_690a1472c438832caa223529854f36d6