### PR TITLE
ci: show DB host and redacted connection params in migration preflight logs

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -305,7 +305,17 @@ jobs:
             DATABASE_SSLMODE="require"
           fi
 
+          echo "Resolved database connection settings for ${{ matrix.environment }}:"
+          echo "  DATABASE_HOST=${DATABASE_HOST}"
+          echo "  DATABASE_PORT=${DATABASE_PORT}"
+          echo "  DATABASE_NAME=${DATABASE_NAME}"
+          echo "  DATABASE_USER=${DATABASE_USER}"
+          echo "  DATABASE_SSLMODE=${DATABASE_SSLMODE}"
+
           DATABASE_URL="postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?sslmode=${DATABASE_SSLMODE}"
+          DATABASE_URL_REDACTED="postgres://${DATABASE_USER}:***@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?sslmode=${DATABASE_SSLMODE}"
+
+          echo "  DATABASE_URL=${DATABASE_URL_REDACTED}"
 
           echo "Running migration preflight for ${{ matrix.environment }} (mode=${MODE})"
           docker run --rm --network host \


### PR DESCRIPTION
### Motivation
- Make migration preflight logs in CI reveal which database host and connection parameters are injected from secrets while ensuring the database password is not exposed.

### Description
- Update ` .gitea/workflows/ci.yml` to echo `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_NAME`, `DATABASE_USER`, and `DATABASE_SSLMODE`, and to print a redacted `DATABASE_URL` (password masked as `***`) before constructing the full `DATABASE_URL` used for migrations.

### Testing
- No automated unit tests were executed locally; repository CI will still run `gofmt`, `go vet`, and `go test ./...` as part of its normal pipeline to validate the change.
- Checklist: [x] Echo DB connection parameters added to ` .gitea/workflows/ci.yml`, [x] Password redaction implemented (`DATABASE_URL_REDACTED`), [x] Changes committed, [x] PR created, [ ] Await CI run and verify logs on runner

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b022f920c8832c82e5349795402195)