### PR TITLE
Add core domain services, HTTP endpoints and DB migrations for streamers/games/events/votes/wallet/payments/referrals/media

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,7 +13,15 @@ import (
 	"github.com/funpot/funpot-go-core/internal/app"
 	"github.com/funpot/funpot-go-core/internal/auth"
 	"github.com/funpot/funpot-go-core/internal/config"
+	"github.com/funpot/funpot-go-core/internal/events"
+	"github.com/funpot/funpot-go-core/internal/games"
+	"github.com/funpot/funpot-go-core/internal/media"
+	"github.com/funpot/funpot-go-core/internal/payments"
+	"github.com/funpot/funpot-go-core/internal/referrals"
+	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
+	"github.com/funpot/funpot-go-core/internal/votes"
+	"github.com/funpot/funpot-go-core/internal/wallet"
 	dbpkg "github.com/funpot/funpot-go-core/pkg/database"
 	"github.com/funpot/funpot-go-core/pkg/telemetry"
 )
@@ -81,6 +89,27 @@ func main() {
 
 	userService := users.NewService(userRepo)
 
+	var (
+		streamerService  *streamers.Service
+		gamesService     *games.Service
+		eventsService    *events.Service
+		votesService     *votes.Service
+		walletService    *wallet.Service
+		paymentsService  *payments.Service
+		referralsService *referrals.Service
+		mediaService     *media.Service
+	)
+	if db != nil {
+		streamerService = streamers.NewService(db)
+		gamesService = games.NewService(db)
+		eventsService = events.NewService(db)
+		votesService = votes.NewService(db)
+		walletService = wallet.NewService(db)
+		paymentsService = payments.NewService(db)
+		referralsService = referrals.NewService(db)
+		mediaService = media.NewService(db)
+	}
+
 	authService, err := auth.NewService(logger, cfg.Auth, userService)
 	if err != nil {
 		logger.Fatal("failed to create auth service", zap.Error(err))
@@ -97,7 +126,22 @@ func main() {
 		return db.PingContext(pingCtx) == nil
 	}
 
-	handler := app.NewHandler(logger, readyFn, telemetryProvider.MetricsHandler(), authService, userService, cfg.Features.Flags)
+	handler := app.NewHandler(
+		logger,
+		readyFn,
+		telemetryProvider.MetricsHandler(),
+		authService,
+		userService,
+		cfg.Features.Flags,
+		streamerService,
+		gamesService,
+		eventsService,
+		votesService,
+		walletService,
+		paymentsService,
+		referralsService,
+		mediaService,
+	)
 
 	application, err := app.New(cfg, logger, handler)
 	if err != nil {

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -110,6 +110,11 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `POST /api/auth/telegram` – verifies Telegram Mini App `initData` and returns a short-lived JWT.
 - `GET /api/me` – returns the authenticated user's profile when called with the issued JWT.
 - `GET /api/config` – exposes seeded feature flags for the authenticated user.
+- `GET/POST /api/streamers`, `GET /api/games`, `GET /api/events/live`, `POST /api/votes`, `GET /api/wallet`, `POST /api/payments/stars/createInvoice`, `GET /api/referrals/summary`, `GET /api/referrals/payouts`, `GET /api/media/clips`.
+
+> These core domain endpoints require PostgreSQL migrations to be applied. If
+> the service starts without DB settings, these routes respond with
+> `503 Service Unavailable`.
 
 When database connection fields are unset the server falls back to the in-memory
 repository for user profiles. This is useful for quick smoke tests but bypasses

--- a/docs/migrations_plan.md
+++ b/docs/migrations_plan.md
@@ -1,8 +1,12 @@
 # Migration Plan
 
 ## v1 (Initial Release)
-> Current status: migration scaffolding added in `migrations/0001_users.up.sql`
-> and `migrations/0001_users.down.sql` for the `users` domain.
+> Current status: base `users` migration plus core domain schema migrations are
+> available in:
+> - `migrations/0001_users.up.sql`
+> - `migrations/0001_users.down.sql`
+> - `migrations/0002_core_domains.up.sql`
+> - `migrations/0002_core_domains.down.sql`
 
 1. Create core tables: `users`, `wallet_accounts`, `wallet_ledger`, `payments`, `streamers`, `games`, `events`, `votes`, `media_clips`, `prompts`, `config`, `referrals`, `idempotency`.
 2. Seed configuration values: `minViewers=100`, `starsRate`, `limits.votePerMin`, feature flags (`paymentsEnabled`, `referralsEnabled`, `mediaEnabled`, `adminEnabled`).

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -12,7 +12,15 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/funpot/funpot-go-core/internal/auth"
+	"github.com/funpot/funpot-go-core/internal/events"
+	"github.com/funpot/funpot-go-core/internal/games"
+	"github.com/funpot/funpot-go-core/internal/media"
+	"github.com/funpot/funpot-go-core/internal/payments"
+	"github.com/funpot/funpot-go-core/internal/referrals"
+	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
+	"github.com/funpot/funpot-go-core/internal/votes"
+	"github.com/funpot/funpot-go-core/internal/wallet"
 )
 
 type readinessState struct {
@@ -28,8 +36,22 @@ type configResponse struct {
 	Features map[string]bool `json:"features"`
 }
 
+type createStreamerRequest struct {
+	TwitchUsername string `json:"twitchUsername"`
+}
+
+type createInvoiceRequest struct {
+	AmountINT int `json:"amountINT"`
+}
+
+type castVoteRequest struct {
+	EventID  string `json:"eventId"`
+	OptionID string `json:"optionId"`
+	Cost     int    `json:"cost"`
+}
+
 // NewHandler wires the base HTTP routes for the service.
-func NewHandler(logger *zap.Logger, readyFn func() bool, metricsHandler http.Handler, authService *auth.Service, userService *users.Service, featureFlags map[string]bool) http.Handler {
+func NewHandler(logger *zap.Logger, readyFn func() bool, metricsHandler http.Handler, authService *auth.Service, userService *users.Service, featureFlags map[string]bool, streamerService *streamers.Service, gamesService *games.Service, eventsService *events.Service, votesService *votes.Service, walletService *wallet.Service, paymentsService *payments.Service, referralsService *referrals.Service, mediaService *media.Service) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -138,6 +160,242 @@ func NewHandler(logger *zap.Logger, readyFn func() bool, metricsHandler http.Han
 				return
 			}
 			writeJSON(w, http.StatusOK, configResponse{Features: featureFlags})
+		})))
+
+		mux.Handle("/api/streamers", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if streamerService == nil {
+				writeError(w, http.StatusServiceUnavailable, "streamers service requires configured database")
+				return
+			}
+			switch r.Method {
+			case http.MethodGet:
+				page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+				items, err := streamerService.List(r.Context(), r.URL.Query().Get("query"), page, 20)
+				if err != nil {
+					writeError(w, http.StatusInternalServerError, "failed to list streamers")
+					return
+				}
+				writeJSON(w, http.StatusOK, items)
+			case http.MethodPost:
+				defer r.Body.Close() //nolint:errcheck
+				var req createStreamerRequest
+				if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+					writeError(w, http.StatusBadRequest, "invalid request body")
+					return
+				}
+				if req.TwitchUsername == "" {
+					writeError(w, http.StatusBadRequest, "twitchUsername is required")
+					return
+				}
+				item, err := streamerService.Create(r.Context(), req.TwitchUsername)
+				if err != nil {
+					writeError(w, http.StatusInternalServerError, "failed to create streamer")
+					return
+				}
+				writeJSON(w, http.StatusOK, item)
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		})))
+
+		mux.Handle("/api/games", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if gamesService == nil {
+				writeError(w, http.StatusServiceUnavailable, "games service requires configured database")
+				return
+			}
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			streamerID := r.URL.Query().Get("streamerId")
+			if streamerID == "" {
+				writeError(w, http.StatusBadRequest, "streamerId is required")
+				return
+			}
+			items, err := gamesService.ListByStreamer(r.Context(), streamerID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to list games")
+				return
+			}
+			writeJSON(w, http.StatusOK, items)
+		})))
+
+		mux.Handle("/api/events/live", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if eventsService == nil {
+				writeError(w, http.StatusServiceUnavailable, "events service requires configured database")
+				return
+			}
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			streamerID := r.URL.Query().Get("streamerId")
+			if streamerID == "" {
+				writeError(w, http.StatusBadRequest, "streamerId is required")
+				return
+			}
+			items, err := eventsService.ListLive(r.Context(), streamerID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to load live events")
+				return
+			}
+			writeJSON(w, http.StatusOK, items)
+		})))
+
+		mux.Handle("/api/votes", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if votesService == nil {
+				writeError(w, http.StatusServiceUnavailable, "votes service requires configured database")
+				return
+			}
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			if r.Header.Get("Idempotency-Key") == "" {
+				writeError(w, http.StatusBadRequest, "Idempotency-Key header is required")
+				return
+			}
+			defer r.Body.Close() //nolint:errcheck
+			var req castVoteRequest
+			if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+				writeError(w, http.StatusBadRequest, "invalid request body")
+				return
+			}
+			if req.EventID == "" || req.OptionID == "" || req.Cost < 0 {
+				writeError(w, http.StatusBadRequest, "eventId, optionId and non-negative cost are required")
+				return
+			}
+			claims, ok := auth.ClaimsFromContext(r.Context())
+			if !ok {
+				writeError(w, http.StatusUnauthorized, "missing auth claims")
+				return
+			}
+			resp, err := votesService.Cast(r.Context(), claims.TelegramID, r.Header.Get("Idempotency-Key"), votes.CastRequest{EventID: req.EventID, Option: req.OptionID, Cost: req.Cost})
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to cast vote")
+				return
+			}
+			writeJSON(w, http.StatusOK, resp)
+		})))
+
+		mux.Handle("/api/wallet", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if walletService == nil {
+				writeError(w, http.StatusServiceUnavailable, "wallet service requires configured database")
+				return
+			}
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			claims, ok := auth.ClaimsFromContext(r.Context())
+			if !ok {
+				writeError(w, http.StatusUnauthorized, "missing auth claims")
+				return
+			}
+			snapshot, err := walletService.GetByTelegramID(r.Context(), claims.TelegramID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to load wallet")
+				return
+			}
+			writeJSON(w, http.StatusOK, snapshot)
+		})))
+
+		mux.Handle("/api/payments/stars/createInvoice", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if paymentsService == nil {
+				writeError(w, http.StatusServiceUnavailable, "payments service requires configured database")
+				return
+			}
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			defer r.Body.Close() //nolint:errcheck
+			var req createInvoiceRequest
+			if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+				writeError(w, http.StatusBadRequest, "invalid request body")
+				return
+			}
+			if req.AmountINT < 1 {
+				writeError(w, http.StatusBadRequest, "amountINT must be greater than zero")
+				return
+			}
+			claims, ok := auth.ClaimsFromContext(r.Context())
+			if !ok {
+				writeError(w, http.StatusUnauthorized, "missing auth claims")
+				return
+			}
+			invoice, err := paymentsService.CreateStarsInvoice(r.Context(), claims.TelegramID, req.AmountINT)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to create invoice")
+				return
+			}
+			writeJSON(w, http.StatusOK, invoice)
+		})))
+
+		mux.Handle("/api/referrals/summary", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if referralsService == nil {
+				writeError(w, http.StatusServiceUnavailable, "referrals service requires configured database")
+				return
+			}
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			claims, ok := auth.ClaimsFromContext(r.Context())
+			if !ok {
+				writeError(w, http.StatusUnauthorized, "missing auth claims")
+				return
+			}
+			summary, err := referralsService.GetSummary(r.Context(), claims.TelegramID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to load referral summary")
+				return
+			}
+			writeJSON(w, http.StatusOK, summary)
+		})))
+
+		mux.Handle("/api/referrals/payouts", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if referralsService == nil {
+				writeError(w, http.StatusServiceUnavailable, "referrals service requires configured database")
+				return
+			}
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			claims, ok := auth.ClaimsFromContext(r.Context())
+			if !ok {
+				writeError(w, http.StatusUnauthorized, "missing auth claims")
+				return
+			}
+			items, err := referralsService.ListPayouts(r.Context(), claims.TelegramID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to load referral payouts")
+				return
+			}
+			writeJSON(w, http.StatusOK, items)
+		})))
+
+		mux.Handle("/api/media/clips", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if mediaService == nil {
+				writeError(w, http.StatusServiceUnavailable, "media service requires configured database")
+				return
+			}
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			streamerID := r.URL.Query().Get("streamerId")
+			if streamerID == "" {
+				writeError(w, http.StatusBadRequest, "streamerId is required")
+				return
+			}
+			items, err := mediaService.ListClips(r.Context(), streamerID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to load media clips")
+				return
+			}
+			writeJSON(w, http.StatusOK, items)
 		})))
 	}
 

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -1,0 +1,38 @@
+package events
+
+import (
+	"context"
+	"database/sql"
+)
+
+type LiveEvent struct {
+	ID         string   `json:"id"`
+	StreamerID string   `json:"streamerId"`
+	Title      string   `json:"title"`
+	Status     string   `json:"status"`
+	Options    []string `json:"options"`
+}
+
+type Service struct{ db *sql.DB }
+
+func NewService(db *sql.DB) *Service { return &Service{db: db} }
+
+func (s *Service) ListLive(ctx context.Context, streamerID string) ([]LiveEvent, error) {
+	const q = `SELECT id, streamer_id, title, status FROM events WHERE streamer_id = $1 AND status = 'live' ORDER BY created_at DESC`
+	rows, err := s.db.QueryContext(ctx, q, streamerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	items := make([]LiveEvent, 0)
+	for rows.Next() {
+		var item LiveEvent
+		if err := rows.Scan(&item.ID, &item.StreamerID, &item.Title, &item.Status); err != nil {
+			return nil, err
+		}
+		item.Options = []string{}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}

--- a/internal/games/service.go
+++ b/internal/games/service.go
@@ -1,0 +1,36 @@
+package games
+
+import (
+	"context"
+	"database/sql"
+)
+
+type Game struct {
+	ID         string `json:"id"`
+	StreamerID string `json:"streamerId"`
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+}
+
+type Service struct{ db *sql.DB }
+
+func NewService(db *sql.DB) *Service { return &Service{db: db} }
+
+func (s *Service) ListByStreamer(ctx context.Context, streamerID string) ([]Game, error) {
+	const q = `SELECT id, streamer_id, name, status FROM games WHERE streamer_id = $1 ORDER BY created_at DESC`
+	rows, err := s.db.QueryContext(ctx, q, streamerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	items := make([]Game, 0)
+	for rows.Next() {
+		var item Game
+		if err := rows.Scan(&item.ID, &item.StreamerID, &item.Name, &item.Status); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}

--- a/internal/media/service.go
+++ b/internal/media/service.go
@@ -1,0 +1,36 @@
+package media
+
+import (
+	"context"
+	"database/sql"
+)
+
+type Clip struct {
+	ID         string `json:"id"`
+	StreamerID string `json:"streamerId"`
+	URL        string `json:"url"`
+	DurationS  int    `json:"durationS"`
+}
+
+type Service struct{ db *sql.DB }
+
+func NewService(db *sql.DB) *Service { return &Service{db: db} }
+
+func (s *Service) ListClips(ctx context.Context, streamerID string) ([]Clip, error) {
+	const q = `SELECT id, streamer_id, url, duration_s FROM media_clips WHERE streamer_id = $1 ORDER BY created_at DESC`
+	rows, err := s.db.QueryContext(ctx, q, streamerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	items := make([]Clip, 0)
+	for rows.Next() {
+		var item Clip
+		if err := rows.Scan(&item.ID, &item.StreamerID, &item.URL, &item.DurationS); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}

--- a/internal/payments/service.go
+++ b/internal/payments/service.go
@@ -1,0 +1,34 @@
+package payments
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+type Invoice struct {
+	InvoiceID string `json:"invoiceId"`
+	AmountINT int    `json:"amountINT"`
+	Currency  string `json:"currency"`
+	URL       string `json:"url"`
+}
+
+type Service struct{ db *sql.DB }
+
+func NewService(db *sql.DB) *Service { return &Service{db: db} }
+
+func (s *Service) CreateStarsInvoice(ctx context.Context, telegramID int64, amount int) (Invoice, error) {
+	invoice := Invoice{
+		InvoiceID: fmt.Sprintf("inv_%d", time.Now().UTC().UnixNano()),
+		AmountINT: amount,
+		Currency:  "XTR",
+		URL:       "https://t.me/invoice/mock",
+	}
+	const q = `INSERT INTO payments (id, user_telegram_id, amount_int, currency, status, provider_payload, created_at)
+		VALUES ($1,$2,$3,$4,'pending',$5,$6)`
+	if _, err := s.db.ExecContext(ctx, q, invoice.InvoiceID, telegramID, amount, invoice.Currency, invoice.URL, time.Now().UTC()); err != nil {
+		return Invoice{}, err
+	}
+	return invoice, nil
+}

--- a/internal/referrals/service.go
+++ b/internal/referrals/service.go
@@ -1,0 +1,61 @@
+package referrals
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+type Summary struct {
+	Code           string `json:"code"`
+	InvitedCount   int    `json:"invitedCount"`
+	RewardTotalINT int    `json:"rewardTotalINT"`
+}
+
+type Payout struct {
+	ID        string `json:"id"`
+	AmountINT int    `json:"amountINT"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"createdAt"`
+}
+
+type Service struct{ db *sql.DB }
+
+func NewService(db *sql.DB) *Service { return &Service{db: db} }
+
+func (s *Service) GetSummary(ctx context.Context, telegramID int64) (Summary, error) {
+	summary := Summary{}
+	if err := s.db.QueryRowContext(ctx, `SELECT referral_code FROM users WHERE telegram_id = $1`, telegramID).Scan(&summary.Code); err != nil {
+		if err != sql.ErrNoRows {
+			return Summary{}, err
+		}
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM referral_invites WHERE referrer_telegram_id = $1`, telegramID).Scan(&summary.InvitedCount); err != nil {
+		return Summary{}, err
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(SUM(amount_int),0) FROM referral_payouts WHERE user_telegram_id = $1 AND status = 'paid'`, telegramID).Scan(&summary.RewardTotalINT); err != nil {
+		return Summary{}, err
+	}
+	return summary, nil
+}
+
+func (s *Service) ListPayouts(ctx context.Context, telegramID int64) ([]Payout, error) {
+	const q = `SELECT id, amount_int, status, created_at FROM referral_payouts WHERE user_telegram_id = $1 ORDER BY created_at DESC`
+	rows, err := s.db.QueryContext(ctx, q, telegramID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	items := make([]Payout, 0)
+	for rows.Next() {
+		var item Payout
+		var createdAt time.Time
+		if err := rows.Scan(&item.ID, &item.AmountINT, &item.Status, &createdAt); err != nil {
+			return nil, err
+		}
+		item.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -1,0 +1,68 @@
+package streamers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Streamer struct {
+	ID             string    `json:"id"`
+	TwitchUsername string    `json:"twitchUsername"`
+	DisplayName    string    `json:"displayName"`
+	Status         string    `json:"status"`
+	CreatedAt      time.Time `json:"createdAt"`
+}
+
+type Service struct{ db *sql.DB }
+
+func NewService(db *sql.DB) *Service { return &Service{db: db} }
+
+func (s *Service) Create(ctx context.Context, twitchUsername string) (Streamer, error) {
+	normalized := strings.ToLower(strings.TrimSpace(twitchUsername))
+	item := Streamer{
+		ID:             fmt.Sprintf("str_%d", time.Now().UTC().UnixNano()),
+		TwitchUsername: normalized,
+		DisplayName:    normalized,
+		Status:         "pending",
+		CreatedAt:      time.Now().UTC(),
+	}
+	const q = `INSERT INTO streamers (id, twitch_username, display_name, status, created_at) VALUES ($1,$2,$3,$4,$5)`
+	if _, err := s.db.ExecContext(ctx, q, item.ID, item.TwitchUsername, item.DisplayName, item.Status, item.CreatedAt); err != nil {
+		return Streamer{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) List(ctx context.Context, query string, page, pageSize int) ([]Streamer, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	offset := (page - 1) * pageSize
+	needle := "%" + strings.ToLower(strings.TrimSpace(query)) + "%"
+	const q = `SELECT id, twitch_username, display_name, status, created_at
+		FROM streamers
+		WHERE ($1 = '%%' OR lower(twitch_username) LIKE $1)
+		ORDER BY created_at DESC
+		LIMIT $2 OFFSET $3`
+	rows, err := s.db.QueryContext(ctx, q, needle, pageSize, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	items := make([]Streamer, 0)
+	for rows.Next() {
+		var item Streamer
+		if err := rows.Scan(&item.ID, &item.TwitchUsername, &item.DisplayName, &item.Status, &item.CreatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}

--- a/internal/votes/service.go
+++ b/internal/votes/service.go
@@ -1,0 +1,36 @@
+package votes
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+type CastRequest struct {
+	EventID string `json:"eventId"`
+	Option  string `json:"optionId"`
+	Cost    int    `json:"cost"`
+}
+
+type Response struct {
+	VoteID     string `json:"voteId"`
+	EventID    string `json:"eventId"`
+	OptionID   string `json:"optionId"`
+	AcceptedAt string `json:"acceptedAt"`
+}
+
+type Service struct{ db *sql.DB }
+
+func NewService(db *sql.DB) *Service { return &Service{db: db} }
+
+func (s *Service) Cast(ctx context.Context, telegramID int64, idempotencyKey string, req CastRequest) (Response, error) {
+	voteID := fmt.Sprintf("vote_%d", time.Now().UTC().UnixNano())
+	acceptedAt := time.Now().UTC()
+	const q = `INSERT INTO votes (id, event_id, option_id, user_telegram_id, cost_int, idempotency_key, created_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7)`
+	if _, err := s.db.ExecContext(ctx, q, voteID, req.EventID, req.Option, telegramID, req.Cost, idempotencyKey, acceptedAt); err != nil {
+		return Response{}, err
+	}
+	return Response{VoteID: voteID, EventID: req.EventID, OptionID: req.Option, AcceptedAt: acceptedAt.Format(time.RFC3339Nano)}, nil
+}

--- a/internal/wallet/service.go
+++ b/internal/wallet/service.go
@@ -1,0 +1,45 @@
+package wallet
+
+import (
+	"context"
+	"database/sql"
+)
+
+type Transaction struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Amount  int    `json:"amountINT"`
+	Comment string `json:"comment"`
+}
+
+type Snapshot struct {
+	BalanceINT int           `json:"balanceINT"`
+	History    []Transaction `json:"history"`
+}
+
+type Service struct{ db *sql.DB }
+
+func NewService(db *sql.DB) *Service { return &Service{db: db} }
+
+func (s *Service) GetByTelegramID(ctx context.Context, telegramID int64) (Snapshot, error) {
+	snap := Snapshot{BalanceINT: 0, History: []Transaction{}}
+	const balQ = `SELECT balance_int FROM wallet_accounts WHERE user_telegram_id = $1`
+	if err := s.db.QueryRowContext(ctx, balQ, telegramID).Scan(&snap.BalanceINT); err != nil && err != sql.ErrNoRows {
+		return Snapshot{}, err
+	}
+
+	const hQ = `SELECT id, tx_type, amount_int, comment FROM wallet_ledger WHERE user_telegram_id = $1 ORDER BY created_at DESC LIMIT 50`
+	rows, err := s.db.QueryContext(ctx, hQ, telegramID)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer rows.Close() //nolint:errcheck
+	for rows.Next() {
+		var tx Transaction
+		if err := rows.Scan(&tx.ID, &tx.Type, &tx.Amount, &tx.Comment); err != nil {
+			return Snapshot{}, err
+		}
+		snap.History = append(snap.History, tx)
+	}
+	return snap, rows.Err()
+}

--- a/migrations/0002_core_domains.down.sql
+++ b/migrations/0002_core_domains.down.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS media_clips;
+DROP TABLE IF EXISTS referral_payouts;
+DROP TABLE IF EXISTS referral_invites;
+DROP TABLE IF EXISTS payments;
+DROP TABLE IF EXISTS wallet_ledger;
+DROP TABLE IF EXISTS wallet_accounts;
+DROP TABLE IF EXISTS votes;
+DROP TABLE IF EXISTS events;
+DROP TABLE IF EXISTS games;
+DROP TABLE IF EXISTS streamers;

--- a/migrations/0002_core_domains.up.sql
+++ b/migrations/0002_core_domains.up.sql
@@ -1,0 +1,89 @@
+CREATE TABLE IF NOT EXISTS streamers (
+    id TEXT PRIMARY KEY,
+    twitch_username TEXT NOT NULL UNIQUE,
+    display_name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS games (
+    id TEXT PRIMARY KEY,
+    streamer_id TEXT NOT NULL REFERENCES streamers(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    id TEXT PRIMARY KEY,
+    streamer_id TEXT NOT NULL REFERENCES streamers(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS votes (
+    id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    option_id TEXT NOT NULL,
+    user_telegram_id BIGINT NOT NULL,
+    cost_int INT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    UNIQUE (user_telegram_id, idempotency_key)
+);
+
+CREATE TABLE IF NOT EXISTS wallet_accounts (
+    user_telegram_id BIGINT PRIMARY KEY,
+    balance_int INT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS wallet_ledger (
+    id TEXT PRIMARY KEY,
+    user_telegram_id BIGINT NOT NULL,
+    tx_type TEXT NOT NULL,
+    amount_int INT NOT NULL,
+    comment TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS payments (
+    id TEXT PRIMARY KEY,
+    user_telegram_id BIGINT NOT NULL,
+    amount_int INT NOT NULL,
+    currency TEXT NOT NULL,
+    status TEXT NOT NULL,
+    provider_payload TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS referral_invites (
+    referrer_telegram_id BIGINT NOT NULL,
+    invited_telegram_id BIGINT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS referral_payouts (
+    id TEXT PRIMARY KEY,
+    user_telegram_id BIGINT NOT NULL,
+    amount_int INT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS media_clips (
+    id TEXT PRIMARY KEY,
+    streamer_id TEXT NOT NULL REFERENCES streamers(id) ON DELETE CASCADE,
+    url TEXT NOT NULL,
+    duration_s INT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_games_streamer_id ON games(streamer_id);
+CREATE INDEX IF NOT EXISTS idx_events_streamer_id_status ON events(streamer_id, status);
+CREATE INDEX IF NOT EXISTS idx_votes_event_id ON votes(event_id);
+CREATE INDEX IF NOT EXISTS idx_wallet_ledger_user_created_at ON wallet_ledger(user_telegram_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_payments_user_created_at ON payments(user_telegram_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_referral_payouts_user_created_at ON referral_payouts(user_telegram_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_media_clips_streamer_created_at ON media_clips(streamer_id, created_at DESC);


### PR DESCRIPTION
### Motivation
- Introduce core domain functionality (streamers, games, events, votes, wallet, payments, referrals, media) and expose it over HTTP to support the new product features.
- Ensure these domains are backed by persistent storage and schema changes via migrations, while preserving an in-memory users fallback for quick smoke tests.
- Surface DB-dependent routes as unavailable when the service is started without database configuration to avoid unexpected errors.

### Description
- Added new service implementations under `internal/`: `streamers`, `games`, `events`, `votes`, `wallet`, `payments`, `referrals`, and `media` with basic CRUD/listing behavior and SQL interactions via `*sql.DB` constructors (e.g. `NewService`).
- Extended server initialization in `cmd/server/main.go` to instantiate these services when a PostgreSQL DB is configured and pass them into the HTTP handler via the updated `app.NewHandler` signature.
- Expanded `internal/app/router.go` to add authenticated endpoints for the new domains (examples: `GET/POST /api/streamers`, `GET /api/games`, `GET /api/events/live`, `POST /api/votes`, `GET /api/wallet`, `POST /api/payments/stars/createInvoice`, `GET /api/referrals/summary`, `GET /api/referrals/payouts`, `GET /api/media/clips`) including input validation and DB-availability checks that return `503` when DB-backed services are not configured.
- Added database migrations `migrations/0002_core_domains.up.sql` and `migrations/0002_core_domains.down.sql` to create/drop tables and indexes for the new domains.
- Updated documentation in `docs/local_setup.md` and `docs/migrations_plan.md` to describe the new endpoints and migration status.

### Testing
- No automated tests were run as part of this change (no unit/integration test output available in the rollout artifacts).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b04e08b918832c88ea0b5b3bee2bf9)