### PR TITLE
Refactor DB config to use discrete env fields instead of URL

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -56,9 +56,9 @@ func main() {
 		userRepo users.Repository
 	)
 
-	if cfg.Database.URL != "" {
+	if cfg.Database.DSN() != "" {
 		db, err = dbpkg.OpenPostgres(dbpkg.PostgresSettings{
-			DSN:             cfg.Database.URL,
+			DSN:             cfg.Database.DSN(),
 			MaxOpenConns:    cfg.Database.MaxOpenConns,
 			MaxIdleConns:    cfg.Database.MaxIdleConns,
 			ConnMaxIdleTime: cfg.Database.ConnMaxIdleTime,
@@ -75,7 +75,7 @@ func main() {
 
 		userRepo = users.NewPostgresRepository(db)
 	} else {
-		logger.Warn("FUNPOT_DATABASE_URL not provided; using in-memory users repository")
+		logger.Warn("database connection parameters not provided; using in-memory users repository")
 		userRepo = users.NewInMemoryRepository()
 	}
 

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -31,7 +31,12 @@ FUNPOT_AUTH_TELEGRAM_BOT_TOKEN=<telegram_bot_token>
 FUNPOT_AUTH_JWT_SECRET=dev-secret
 FUNPOT_AUTH_JWT_TTL=15m
 FUNPOT_DATABASE_ENABLED=true
-FUNPOT_DATABASE_URL=postgres://funpot:funpot@localhost:5432/funpot?sslmode=disable
+FUNPOT_DATABASE_HOST=localhost
+FUNPOT_DATABASE_PORT=5432
+FUNPOT_DATABASE_NAME=funpot
+FUNPOT_DATABASE_USER=funpot
+FUNPOT_DATABASE_PASSWORD=funpot
+FUNPOT_DATABASE_SSLMODE=disable
 FUNPOT_DATABASE_MAX_OPEN_CONNS=10
 FUNPOT_DATABASE_MIN_OPEN_CONNS=1
 FUNPOT_DATABASE_CONNECT_TIMEOUT=5s
@@ -58,12 +63,12 @@ docker run --rm -p 5432:5432 \
   postgres:16
 ```
 
-Once the container is running, export `FUNPOT_DATABASE_URL` from the config example above (or update `.env`) to match your credentials. Apply database migrations before starting the server:
+Once the container is running, export database fields from the config example above (or update `.env`). Build a DSN for tools like `migrate` and apply database migrations before starting the server:
 
 ```bash
 go run github.com/golang-migrate/migrate/v4/cmd/migrate@latest \
   -path migrations \
-  -database "$FUNPOT_DATABASE_URL" up
+  -database "postgres://${FUNPOT_DATABASE_USER}:${FUNPOT_DATABASE_PASSWORD}@${FUNPOT_DATABASE_HOST}:${FUNPOT_DATABASE_PORT}/${FUNPOT_DATABASE_NAME}?sslmode=${FUNPOT_DATABASE_SSLMODE}" up
 ```
 
 ## Running the Server
@@ -81,7 +86,7 @@ docker run --name funpot-postgres \
 Apply migrations before starting the API:
 
 ```bash
-migrate -path ./migrations -database "$FUNPOT_DATABASE_URL" up
+migrate -path ./migrations -database "postgres://${FUNPOT_DATABASE_USER}:${FUNPOT_DATABASE_PASSWORD}@${FUNPOT_DATABASE_HOST}:${FUNPOT_DATABASE_PORT}/${FUNPOT_DATABASE_NAME}?sslmode=${FUNPOT_DATABASE_SSLMODE}" up
 ```
 
 Then start the service:
@@ -106,7 +111,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/me` – returns the authenticated user's profile when called with the issued JWT.
 - `GET /api/config` – exposes seeded feature flags for the authenticated user.
 
-When `FUNPOT_DATABASE_URL` is unset the server falls back to the in-memory
+When database connection fields are unset the server falls back to the in-memory
 repository for user profiles. This is useful for quick smoke tests but bypasses
 database persistence; prefer configuring PostgreSQL locally to exercise the
 full stack.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -58,7 +59,12 @@ type AuthConfig struct {
 // DatabaseConfig controls PostgreSQL connectivity.
 type DatabaseConfig struct {
 	Enabled         bool
-	URL             string
+	Host            string
+	Port            int
+	Name            string
+	User            string
+	Password        string
+	SSLMode         string
 	MaxOpenConns    int
 	MinOpenConns    int
 	MaxIdleConns    int
@@ -66,6 +72,26 @@ type DatabaseConfig struct {
 	ConnMaxLifetime time.Duration
 	ConnectTimeout  time.Duration
 	HealthcheckPing time.Duration
+}
+
+// DSN builds a PostgreSQL connection string from database fields.
+func (d DatabaseConfig) DSN() string {
+	if d.Host == "" || d.Port <= 0 || d.Name == "" || d.User == "" {
+		return ""
+	}
+
+	connURL := &url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(d.User, d.Password),
+		Host:   fmt.Sprintf("%s:%d", d.Host, d.Port),
+		Path:   d.Name,
+	}
+
+	q := connURL.Query()
+	q.Set("sslmode", d.SSLMode)
+	connURL.RawQuery = q.Encode()
+
+	return connURL.String()
 }
 
 // JWTConfig holds settings for token issuance.
@@ -163,6 +189,11 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 
+	databasePort, err := getInt("FUNPOT_DATABASE_PORT", 5432)
+	if err != nil {
+		return Config{}, err
+	}
+
 	cfg := Config{
 		Environment: getString("FUNPOT_ENV", "development"),
 		Server: ServerConfig{
@@ -193,7 +224,12 @@ func Load() (Config, error) {
 		},
 		Database: DatabaseConfig{
 			Enabled:         databaseEnabled,
-			URL:             os.Getenv("FUNPOT_DATABASE_URL"),
+			Host:            os.Getenv("FUNPOT_DATABASE_HOST"),
+			Port:            databasePort,
+			Name:            os.Getenv("FUNPOT_DATABASE_NAME"),
+			User:            os.Getenv("FUNPOT_DATABASE_USER"),
+			Password:        os.Getenv("FUNPOT_DATABASE_PASSWORD"),
+			SSLMode:         getString("FUNPOT_DATABASE_SSLMODE", "disable"),
 			MaxOpenConns:    maxOpenConns,
 			MinOpenConns:    minOpenConns,
 			MaxIdleConns:    maxIdleConns,
@@ -207,8 +243,13 @@ func Load() (Config, error) {
 		},
 	}
 
-	if cfg.Database.Enabled && cfg.Database.URL == "" {
-		return Config{}, fmt.Errorf("FUNPOT_DATABASE_URL is required when FUNPOT_DATABASE_ENABLED=true")
+	if cfg.Database.Enabled {
+		if cfg.Database.Host == "" || cfg.Database.Name == "" || cfg.Database.User == "" {
+			return Config{}, fmt.Errorf("FUNPOT_DATABASE_HOST, FUNPOT_DATABASE_NAME and FUNPOT_DATABASE_USER are required when FUNPOT_DATABASE_ENABLED=true")
+		}
+		if cfg.Database.Port < 1 || cfg.Database.Port > 65535 {
+			return Config{}, fmt.Errorf("FUNPOT_DATABASE_PORT must be between 1 and 65535")
+		}
 	}
 
 	if cfg.Database.MinOpenConns < 0 || cfg.Database.MaxOpenConns < 1 || cfg.Database.MinOpenConns > cfg.Database.MaxOpenConns {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,7 +8,12 @@ import (
 
 func TestLoadDatabaseConfig(t *testing.T) {
 	t.Setenv("FUNPOT_DATABASE_ENABLED", "true")
-	t.Setenv("FUNPOT_DATABASE_URL", "postgres://funpot:funpot@localhost:5432/funpot?sslmode=disable")
+	t.Setenv("FUNPOT_DATABASE_HOST", "localhost")
+	t.Setenv("FUNPOT_DATABASE_PORT", "5432")
+	t.Setenv("FUNPOT_DATABASE_NAME", "funpot")
+	t.Setenv("FUNPOT_DATABASE_USER", "funpot")
+	t.Setenv("FUNPOT_DATABASE_PASSWORD", "funpot")
+	t.Setenv("FUNPOT_DATABASE_SSLMODE", "disable")
 	t.Setenv("FUNPOT_DATABASE_MAX_OPEN_CONNS", "20")
 	t.Setenv("FUNPOT_DATABASE_MIN_OPEN_CONNS", "2")
 	t.Setenv("FUNPOT_DATABASE_CONNECT_TIMEOUT", "7s")
@@ -22,8 +27,8 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	if !cfg.Database.Enabled {
 		t.Fatalf("expected database enabled")
 	}
-	if cfg.Database.URL == "" {
-		t.Fatalf("expected database url to be set")
+	if cfg.Database.DSN() == "" {
+		t.Fatalf("expected database connection settings to be set")
 	}
 	if cfg.Database.MaxOpenConns != 20 {
 		t.Fatalf("expected max open conns 20, got %d", cfg.Database.MaxOpenConns)
@@ -46,19 +51,33 @@ func TestLoadDatabaseValidation(t *testing.T) {
 		unsets []string
 	}{
 		{
-			name: "missing url when enabled",
+			name: "missing host when enabled",
 			env: map[string]string{
 				"FUNPOT_DATABASE_ENABLED": "true",
+				"FUNPOT_DATABASE_NAME":    "funpot",
+				"FUNPOT_DATABASE_USER":    "funpot",
 			},
-			unsets: []string{"FUNPOT_DATABASE_URL"},
+			unsets: []string{"FUNPOT_DATABASE_HOST"},
 		},
 		{
 			name: "invalid pool bounds",
 			env: map[string]string{
 				"FUNPOT_DATABASE_ENABLED":        "true",
-				"FUNPOT_DATABASE_URL":            "postgres://funpot:funpot@localhost:5432/funpot?sslmode=disable",
+				"FUNPOT_DATABASE_HOST":           "localhost",
+				"FUNPOT_DATABASE_NAME":           "funpot",
+				"FUNPOT_DATABASE_USER":           "funpot",
 				"FUNPOT_DATABASE_MAX_OPEN_CONNS": "2",
 				"FUNPOT_DATABASE_MIN_OPEN_CONNS": "5",
+			},
+		},
+		{
+			name: "invalid port",
+			env: map[string]string{
+				"FUNPOT_DATABASE_ENABLED": "true",
+				"FUNPOT_DATABASE_HOST":    "localhost",
+				"FUNPOT_DATABASE_PORT":    "70000",
+				"FUNPOT_DATABASE_NAME":    "funpot",
+				"FUNPOT_DATABASE_USER":    "funpot",
 			},
 		},
 	}

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -12,7 +12,7 @@ import (
 
 // OpenPostgresPool creates and validates a PostgreSQL connection pool.
 func OpenPostgresPool(ctx context.Context, cfg config.DatabaseConfig) (*pgxpool.Pool, error) {
-	poolCfg, err := pgxpool.ParseConfig(cfg.URL)
+	poolCfg, err := pgxpool.ParseConfig(cfg.DSN())
 	if err != nil {
 		return nil, fmt.Errorf("parse database url: %w", err)
 	}


### PR DESCRIPTION
### Motivation
- Replace a single `FUNPOT_DATABASE_URL` string with explicit DB fields to make connection settings clearer and easier to validate.
- Allow building a canonical DSN from structured fields and enforce required fields/port range when `FUNPOT_DATABASE_ENABLED=true`.

### Description
- Replace `DatabaseConfig.URL` with `Host/Port/Name/User/Password/SSLMode` fields and add `DatabaseConfig.DSN()` which composes a PostgreSQL DSN. 
- Read new environment variables (`FUNPOT_DATABASE_HOST`, `FUNPOT_DATABASE_PORT`, `FUNPOT_DATABASE_NAME`, `FUNPOT_DATABASE_USER`, `FUNPOT_DATABASE_PASSWORD`, `FUNPOT_DATABASE_SSLMODE`) in `config.Load()` and validate required fields and port range. 
- Use the composed DSN in runtime code by switching server startup to `cfg.Database.DSN()` and updating the internal pgx pool initializer to parse `cfg.DSN()`.
- Update configuration tests (`internal/config/config_test.go`) to exercise the new variables and add a test case for invalid port; update local setup docs (`docs/local_setup.md`) and migration examples to show the separate variables and example DSN.

### Testing
- Ran `gofmt` and `go test ./...`, and all automated tests passed (`go test ./...` returned success across packages). 
- Verified unit test updates in `internal/config` and ensured `DatabaseConfig.DSN()` is exercised by tests.

Checklist
- [x] Replace `FUNPOT_DATABASE_URL` with discrete env vars and fields in `DatabaseConfig`.
- [x] Add `DatabaseConfig.DSN()` helper to build a DSN from fields.
- [x] Update server and internal Postgres pool usage to consume the composed DSN.
- [x] Update and run config tests to reflect new env vars and add invalid-port case.
- [x] Update `docs/local_setup.md` with new environment variables and migration command example.
- [ ] Update external deployment manifests/secrets (helm/CI/CD) to provide the new variables where applicable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8a3f735c832ca03ae5013d95ecc3)