### PR TITLE
fix(cd): run Gitea CD workflow directly on pushes to main/dev

### DIFF
--- a/.gitea/workflows/cd.yml
+++ b/.gitea/workflows/cd.yml
@@ -1,10 +1,11 @@
 name: FunPot Core CD
 
 on:
-  workflow_run:
-    workflows: ["FunPot Core CI"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -43,14 +44,11 @@ jobs:
             migration_mode_secret: PROD_MIGRATIONS_MODE
             healthcheck_timeout: 420
             healthcheck_interval: 10
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == matrix.branch
+    if: ${{ github.ref_name == matrix.branch }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.sha }}
 
       - name: Verify registry configuration
         run: |
@@ -75,7 +73,7 @@ jobs:
       - name: Resolve image reference
         id: image
         env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           IMAGE_REF="${REGISTRY_URL}/${REGISTRY_REPOSITORY}:${HEAD_SHA}"
@@ -133,7 +131,7 @@ jobs:
           WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
           ENVIRONMENT: ${{ matrix.environment }}
           BRANCH: ${{ matrix.branch }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ -z "${WEBHOOK_URL:-}" ]; then


### PR DESCRIPTION
### Motivation
- The CD workflow was not reliably starting in Gitea because it relied on GitHub-centric `workflow_run` events and `github.event.workflow_run.*` fields that are unsupported or unreliable in Gitea Actions. 
- The goal is to make deployments deterministic in Gitea by triggering the CD workflow directly on pushes to the canonical branches and allow manual runs.

### Description
- Replace `on: workflow_run` with `on: push` for `main` and `dev` and add `workflow_dispatch` to `.gitea/workflows/cd.yml`. 
- Replace the complex `workflow_run` condition with `if: ${{ github.ref_name == matrix.branch }}` to gate matrix environments by branch. 
- Replace usages of `github.event.workflow_run.head_sha` with `github.sha` for `actions/checkout`, image reference resolution, and the webhook payload so the workflow operates from the current push context.

### Testing
- Ran `git diff --check`, which returned no issues. 
- Attempted to validate the YAML with `python -c` using `yaml.safe_load`, but the environment lacks `PyYAML` resulting in a `ModuleNotFoundError`. 
- Checklist: [x] analyzed CD workflow and identified `workflow_run` issue; [x] updated `.gitea/workflows/cd.yml` to use `push`/`workflow_dispatch`; [x] changed branch gating to `github.ref_name`; [x] replaced `workflow_run` SHA refs with `github.sha` in checkout/image/webhook; [x] committed changes and created PR; [ ] verify an actual CD run on push to `dev` and `main` in your Gitea instance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afefe07994832ca16088fa559ec91d)