### PR TITLE
Add client config, streamers and events services and HTTP endpoints

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/funpot/funpot-go-core/internal/app"
 	"github.com/funpot/funpot-go-core/internal/auth"
 	"github.com/funpot/funpot-go-core/internal/config"
+	"github.com/funpot/funpot-go-core/internal/events"
+	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
 	dbpkg "github.com/funpot/funpot-go-core/pkg/database"
 	"github.com/funpot/funpot-go-core/pkg/telemetry"
@@ -80,6 +82,8 @@ func main() {
 	}
 
 	userService := users.NewService(userRepo)
+	streamersService := streamers.NewService()
+	eventsService := events.NewService(nil)
 
 	authService, err := auth.NewService(logger, cfg.Auth, userService)
 	if err != nil {
@@ -97,7 +101,16 @@ func main() {
 		return db.PingContext(pingCtx) == nil
 	}
 
-	handler := app.NewHandler(logger, readyFn, telemetryProvider.MetricsHandler(), authService, userService, cfg.Features.Flags)
+	handler := app.NewHandler(
+		logger,
+		readyFn,
+		telemetryProvider.MetricsHandler(),
+		authService,
+		userService,
+		streamersService,
+		eventsService,
+		app.ConfigResponseFromConfig(cfg),
+	)
 
 	application, err := app.New(cfg, logger, handler)
 	if err != nil {

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -42,6 +42,10 @@ FUNPOT_DATABASE_MIN_OPEN_CONNS=1
 FUNPOT_DATABASE_CONNECT_TIMEOUT=5s
 FUNPOT_DATABASE_HEALTHCHECK_TIMEOUT=1s
 FUNPOT_FEATURE_FLAGS=wallet=false,votes=false
+FUNPOT_CLIENT_STARS_RATE=1
+FUNPOT_CLIENT_MIN_VIEWERS=100
+FUNPOT_CLIENT_CURRENCIES=INT
+FUNPOT_CLIENT_LIMIT_VOTE_PER_MIN=30
 FUNPOT_DATABASE_MAX_OPEN_CONNS=10
 FUNPOT_DATABASE_MAX_IDLE_CONNS=5
 FUNPOT_DATABASE_CONN_MAX_IDLE_TIME=5m
@@ -109,7 +113,10 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /metrics` – Prometheus metrics when enabled, `204 No Content` otherwise.
 - `POST /api/auth/telegram` – verifies Telegram Mini App `initData` and returns a short-lived JWT.
 - `GET /api/me` – returns the authenticated user's profile when called with the issued JWT.
-- `GET /api/config` – exposes seeded feature flags for the authenticated user.
+- `GET /api/config` – exposes client configuration and feature flags for the authenticated user.
+- `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
+- `POST /api/streamers` – submits a Twitch streamer username for moderation/validation.
+- `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
 
 When database connection fields are unset the server falls back to the in-memory
 repository for user profiles. This is useful for quick smoke tests but bypasses

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6,6 +6,36 @@ info:
 servers:
   - url: https://api.funpot.example
 paths:
+  /api/auth/telegram:
+    post:
+      summary: Authenticate via Telegram Mini App initData
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [initData]
+              properties:
+                initData:
+                  type: string
+      responses:
+        '200':
+          description: Authentication succeeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                  expiresAt:
+                    type: string
+                    format: date-time
+                  user:
+                    $ref: '#/components/schemas/UserProfile'
+        default:
+          $ref: '#/components/responses/Error'
   /api/me:
     get:
       summary: Get current user profile
@@ -867,4 +897,3 @@ components:
         checkedAt:
           type: string
           format: date-time
-

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -7,11 +7,15 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/funpot/funpot-go-core/internal/auth"
+	"github.com/funpot/funpot-go-core/internal/config"
+	"github.com/funpot/funpot-go-core/internal/events"
+	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
 )
 
@@ -24,12 +28,45 @@ type telegramAuthRequest struct {
 	InitData string `json:"initData"`
 }
 
-type configResponse struct {
-	Features map[string]bool `json:"features"`
+type ClientConfigResponse struct {
+	StarsRate  float64         `json:"starsRate"`
+	MinViewers int             `json:"minViewers"`
+	Features   map[string]bool `json:"features"`
+	Currencies []string        `json:"currencies"`
+	Limits     configLimits    `json:"limits"`
+}
+
+func ConfigResponseFromConfig(cfg config.Config) ClientConfigResponse {
+	return ClientConfigResponse{
+		StarsRate:  cfg.Client.StarsRate,
+		MinViewers: cfg.Client.MinViewers,
+		Features:   cfg.Features.Flags,
+		Currencies: cfg.Client.Currencies,
+		Limits: configLimits{
+			VotePerMin: cfg.Client.VotePerMin,
+		},
+	}
+}
+
+type configLimits struct {
+	VotePerMin int `json:"votePerMin"`
+}
+
+type streamerSubmitRequest struct {
+	TwitchUsername string `json:"twitchUsername"`
 }
 
 // NewHandler wires the base HTTP routes for the service.
-func NewHandler(logger *zap.Logger, readyFn func() bool, metricsHandler http.Handler, authService *auth.Service, userService *users.Service, featureFlags map[string]bool) http.Handler {
+func NewHandler(
+	logger *zap.Logger,
+	readyFn func() bool,
+	metricsHandler http.Handler,
+	authService *auth.Service,
+	userService *users.Service,
+	streamersService *streamers.Service,
+	eventsService *events.Service,
+	clientConfig ClientConfigResponse,
+) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -137,8 +174,68 @@ func NewHandler(logger *zap.Logger, readyFn func() bool, metricsHandler http.Han
 				w.WriteHeader(http.StatusMethodNotAllowed)
 				return
 			}
-			writeJSON(w, http.StatusOK, configResponse{Features: featureFlags})
+			writeJSON(w, http.StatusOK, clientConfig)
 		})))
+
+		if streamersService != nil {
+			mux.Handle("/api/streamers", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					page, err := strconv.Atoi(strings.TrimSpace(r.URL.Query().Get("page")))
+					if err != nil && r.URL.Query().Get("page") != "" {
+						writeError(w, http.StatusBadRequest, "page must be a positive integer")
+						return
+					}
+					items := streamersService.List(r.Context(), r.URL.Query().Get("query"), page)
+					writeJSON(w, http.StatusOK, items)
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req streamerSubmitRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					claims, ok := auth.ClaimsFromContext(r.Context())
+					if !ok {
+						writeError(w, http.StatusUnauthorized, "missing auth claims")
+						return
+					}
+					submission, err := streamersService.Submit(r.Context(), req.TwitchUsername, claims.Subject)
+					if err != nil {
+						if errors.Is(err, streamers.ErrInvalidUsername) {
+							writeError(w, http.StatusBadRequest, err.Error())
+							return
+						}
+						logger.Error("failed to submit streamer", zap.Error(err))
+						writeError(w, http.StatusInternalServerError, "failed to submit streamer")
+						return
+					}
+					writeJSON(w, http.StatusOK, submission)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+		}
+
+		if eventsService != nil {
+			mux.Handle("/api/events/live", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				streamerID := strings.TrimSpace(r.URL.Query().Get("streamerId"))
+				if streamerID == "" {
+					writeError(w, http.StatusBadRequest, "streamerId is required")
+					return
+				}
+				writeJSON(w, http.StatusOK, eventsService.ListLiveByStreamer(r.Context(), streamerID))
+			})))
+		}
 	}
 
 	return mux

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Auth        AuthConfig
 	Database    DatabaseConfig
 	Features    FeatureConfig
+	Client      ClientConfig
 }
 
 // ServerConfig holds HTTP server settings.
@@ -105,6 +106,14 @@ type FeatureConfig struct {
 	Flags map[string]bool
 }
 
+// ClientConfig is returned by /api/config for Mini App runtime behavior.
+type ClientConfig struct {
+	StarsRate  float64
+	MinViewers int
+	Currencies []string
+	VotePerMin int
+}
+
 // Load reads configuration from the environment, applying defaults and .env overrides.
 func Load() (Config, error) {
 	_ = godotenv.Load()
@@ -174,6 +183,23 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 
+	starsRate, err := getFloat("FUNPOT_CLIENT_STARS_RATE", 1)
+	if err != nil {
+		return Config{}, err
+	}
+
+	minViewers, err := getInt("FUNPOT_CLIENT_MIN_VIEWERS", 100)
+	if err != nil {
+		return Config{}, err
+	}
+
+	votePerMin, err := getInt("FUNPOT_CLIENT_LIMIT_VOTE_PER_MIN", 30)
+	if err != nil {
+		return Config{}, err
+	}
+
+	currencies := getCSVStrings("FUNPOT_CLIENT_CURRENCIES", []string{"INT"})
+
 	maxIdleConns, err := getInt("FUNPOT_DATABASE_MAX_IDLE_CONNS", 5)
 	if err != nil {
 		return Config{}, err
@@ -240,6 +266,12 @@ func Load() (Config, error) {
 		},
 		Features: FeatureConfig{
 			Flags: featureFlags,
+		},
+		Client: ClientConfig{
+			StarsRate:  starsRate,
+			MinViewers: minViewers,
+			Currencies: currencies,
+			VotePerMin: votePerMin,
 		},
 	}
 
@@ -338,4 +370,23 @@ func getFeatureFlags(key string) (map[string]bool, error) {
 		flags[key] = enabled
 	}
 	return flags, nil
+}
+
+func getCSVStrings(key string, fallback []string) []string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	rawItems := strings.Split(value, ",")
+	items := make([]string, 0, len(rawItems))
+	for _, item := range rawItems {
+		trimmed := strings.TrimSpace(item)
+		if trimmed != "" {
+			items = append(items, trimmed)
+		}
+	}
+	if len(items) == 0 {
+		return fallback
+	}
+	return items
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,10 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	t.Setenv("FUNPOT_DATABASE_MIN_OPEN_CONNS", "2")
 	t.Setenv("FUNPOT_DATABASE_CONNECT_TIMEOUT", "7s")
 	t.Setenv("FUNPOT_DATABASE_HEALTHCHECK_TIMEOUT", "2s")
+	t.Setenv("FUNPOT_CLIENT_STARS_RATE", "1.5")
+	t.Setenv("FUNPOT_CLIENT_MIN_VIEWERS", "150")
+	t.Setenv("FUNPOT_CLIENT_CURRENCIES", "INT,USD")
+	t.Setenv("FUNPOT_CLIENT_LIMIT_VOTE_PER_MIN", "40")
 
 	cfg, err := Load()
 	if err != nil {
@@ -41,6 +45,18 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	}
 	if cfg.Database.HealthcheckPing != 2*time.Second {
 		t.Fatalf("expected healthcheck timeout 2s, got %s", cfg.Database.HealthcheckPing)
+	}
+	if cfg.Client.StarsRate != 1.5 {
+		t.Fatalf("expected stars rate 1.5, got %v", cfg.Client.StarsRate)
+	}
+	if cfg.Client.MinViewers != 150 {
+		t.Fatalf("expected min viewers 150, got %d", cfg.Client.MinViewers)
+	}
+	if len(cfg.Client.Currencies) != 2 {
+		t.Fatalf("expected 2 currencies, got %d", len(cfg.Client.Currencies))
+	}
+	if cfg.Client.VotePerMin != 40 {
+		t.Fatalf("expected vote per min 40, got %d", cfg.Client.VotePerMin)
 	}
 }
 

--- a/internal/events/model.go
+++ b/internal/events/model.go
@@ -1,0 +1,22 @@
+package events
+
+type Option struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+type UserVote struct {
+	OptionID string `json:"optionId"`
+}
+
+type LiveEvent struct {
+	ID          string         `json:"id"`
+	GameID      *string        `json:"gameId"`
+	StreamerID  string         `json:"-"`
+	Title       string         `json:"title"`
+	Options     []Option       `json:"options"`
+	ClosesAt    string         `json:"closesAt"`
+	Totals      map[string]int `json:"totals"`
+	UserVote    *UserVote      `json:"userVote,omitempty"`
+	CostPerVote int            `json:"costPerVote"`
+}

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -1,0 +1,30 @@
+package events
+
+import (
+	"context"
+	"sync"
+)
+
+type Service struct {
+	mu    sync.RWMutex
+	items []LiveEvent
+}
+
+func NewService(seed []LiveEvent) *Service {
+	items := make([]LiveEvent, len(seed))
+	copy(items, seed)
+	return &Service{items: items}
+}
+
+func (s *Service) ListLiveByStreamer(_ context.Context, streamerID string) []LiveEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]LiveEvent, 0)
+	for _, item := range s.items {
+		if item.StreamerID == streamerID {
+			result = append(result, item)
+		}
+	}
+	return result
+}

--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -1,0 +1,16 @@
+package events
+
+import "testing"
+
+func TestListLiveByStreamer(t *testing.T) {
+	svc := NewService([]LiveEvent{
+		{ID: "evt-1", StreamerID: "s-1"},
+		{ID: "evt-2", StreamerID: "s-2"},
+		{ID: "evt-3", StreamerID: "s-1"},
+	})
+
+	items := svc.ListLiveByStreamer(t.Context(), "s-1")
+	if len(items) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(items))
+	}
+}

--- a/internal/streamers/model.go
+++ b/internal/streamers/model.go
@@ -1,0 +1,18 @@
+package streamers
+
+type Streamer struct {
+	ID          string `json:"id"`
+	Platform    string `json:"platform"`
+	Username    string `json:"username"`
+	DisplayName string `json:"displayName"`
+	Online      bool   `json:"online"`
+	Viewers     int    `json:"viewers"`
+	AddedBy     string `json:"addedBy"`
+	Status      string `json:"status"`
+}
+
+type Submission struct {
+	ID     string  `json:"id"`
+	Status string  `json:"status"`
+	Reason *string `json:"reason"`
+}

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -1,0 +1,76 @@
+package streamers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+var ErrInvalidUsername = errors.New("twitchUsername is required")
+
+type Service struct {
+	mu    sync.RWMutex
+	items []Streamer
+}
+
+func NewService() *Service {
+	return &Service{items: []Streamer{}}
+}
+
+func (s *Service) List(_ context.Context, query string, page int) []Streamer {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if page < 1 {
+		page = 1
+	}
+	needle := strings.ToLower(strings.TrimSpace(query))
+	matches := make([]Streamer, 0, len(s.items))
+	for _, item := range s.items {
+		if needle == "" || strings.Contains(strings.ToLower(item.Username), needle) || strings.Contains(strings.ToLower(item.DisplayName), needle) {
+			matches = append(matches, item)
+		}
+	}
+
+	const pageSize = 20
+	start := (page - 1) * pageSize
+	if start >= len(matches) {
+		return []Streamer{}
+	}
+	end := start + pageSize
+	if end > len(matches) {
+		end = len(matches)
+	}
+	result := make([]Streamer, end-start)
+	copy(result, matches[start:end])
+	return result
+}
+
+func (s *Service) Submit(_ context.Context, twitchUsername, addedBy string) (Submission, error) {
+	username := strings.TrimSpace(twitchUsername)
+	if username == "" {
+		return Submission{}, ErrInvalidUsername
+	}
+
+	now := time.Now().UTC().UnixNano()
+	id := fmt.Sprintf("str_%d", now)
+	streamer := Streamer{
+		ID:          id,
+		Platform:    "twitch",
+		Username:    username,
+		DisplayName: username,
+		Online:      false,
+		Viewers:     0,
+		AddedBy:     addedBy,
+		Status:      "pending",
+	}
+
+	s.mu.Lock()
+	s.items = append(s.items, streamer)
+	s.mu.Unlock()
+
+	return Submission{ID: id, Status: "pending", Reason: nil}, nil
+}

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -1,0 +1,28 @@
+package streamers
+
+import "testing"
+
+func TestSubmitAndList(t *testing.T) {
+	svc := NewService()
+
+	_, err := svc.Submit(t.Context(), "", "user-1")
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	sub, err := svc.Submit(t.Context(), "best_streamer", "user-1")
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if sub.Status != "pending" {
+		t.Fatalf("expected pending status, got %s", sub.Status)
+	}
+
+	items := svc.List(t.Context(), "best", 1)
+	if len(items) != 1 {
+		t.Fatalf("expected one result, got %d", len(items))
+	}
+	if items[0].Username != "best_streamer" {
+		t.Fatalf("unexpected username: %s", items[0].Username)
+	}
+}


### PR DESCRIPTION
### Motivation
- Expose client-side configuration to the Mini App runtime and introduce streaming/event primitives to support streamer catalog, submissions and live event listing. 
- Wire new services into the HTTP handler so APIs can return streamer catalog, accept streamer submissions and list live events for a streamer.

### Description
- Add `ClientConfig` to `internal/config` and parse new env vars `FUNPOT_CLIENT_*`, including helper `getCSVStrings`, and provide `ConfigResponseFromConfig` mapping for the handler. 
- Implement `internal/streamers` package with `Streamer` and `Submission` models, in-memory `Service` with `List` and `Submit` methods, and unit tests. 
- Implement `internal/events` package with `LiveEvent` model and in-memory `Service` with `ListLiveByStreamer` and unit tests. 
- Update HTTP router in `internal/app/router.go` to return the client config at `GET /api/config`, and add authenticated endpoints `GET|POST /api/streamers` and `GET /api/events/live`. 
- Wire new `streamers` and `events` services into `cmd/server/main.go` and adapt `app.NewHandler` call signature. 
- Update documentation in `docs/local_setup.md` and `docs/openapi.yaml` to include new env vars and API surface.

### Testing
- Ran unit tests with `go test ./...` which executed `internal/config/config_test.go`, `internal/streamers/service_test.go`, and `internal/events/service_test.go`, and they passed. 
- Verified basic build by running `go build ./cmd/server` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4371af164832c96ffc5dd7a11a9ed)