### PR TITLE
ci(cd): add retry loop when verifying published image

### DIFF
--- a/.gitea/workflows/cd.yml
+++ b/.gitea/workflows/cd.yml
@@ -84,7 +84,24 @@ jobs:
           IMAGE_REF: ${{ steps.image.outputs.image_ref }}
         run: |
           set -euo pipefail
-          docker pull "$IMAGE_REF"
+          timeout_seconds=300
+          interval_seconds=10
+          max_attempts=$(( (timeout_seconds + interval_seconds - 1) / interval_seconds ))
+
+          attempt=1
+          while [ "$attempt" -le "$max_attempts" ]; do
+            if docker pull "$IMAGE_REF"; then
+              echo "Published image is available: $IMAGE_REF"
+              exit 0
+            fi
+
+            echo "Attempt $attempt/$max_attempts: image is not published yet, retrying in ${interval_seconds}s"
+            sleep "$interval_seconds"
+            attempt=$((attempt + 1))
+          done
+
+          echo "Image was not published in time: $IMAGE_REF" >&2
+          exit 1
 
       - name: Run database migrations
         env:


### PR DESCRIPTION
### Motivation
- The CD job intermittently failed with `manifest unknown` when `docker pull` raced the image being published, causing spurious deploy failures.
- Add resiliency so deploys wait briefly and retry instead of failing immediately on transient registry propagation delays.

### Description
- Replace the single `docker pull "$IMAGE_REF"` in `.gitea/workflows/cd.yml` with a polling loop that retries up to 300 seconds with 10s intervals.
- The new step exits successfully as soon as `docker pull` succeeds and prints a clear error if the image is still unavailable after retries.
- Changes are committed under the message `ci(cd): add retry loop when verifying published image` and affect only `.gitea/workflows/cd.yml`.

### Testing
- Ran `git diff -- .gitea/workflows/cd.yml` to review the patch and confirm the intended shell changes succeeded. 
- Attempted to parse the workflow with a small Python `yaml.safe_load` check, but the environment lacked `PyYAML` so the parse check could not be completed. 
- Committed the change and created the PR so CI will run the updated workflow validation and deploy steps in the runner (CI result pending).

Checklist
- [x] Root cause identified as registry propagation race causing `manifest unknown`.
- [x] Added retry/polling logic to the `Verify published image` step in `.gitea/workflows/cd.yml`.
- [x] Changes committed and PR created.
- [ ] Observe CI/CD runs to confirm the flake is resolved in the real runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff304d934832caf3648cb30d5a711)