### PR TITLE
Replace use of t.Context() with context.Background() in tests

### DIFF
--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -1,6 +1,9 @@
 package events
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestListLiveByStreamer(t *testing.T) {
 	svc := NewService([]LiveEvent{
@@ -9,7 +12,7 @@ func TestListLiveByStreamer(t *testing.T) {
 		{ID: "evt-3", StreamerID: "s-1"},
 	})
 
-	items := svc.ListLiveByStreamer(t.Context(), "s-1")
+	items := svc.ListLiveByStreamer(context.Background(), "s-1")
 	if len(items) != 2 {
 		t.Fatalf("expected 2 events, got %d", len(items))
 	}

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -1,16 +1,19 @@
 package streamers
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestSubmitAndList(t *testing.T) {
 	svc := NewService()
 
-	_, err := svc.Submit(t.Context(), "", "user-1")
+	_, err := svc.Submit(context.Background(), "", "user-1")
 	if err == nil {
 		t.Fatalf("expected validation error")
 	}
 
-	sub, err := svc.Submit(t.Context(), "best_streamer", "user-1")
+	sub, err := svc.Submit(context.Background(), "best_streamer", "user-1")
 	if err != nil {
 		t.Fatalf("Submit() error = %v", err)
 	}
@@ -18,7 +21,7 @@ func TestSubmitAndList(t *testing.T) {
 		t.Fatalf("expected pending status, got %s", sub.Status)
 	}
 
-	items := svc.List(t.Context(), "best", 1)
+	items := svc.List(context.Background(), "best", 1)
 	if len(items) != 1 {
 		t.Fatalf("expected one result, got %d", len(items))
 	}


### PR DESCRIPTION
### Motivation

- Remove dependency on `testing.T`'s `Context()` within unit tests to avoid coupling to the test harness and possible Go version differences. 
- Ensure tests use an explicit, stable root context so behavior is deterministic and compatible across environments.

### Description

- Added `context` imports to `internal/events/service_test.go` and `internal/streamers/service_test.go` and replaced all uses of `t.Context()` with `context.Background()`.
- Updated tests `TestListLiveByStreamer` and `TestSubmitAndList` to call service methods with `context.Background()`.

### Testing

- Ran `go test ./internal/events -run TestListLiveByStreamer` and the test succeeded.
- Ran `go test ./internal/streamers -run TestSubmitAndList` and the test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43a263094832c976140a10660ad4b)