### PR TITLE
Fix CD workflow YAML parsing error in webhook payload step

### DIFF
--- a/.gitea/workflows/cd.yml
+++ b/.gitea/workflows/cd.yml
@@ -138,14 +138,8 @@ jobs:
             echo "Webhook URL secret '${{ matrix.webhook_secret }}' is missing." >&2
             exit 1
           fi
-          cat <<EOF >payload.json
-{
-  "environment": "${ENVIRONMENT}",
-  "branch": "${BRANCH}",
-  "image": "${IMAGE_REF}",
-  "sha": "${HEAD_SHA}"
-}
-EOF
+          printf '{"environment":"%s","branch":"%s","image":"%s","sha":"%s"}\n' \
+            "$ENVIRONMENT" "$BRANCH" "$IMAGE_REF" "$HEAD_SHA" >payload.json
           curl -fsSL -X POST -H 'Content-Type: application/json' --data @payload.json "$WEBHOOK_URL"
 
       - name: Resolve healthcheck target


### PR DESCRIPTION
### Motivation
- The CD workflow at ` .gitea/workflows/cd.yml` failed YAML parsing (`could not find expected ':'`) because the webhook payload heredoc block broke YAML structure and prevented the pipeline from loading. 
- Ensure the CD pipeline can be parsed and executed by Gitea Actions so deployments are not blocked by workflow-load errors. 
- Surface other CI/CD compatibility risks found during review so they can be addressed in follow-ups. 

### Description
- Replaced the problematic heredoc JSON block in the `Trigger environment webhook` step of ` .gitea/workflows/cd.yml` with a single-line `printf` that writes a compact JSON payload to `payload.json` to avoid YAML parsing issues. 
- Kept the change constrained to ` .gitea/workflows/cd.yml` and committed the fix. 
- Left notes about additional compatibility concerns in ` .gitea/workflows/ci.yml` and ` .gitea/workflows/cd.yml` for follow-up (runner labels and `if:` expression contexts). 

### Testing
- Parsed both workflows with PyYAML using `yaml.safe_load` which now reports `OK` for ` .gitea/workflows/ci.yml` and ` .gitea/workflows/cd.yml`. ✅
- Ran `actionlint` against the workflow files which completed but reported compatibility/style warnings such as unknown custom runner label `ubuntu-build`, use of `secrets.*` in `if:` expressions, and `matrix.*` used at job-level `if:`; these are noted for follow-up. ⚠️
- Commit and PR created with the change; tests and validation commands executed during the rollout succeeded as reported. ✅

Checklist
- [x] Fix YAML parse error in ` .gitea/workflows/cd.yml` payload block
- [x] Validate workflows parse with `yaml.safe_load`
- [x] Run `actionlint` and capture compatibility warnings
- [x] Commit change and open PR
- [ ] Follow up to address `actionlint` warnings (runner label, `secrets.*` in `if:`, `matrix.*` usage)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff15369ac832c91ad742b03aa3c6c)