### PR TITLE
fix(docker): align build image with Go 1.24.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22 AS build
+FROM golang:1.24.3 AS build
 WORKDIR /app
 
 # Leverage caching by copying go.mod and go.sum first


### PR DESCRIPTION
### Motivation
- Fix Docker build failure caused by a Go toolchain mismatch between the build image and the project `go.mod`/`toolchain` version.

### Description
- Update the build-stage base image in `Dockerfile` from `golang:1.22` to `golang:1.24.3` so `RUN go mod download` succeeds and the container toolchain matches `go.mod` (`go 1.24.0`, `toolchain go1.24.3`).
- Checklist:
  - [x] Update `Dockerfile` build image to `golang:1.24.3`.
  - [x] Commit the change.
  - [x] Run `go test ./...` in the repository.
  - [ ] Verify `docker build` in an environment with Docker/CI.

### Testing
- Ran `go test ./...` and the test run succeeded for the repository packages that contain tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84ea51e58832cb91392f1bd158347)