### PR TITLE
Fix undefined readiness callback in cmd/server

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/funpot/funpot-go-core/internal/app"
 	"github.com/funpot/funpot-go-core/internal/auth"
 	"github.com/funpot/funpot-go-core/internal/config"
-	"github.com/funpot/funpot-go-core/internal/database"
 	"github.com/funpot/funpot-go-core/internal/users"
 	dbpkg "github.com/funpot/funpot-go-core/pkg/database"
 	"github.com/funpot/funpot-go-core/pkg/telemetry"
@@ -85,6 +84,17 @@ func main() {
 	authService, err := auth.NewService(logger, cfg.Auth, userService)
 	if err != nil {
 		logger.Fatal("failed to create auth service", zap.Error(err))
+	}
+
+	readyFn := func() bool {
+		if db == nil {
+			return true
+		}
+
+		pingCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		return db.PingContext(pingCtx) == nil
 	}
 
 	handler := app.NewHandler(logger, readyFn, telemetryProvider.MetricsHandler(), authService, userService, cfg.Features.Flags)


### PR DESCRIPTION
### Motivation
- CI `go vet` for `cmd/server` failed because `readyFn` was referenced but not defined, breaking build checks.
- Provide a concrete readiness function that reflects DB connectivity when Postgres is configured and remains healthy in in-memory mode.

### Description
- Define `readyFn` in `cmd/server/main.go` that returns `true` when no DB is configured and otherwise performs `db.PingContext` with a 2s timeout.
- Wire the new `readyFn` into `app.NewHandler` instead of the previously missing identifier.
- Remove the now-unused `internal/database` import from `cmd/server/main.go` to keep imports clean.

### Testing
- Ran `go vet ./cmd/server` which completed successfully and no `undefined` identifier remains.
- Ran `go test ./cmd/server` which succeeded (no test files in the package). 
- Checklist:
  - [x] Fix undefined `readyFn` and implement DB-backed readiness check.
  - [x] Wire `readyFn` into `app.NewHandler`.
  - [x] Remove unused import `internal/database` from `cmd/server/main.go`.
  - [x] Verified `go vet ./cmd/server` locally.
  - [x] Verified `go test ./cmd/server` locally.
  - [ ] Run full test suite `go test ./...` and linting (`golangci-lint`) in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab1788ba88832ca243b825ccd1a7a2)