### PR TITLE
Fix migration preflight check mode to avoid DB DNS failures

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -245,6 +245,50 @@ jobs:
         run: |
           set -euo pipefail
 
+          MODE="${MIGRATIONS_MODE:-check}"
+          MODE="$(printf '%s' "$MODE" | tr '[:upper:]' '[:lower:]')"
+          if [ "$MODE" != "check" ] && [ "$MODE" != "apply" ]; then
+            echo "Invalid migrations mode '$MODE'. Allowed values: check, apply." >&2
+            exit 1
+          fi
+
+          if [ "$MODE" = "check" ]; then
+            echo "Running migration preflight for ${{ matrix.environment }} (mode=${MODE})"
+            echo "Validating migration files naming and up/down pairs (database connection is not required in check mode)."
+
+            mapfile -t up_files < <(find migrations -maxdepth 1 -type f -name '*.up.sql' -printf '%f\n' | sort)
+            mapfile -t down_files < <(find migrations -maxdepth 1 -type f -name '*.down.sql' -printf '%f\n' | sort)
+
+            if [ "${#up_files[@]}" -eq 0 ]; then
+              echo "No '*.up.sql' files found in migrations/." >&2
+              exit 1
+            fi
+
+            if [ "${#up_files[@]}" -ne "${#down_files[@]}" ]; then
+              echo "Migrations mismatch: ${#up_files[@]} up files vs ${#down_files[@]} down files." >&2
+              exit 1
+            fi
+
+            for up_file in "${up_files[@]}"; do
+              version="${up_file%%_*}"
+              case "$version" in
+                ''|*[!0-9]*)
+                  echo "Invalid migration version prefix in '$up_file'. Expected '<number>_<name>.up.sql'." >&2
+                  exit 1
+                  ;;
+              esac
+
+              expected_down="${up_file%.up.sql}.down.sql"
+              if [ ! -f "migrations/$expected_down" ]; then
+                echo "Missing down migration for '$up_file' (expected '$expected_down')." >&2
+                exit 1
+              fi
+            done
+
+            echo "Migrations mode is 'check'; migration files preflight completed successfully."
+            exit 0
+          fi
+
           required_vars=(DATABASE_HOST DATABASE_PORT DATABASE_NAME DATABASE_USER DATABASE_PASSWORD)
           missing=0
           for v in "${required_vars[@]}"; do
@@ -263,13 +307,6 @@ jobs:
 
           DATABASE_URL="postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?sslmode=${DATABASE_SSLMODE}"
 
-          MODE="${MIGRATIONS_MODE:-check}"
-          MODE="$(printf '%s' "$MODE" | tr '[:upper:]' '[:lower:]')"
-          if [ "$MODE" != "check" ] && [ "$MODE" != "apply" ]; then
-            echo "Invalid migrations mode '$MODE'. Allowed values: check, apply." >&2
-            exit 1
-          fi
-
           echo "Running migration preflight for ${{ matrix.environment }} (mode=${MODE})"
           docker run --rm \
             -v "$PWD/migrations:/migrations:ro" \
@@ -277,11 +314,6 @@ jobs:
             -path=/migrations \
             -database "$DATABASE_URL" \
             version
-
-          if [ "$MODE" = "check" ]; then
-            echo "Migrations mode is 'check'; skipping apply step."
-            exit 0
-          fi
 
           docker run --rm \
             -v "$PWD/migrations:/migrations:ro" \

--- a/docs/ci_cd_registry_setup.md
+++ b/docs/ci_cd_registry_setup.md
@@ -14,18 +14,18 @@ The `FunPot Core CI` workflow expects these secrets:
 | `REGISTRY_USERNAME` | Service account or robot user with push/pull permissions. | Authenticates Docker login in CI. |
 | `REGISTRY_PASSWORD` | Token or password generated for the above user. | Authenticates Docker login in CI. |
 | `FUNPOT_AUTH_TELEGRAM_BOT_TOKEN` | Token issued by BotFather for the Telegram Mini App bot. | Enables smoke tests to authenticate against the container. |
-| `DEV_DATABASE_HOST` | Development PostgreSQL host. | Used to compose CI migration DSN on `dev` branch. |
-| `DEV_DATABASE_PORT` | Development PostgreSQL port. | Used to compose CI migration DSN on `dev` branch. |
-| `DEV_DATABASE_NAME` | Development PostgreSQL database name. | Used to compose CI migration DSN on `dev` branch. |
-| `DEV_DATABASE_USER` | Development PostgreSQL user. | Used to compose CI migration DSN on `dev` branch. |
-| `DEV_DATABASE_PASSWORD` | Development PostgreSQL password. | Used to compose CI migration DSN on `dev` branch. |
-| `DEV_DATABASE_SSLMODE` | Development PostgreSQL sslmode (`disable`, `require`, etc.). | Optional, defaults to `require` in CI migration stage. |
-| `PROD_DATABASE_HOST` | Production PostgreSQL host. | Used to compose CI migration DSN on `main` branch. |
-| `PROD_DATABASE_PORT` | Production PostgreSQL port. | Used to compose CI migration DSN on `main` branch. |
-| `PROD_DATABASE_NAME` | Production PostgreSQL database name. | Used to compose CI migration DSN on `main` branch. |
-| `PROD_DATABASE_USER` | Production PostgreSQL user. | Used to compose CI migration DSN on `main` branch. |
-| `PROD_DATABASE_PASSWORD` | Production PostgreSQL password. | Used to compose CI migration DSN on `main` branch. |
-| `PROD_DATABASE_SSLMODE` | Production PostgreSQL sslmode (`disable`, `require`, etc.). | Optional, defaults to `require` in CI migration stage. |
+| `DEV_DATABASE_HOST` | Development PostgreSQL host. | Used to compose CI migration DSN on `dev` branch when mode is `apply`. |
+| `DEV_DATABASE_PORT` | Development PostgreSQL port. | Used to compose CI migration DSN on `dev` branch when mode is `apply`. |
+| `DEV_DATABASE_NAME` | Development PostgreSQL database name. | Used to compose CI migration DSN on `dev` branch when mode is `apply`. |
+| `DEV_DATABASE_USER` | Development PostgreSQL user. | Used to compose CI migration DSN on `dev` branch when mode is `apply`. |
+| `DEV_DATABASE_PASSWORD` | Development PostgreSQL password. | Used to compose CI migration DSN on `dev` branch when mode is `apply`. |
+| `DEV_DATABASE_SSLMODE` | Development PostgreSQL sslmode (`disable`, `require`, etc.). | Optional, defaults to `require` in CI migration stage when mode is `apply`. |
+| `PROD_DATABASE_HOST` | Production PostgreSQL host. | Used to compose CI migration DSN on `main` branch when mode is `apply`. |
+| `PROD_DATABASE_PORT` | Production PostgreSQL port. | Used to compose CI migration DSN on `main` branch when mode is `apply`. |
+| `PROD_DATABASE_NAME` | Production PostgreSQL database name. | Used to compose CI migration DSN on `main` branch when mode is `apply`. |
+| `PROD_DATABASE_USER` | Production PostgreSQL user. | Used to compose CI migration DSN on `main` branch when mode is `apply`. |
+| `PROD_DATABASE_PASSWORD` | Production PostgreSQL password. | Used to compose CI migration DSN on `main` branch when mode is `apply`. |
+| `PROD_DATABASE_SSLMODE` | Production PostgreSQL sslmode (`disable`, `require`, etc.). | Optional, defaults to `require` in CI migration stage when mode is `apply`. |
 | `DEV_MIGRATIONS_MODE` | `check` or `apply`. | Controls dev migration behavior in CI (`check` default). |
 | `PROD_MIGRATIONS_MODE` | `check` or `apply`. | Controls production migration behavior in CI (`check` default, recommended). |
 
@@ -34,8 +34,8 @@ Migration execution was moved from CD to the CI workflow:
 
 - On `dev` pushes CI uses `DEV_DATABASE_HOST/PORT/NAME/USER/PASSWORD(/SSLMODE)` + `DEV_MIGRATIONS_MODE`.
 - On `main` pushes CI uses `PROD_DATABASE_HOST/PORT/NAME/USER/PASSWORD(/SSLMODE)` + `PROD_MIGRATIONS_MODE`.
-- `check` (default): validates migration metadata (`migrate version`) and exits.
-- `apply`: runs preflight and then executes `migrate up`.
+- `check` (default): validates migration file set only (naming + up/down pair consistency) and exits without DB connection.
+- `apply`: runs DB preflight (`migrate version`) and then executes `migrate up`.
 
 This keeps schema validation in the pipeline while leaving deployment orchestration
 to external infrastructure.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -151,8 +151,8 @@ Database migration validation now runs in `FunPot Core CI`:
 
 Mode behavior:
 
-- `check` (default): execute migration metadata preflight only.
-- `apply`: execute preflight and then `migrate up`.
+- `check` (default): validate migration files naming and up/down pair consistency only (no DB connectivity required).
+- `apply`: execute DB preflight and then `migrate up`.
 
 Set these repository secrets before enabling branch deployment automation:
 


### PR DESCRIPTION
### Motivation
- The CI `migration preflight` step in `check` mode still invoked `migrate version` which required a live DB and caused DNS/network failures (e.g. `lookup ... on 8.8.8.8:53: no such host`), so the pipeline needs a DB-less preflight that validates migration files only.

### Description
- Add mode handling to the `Run migration preflight` step in `.gitea/workflows/ci.yml` so `MIGRATIONS_MODE=check` validates migration files locally (presence of `*.up.sql`, one-to-one `up/down` pairing, numeric version prefix) and exits without contacting the database. 
- Preserve the original DB-backed flow for `MIGRATIONS_MODE=apply`, which composes `DATABASE_URL` and runs the `migrate` Docker image with `version` and `up` commands. 
- Update documentation in `docs/ci_cd_registry_setup.md` and `docs/local_setup.md` to clarify that `check` validates file naming/pairing only and that DB secrets are required only for `apply`.

### Testing
- Executed the new shell preflight logic locally against the `migrations/` directory (using the `find`/`mapfile` checks and numeric-prefix validation) and it completed successfully. 
- Verified the workflow file changes were committed and a PR was created with the title `Fix migration preflight check mode to avoid DB DNS failures`.
- Checklist of deliverables: [x] Update CI preflight to run DB-less `check` mode, [x] Keep `apply` behavior with DB-backed `migrate`, [x] Update docs to reflect new mode semantics, [x] Local preflight validation succeeded, [ ] Observe a full CI run on the remote runner and confirm pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0040b5b5c832cbe774182777da8e0)