### PR TITLE
Fix users Postgres repository build errors and align update tests

### DIFF
--- a/internal/users/postgres.go
+++ b/internal/users/postgres.go
@@ -59,8 +59,11 @@ ON CONFLICT (telegram_id) DO NOTHING`
 		profile.ReferralCode,
 		profile.CreatedAt,
 		profile.UpdatedAt,
-	)
-	return err
+	); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Update persists an existing profile.
@@ -76,7 +79,7 @@ func (r *PostgresRepository) Update(ctx context.Context, profile Profile) error 
 		WHERE telegram_id = $1
 	`
 
-	result, err := r.pool.Exec(ctx, query,
+	result, err := r.db.ExecContext(ctx, query,
 		profile.TelegramID,
 		profile.Username,
 		profile.FirstName,
@@ -88,7 +91,11 @@ func (r *PostgresRepository) Update(ctx context.Context, profile Profile) error 
 	if err != nil {
 		return err
 	}
-	if result.RowsAffected() == 0 {
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
 		return ErrNotFound
 	}
 	return nil

--- a/internal/users/postgres_test.go
+++ b/internal/users/postgres_test.go
@@ -129,14 +129,15 @@ func TestPostgresRepository_Update(t *testing.T) {
 		UpdatedAt:    now,
 	}
 
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE users\nSET username = $1,\n    first_name = $2,\n    last_name = $3,\n    language_code = $4,\n    updated_at = $5\nWHERE telegram_id = $6")).
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE users\nSET username = $2,\n    first_name = $3,\n    last_name = $4,\n    language_code = $5,\n    referral_code = $6,\n    updated_at = $7\nWHERE telegram_id = $1")).
 		WithArgs(
+			profile.TelegramID,
 			profile.Username,
 			profile.FirstName,
 			profile.LastName,
 			profile.LanguageCode,
+			profile.ReferralCode,
 			profile.UpdatedAt,
-			profile.TelegramID,
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -160,8 +161,8 @@ func TestPostgresRepository_UpdateNotFound(t *testing.T) {
 	now := time.Now().UTC()
 	profile := Profile{TelegramID: 42, UpdatedAt: now}
 
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE users\nSET username = $1,\n    first_name = $2,\n    last_name = $3,\n    language_code = $4,\n    updated_at = $5\nWHERE telegram_id = $6")).
-		WithArgs("", "", "", "", profile.UpdatedAt, profile.TelegramID).
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE users\nSET username = $2,\n    first_name = $3,\n    last_name = $4,\n    language_code = $5,\n    referral_code = $6,\n    updated_at = $7\nWHERE telegram_id = $1")).
+		WithArgs(profile.TelegramID, "", "", "", "", "", profile.UpdatedAt).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	err = repo.Update(context.Background(), profile)


### PR DESCRIPTION
### Motivation

- Compilation and `gofmt` were failing due to a syntax error in the users Postgres repository and mismatched SQL used by unit tests.
- The `Update` implementation referenced a non-existent `r.pool` and didn't robustly handle `RowsAffected()` errors, which could hide failures.

### Description

- Fixed `Create` to use a proper `if _, err := r.db.ExecContext(...); err != nil { return err }` pattern and return `nil` on success in `internal/users/postgres.go`.
- Replaced `r.pool.Exec` with `r.db.ExecContext` in `Update` and added checking of `RowsAffected()` (including handling its error) before returning `ErrNotFound`.
- Updated SQL mock expectations in `internal/users/postgres_test.go` to match the actual `UPDATE` statement (added `referral_code` and adjusted argument order to match `$1` = `telegram_id`).
- Changes were committed and a PR was created documenting the fix.

### Testing

- Ran `gofmt -w internal/users/postgres.go internal/users/postgres_test.go` successfully.
- Ran `go test ./internal/users` which passed (`ok`).
- Running `go test ./...` still fails due to pre-existing, unrelated errors in `internal/config/config.go`.

Checklist

- [x] Fix syntax error in `internal/users/postgres.go` so `gofmt`/build errors are resolved.
- [x] Update `Update` implementation to use `r.db.ExecContext` and handle `RowsAffected()` errors.
- [x] Update unit tests in `internal/users/postgres_test.go` to match the current SQL and argument order.
- [x] Run `gofmt` and `go test ./internal/users` (tests passed).
- [ ] Fix unrelated failures in `internal/config/config.go` so `go test ./...` passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0818e938832c80697d378cf7c119)