### PR TITLE
ci: split migration DB secrets instead of single URL

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -210,11 +210,21 @@ jobs:
         include:
           - environment: development
             branch: dev
-            database_url_secret: DEV_DATABASE_URL
+            database_host_secret: DEV_DATABASE_HOST
+            database_port_secret: DEV_DATABASE_PORT
+            database_name_secret: DEV_DATABASE_NAME
+            database_user_secret: DEV_DATABASE_USER
+            database_password_secret: DEV_DATABASE_PASSWORD
+            database_sslmode_secret: DEV_DATABASE_SSLMODE
             migration_mode_secret: DEV_MIGRATIONS_MODE
           - environment: production
             branch: main
-            database_url_secret: PROD_DATABASE_URL
+            database_host_secret: PROD_DATABASE_HOST
+            database_port_secret: PROD_DATABASE_PORT
+            database_name_secret: PROD_DATABASE_NAME
+            database_user_secret: PROD_DATABASE_USER
+            database_password_secret: PROD_DATABASE_PASSWORD
+            database_sslmode_secret: PROD_DATABASE_SSLMODE
             migration_mode_secret: PROD_MIGRATIONS_MODE
 
     steps:
@@ -225,15 +235,33 @@ jobs:
 
       - name: Run migration preflight
         env:
-          DATABASE_URL: ${{ secrets[matrix.database_url_secret] }}
+          DATABASE_HOST: ${{ secrets[matrix.database_host_secret] }}
+          DATABASE_PORT: ${{ secrets[matrix.database_port_secret] }}
+          DATABASE_NAME: ${{ secrets[matrix.database_name_secret] }}
+          DATABASE_USER: ${{ secrets[matrix.database_user_secret] }}
+          DATABASE_PASSWORD: ${{ secrets[matrix.database_password_secret] }}
+          DATABASE_SSLMODE: ${{ secrets[matrix.database_sslmode_secret] }}
           MIGRATIONS_MODE: ${{ secrets[matrix.migration_mode_secret] }}
         run: |
           set -euo pipefail
 
-          if [ -z "${DATABASE_URL:-}" ]; then
-            echo "Database URL secret '${{ matrix.database_url_secret }}' is missing; skipping migrations."
+          required_vars=(DATABASE_HOST DATABASE_PORT DATABASE_NAME DATABASE_USER DATABASE_PASSWORD)
+          missing=0
+          for v in "${required_vars[@]}"; do
+            if [ -z "${!v:-}" ]; then
+              echo "Database secret for $v is missing; skipping migrations."
+              missing=1
+            fi
+          done
+          if [ "$missing" -eq 1 ]; then
             exit 0
           fi
+
+          if [ -z "${DATABASE_SSLMODE:-}" ]; then
+            DATABASE_SSLMODE="require"
+          fi
+
+          DATABASE_URL="postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?sslmode=${DATABASE_SSLMODE}"
 
           MODE="${MIGRATIONS_MODE:-check}"
           MODE="$(printf '%s' "$MODE" | tr '[:upper:]' '[:lower:]')"

--- a/docs/ci_cd_registry_setup.md
+++ b/docs/ci_cd_registry_setup.md
@@ -14,16 +14,26 @@ The `FunPot Core CI` workflow expects these secrets:
 | `REGISTRY_USERNAME` | Service account or robot user with push/pull permissions. | Authenticates Docker login in CI. |
 | `REGISTRY_PASSWORD` | Token or password generated for the above user. | Authenticates Docker login in CI. |
 | `FUNPOT_AUTH_TELEGRAM_BOT_TOKEN` | Token issued by BotFather for the Telegram Mini App bot. | Enables smoke tests to authenticate against the container. |
-| `DEV_DATABASE_URL` | PostgreSQL DSN for development (URL-encoded, includes `sslmode`). | Used by CI migration preflight on `dev` branch. |
-| `PROD_DATABASE_URL` | PostgreSQL DSN for production (URL-encoded, includes `sslmode`). | Used by CI migration preflight on `main` branch. |
+| `DEV_DATABASE_HOST` | Development PostgreSQL host. | Used to compose CI migration DSN on `dev` branch. |
+| `DEV_DATABASE_PORT` | Development PostgreSQL port. | Used to compose CI migration DSN on `dev` branch. |
+| `DEV_DATABASE_NAME` | Development PostgreSQL database name. | Used to compose CI migration DSN on `dev` branch. |
+| `DEV_DATABASE_USER` | Development PostgreSQL user. | Used to compose CI migration DSN on `dev` branch. |
+| `DEV_DATABASE_PASSWORD` | Development PostgreSQL password. | Used to compose CI migration DSN on `dev` branch. |
+| `DEV_DATABASE_SSLMODE` | Development PostgreSQL sslmode (`disable`, `require`, etc.). | Optional, defaults to `require` in CI migration stage. |
+| `PROD_DATABASE_HOST` | Production PostgreSQL host. | Used to compose CI migration DSN on `main` branch. |
+| `PROD_DATABASE_PORT` | Production PostgreSQL port. | Used to compose CI migration DSN on `main` branch. |
+| `PROD_DATABASE_NAME` | Production PostgreSQL database name. | Used to compose CI migration DSN on `main` branch. |
+| `PROD_DATABASE_USER` | Production PostgreSQL user. | Used to compose CI migration DSN on `main` branch. |
+| `PROD_DATABASE_PASSWORD` | Production PostgreSQL password. | Used to compose CI migration DSN on `main` branch. |
+| `PROD_DATABASE_SSLMODE` | Production PostgreSQL sslmode (`disable`, `require`, etc.). | Optional, defaults to `require` in CI migration stage. |
 | `DEV_MIGRATIONS_MODE` | `check` or `apply`. | Controls dev migration behavior in CI (`check` default). |
 | `PROD_MIGRATIONS_MODE` | `check` or `apply`. | Controls production migration behavior in CI (`check` default, recommended). |
 
 ## Migration Stage in CI
 Migration execution was moved from CD to the CI workflow:
 
-- On `dev` pushes CI uses `DEV_DATABASE_URL` + `DEV_MIGRATIONS_MODE`.
-- On `main` pushes CI uses `PROD_DATABASE_URL` + `PROD_MIGRATIONS_MODE`.
+- On `dev` pushes CI uses `DEV_DATABASE_HOST/PORT/NAME/USER/PASSWORD(/SSLMODE)` + `DEV_MIGRATIONS_MODE`.
+- On `main` pushes CI uses `PROD_DATABASE_HOST/PORT/NAME/USER/PASSWORD(/SSLMODE)` + `PROD_MIGRATIONS_MODE`.
 - `check` (default): validates migration metadata (`migrate version`) and exits.
 - `apply`: runs preflight and then executes `migrate up`.
 

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -97,7 +97,7 @@ approximate sequencing, and validation criteria.
 ### Operational Automation
 - [x] Ship CI workflow that publishes per-branch images for external deployment
   automation (`dev` and `main`).
-- [x] Move migration preflight/apply stage into CI (`DEV/PROD_DATABASE_URL`,
+- [x] Move migration preflight/apply stage into CI (`DEV/PROD_DATABASE_HOST|PORT|NAME|USER|PASSWORD|SSLMODE`,
   `DEV/PROD_MIGRATIONS_MODE`).
 - [x] Document Watchtower as the deployment mechanism outside repository
   workflows.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -146,8 +146,8 @@ Recommended tag mapping:
 ### Migration checks in CI
 Database migration validation now runs in `FunPot Core CI`:
 
-- `dev` branch uses `DEV_DATABASE_URL` + `DEV_MIGRATIONS_MODE`
-- `main` branch uses `PROD_DATABASE_URL` + `PROD_MIGRATIONS_MODE`
+- `dev` branch uses `DEV_DATABASE_HOST/PORT/NAME/USER/PASSWORD(/SSLMODE)` + `DEV_MIGRATIONS_MODE`
+- `main` branch uses `PROD_DATABASE_HOST/PORT/NAME/USER/PASSWORD(/SSLMODE)` + `PROD_MIGRATIONS_MODE`
 
 Mode behavior:
 
@@ -156,7 +156,17 @@ Mode behavior:
 
 Set these repository secrets before enabling branch deployment automation:
 
-- `DEV_DATABASE_URL`
-- `PROD_DATABASE_URL`
+- `DEV_DATABASE_HOST`
+- `DEV_DATABASE_PORT`
+- `DEV_DATABASE_NAME`
+- `DEV_DATABASE_USER`
+- `DEV_DATABASE_PASSWORD`
+- `DEV_DATABASE_SSLMODE` (optional, defaults to `require`)
+- `PROD_DATABASE_HOST`
+- `PROD_DATABASE_PORT`
+- `PROD_DATABASE_NAME`
+- `PROD_DATABASE_USER`
+- `PROD_DATABASE_PASSWORD`
+- `PROD_DATABASE_SSLMODE` (optional, defaults to `require`)
 - `DEV_MIGRATIONS_MODE` (`check` or `apply`)
 - `PROD_MIGRATIONS_MODE` (`check` or `apply`)


### PR DESCRIPTION
### Motivation
- The migration preflight step relied on a single `DEV/PROD_DATABASE_URL` secret which complicates secret rotation and management. 
- The goal is to use independent DB connection parameters (host/port/name/user/password/sslmode) per environment and assemble the DSN inside CI for clearer, safer secret handling.

### Description
- Updated `.gitea/workflows/ci.yml` migration matrix to accept `*_DATABASE_HOST`, `*_DATABASE_PORT`, `*_DATABASE_NAME`, `*_DATABASE_USER`, `*_DATABASE_PASSWORD`, and optional `*_DATABASE_SSLMODE` for both `dev` and `main` environments. 
- The migration step now validates required parts, defaults `DATABASE_SSLMODE` to `require` when unset, and composes `DATABASE_URL` as `postgres://user:pass@host:port/name?sslmode=...` before running `migrate`. 
- Documentation updated to match the new secret model in `docs/ci_cd_registry_setup.md`, `docs/local_setup.md`, and `docs/implementation_plan.md`. 
- Checklist (completed vs outstanding) aligned with the implementation plan: [x] CI switched to split DB secrets; [x] Docs updated; [x] Implementation plan synced; [x] Changes committed and PR created; [ ] Add new secrets to repository/infrastructure.

### Testing
- Ran automated tests with `go test ./...` and the test suite passed (package tests reported `ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69affcdfad7c832c84762ec6d637abde)