### PR TITLE
Streamer onboarding: Twitch validation, rate limits, and status filtering

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -35,9 +35,9 @@ approximate sequencing, and validation criteria.
   feature flags.
 
 ### M2 – Streamer Catalog & Games Skeleton
-- [ ] Implement streamer onboarding (`POST /api/streamers`) with Twitch
+- [x] Implement streamer onboarding (`POST /api/streamers`) with Twitch
   validation integration stub and rate limits.
-- [ ] Expose streamer listings (`GET /api/streamers`) with pagination and
+- [x] Expose streamer listings (`GET /api/streamers`) with pagination and
   moderation states.
 - [ ] Create `games` module storing rules, statuses, and admin CRUD endpoints.
 - [ ] Introduce admin role enforcement and basic UI scaffolds.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -79,6 +79,11 @@ paths:
           schema:
             type: integer
             minimum: 1
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [pending, approved, rejected]
       responses:
         '200':
           description: Streamer list
@@ -91,7 +96,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
     post:
-      summary: Submit a streamer for validation
+      summary: Submit a streamer for Twitch validation
       security:
         - bearerAuth: []
       requestBody:
@@ -111,6 +116,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StreamerSubmission'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         default:
           $ref: '#/components/responses/Error'
   /api/games:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -121,7 +121,7 @@ func NewHandler(
 
 			resp, err := authService.Authenticate(r.Context(), req.InitData, time.Now().UTC())
 			if err != nil {
-				status := http.StatusBadRequest
+				var status int
 				switch {
 				case errors.Is(err, auth.ErrInvalidHash), errors.Is(err, auth.ErrExpired):
 					status = http.StatusUnauthorized
@@ -186,7 +186,12 @@ func NewHandler(
 						writeError(w, http.StatusBadRequest, "page must be a positive integer")
 						return
 					}
-					items := streamersService.List(r.Context(), r.URL.Query().Get("query"), page)
+					statusFilter := r.URL.Query().Get("status")
+					if !streamers.IsSupportedStatus(statusFilter) {
+						writeError(w, http.StatusBadRequest, streamers.ErrInvalidStatus.Error())
+						return
+					}
+					items := streamersService.List(r.Context(), r.URL.Query().Get("query"), statusFilter, page)
 					writeJSON(w, http.StatusOK, items)
 				case http.MethodPost:
 					defer r.Body.Close() //nolint:errcheck
@@ -207,8 +212,12 @@ func NewHandler(
 					}
 					submission, err := streamersService.Submit(r.Context(), req.TwitchUsername, claims.Subject)
 					if err != nil {
-						if errors.Is(err, streamers.ErrInvalidUsername) {
+						if errors.Is(err, streamers.ErrInvalidUsername) || errors.Is(err, streamers.ErrTwitchUnavailable) {
 							writeError(w, http.StatusBadRequest, err.Error())
+							return
+						}
+						if errors.Is(err, streamers.ErrRateLimited) {
+							writeError(w, http.StatusTooManyRequests, err.Error())
 							return
 						}
 						logger.Error("failed to submit streamer", zap.Error(err))

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -4,23 +4,67 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 )
 
-var ErrInvalidUsername = errors.New("twitchUsername is required")
+var (
+	ErrInvalidUsername   = errors.New("twitchUsername is required")
+	ErrInvalidStatus     = errors.New("status filter is invalid")
+	ErrRateLimited       = errors.New("submission rate limit exceeded")
+	ErrTwitchUnavailable = errors.New("failed to validate twitch username")
+)
+
+var twitchUsernamePattern = regexp.MustCompile(`^[a-zA-Z0-9_]{4,25}$`)
+
+type TwitchValidator interface {
+	ValidateUsername(ctx context.Context, username string) (displayName string, err error)
+}
+
+type noopTwitchValidator struct{}
+
+func (v noopTwitchValidator) ValidateUsername(_ context.Context, username string) (string, error) {
+	if !twitchUsernamePattern.MatchString(username) {
+		return "", ErrTwitchUnavailable
+	}
+	return strings.ToLower(username), nil
+}
+
+type submissionLimit struct {
+	count      int
+	windowEnds time.Time
+}
 
 type Service struct {
-	mu    sync.RWMutex
-	items []Streamer
+	mu             sync.RWMutex
+	items          []Streamer
+	validator      TwitchValidator
+	rateLimitMu    sync.Mutex
+	rateLimitByKey map[string]submissionLimit
+	nowFn          func() time.Time
 }
 
 func NewService() *Service {
-	return &Service{items: []Streamer{}}
+	return NewServiceWithValidator(noopTwitchValidator{})
 }
 
-func (s *Service) List(_ context.Context, query string, page int) []Streamer {
+func NewServiceWithValidator(validator TwitchValidator) *Service {
+	if validator == nil {
+		validator = noopTwitchValidator{}
+	}
+	return &Service{
+		items:          []Streamer{},
+		validator:      validator,
+		rateLimitByKey: make(map[string]submissionLimit),
+		nowFn: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+}
+
+func (s *Service) List(_ context.Context, query, status string, page int) []Streamer {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -28,11 +72,16 @@ func (s *Service) List(_ context.Context, query string, page int) []Streamer {
 		page = 1
 	}
 	needle := strings.ToLower(strings.TrimSpace(query))
+	statusFilter := strings.ToLower(strings.TrimSpace(status))
 	matches := make([]Streamer, 0, len(s.items))
 	for _, item := range s.items {
-		if needle == "" || strings.Contains(strings.ToLower(item.Username), needle) || strings.Contains(strings.ToLower(item.DisplayName), needle) {
-			matches = append(matches, item)
+		if needle != "" && !strings.Contains(strings.ToLower(item.Username), needle) && !strings.Contains(strings.ToLower(item.DisplayName), needle) {
+			continue
 		}
+		if statusFilter != "" && strings.ToLower(item.Status) != statusFilter {
+			continue
+		}
+		matches = append(matches, item)
 	}
 
 	const pageSize = 20
@@ -49,19 +98,31 @@ func (s *Service) List(_ context.Context, query string, page int) []Streamer {
 	return result
 }
 
-func (s *Service) Submit(_ context.Context, twitchUsername, addedBy string) (Submission, error) {
+func (s *Service) Submit(ctx context.Context, twitchUsername, addedBy string) (Submission, error) {
 	username := strings.TrimSpace(twitchUsername)
 	if username == "" {
 		return Submission{}, ErrInvalidUsername
 	}
+	if !IsSupportedStatus("pending") {
+		return Submission{}, ErrInvalidStatus
+	}
 
-	now := time.Now().UTC().UnixNano()
+	if !s.allowSubmission(addedBy) {
+		return Submission{}, ErrRateLimited
+	}
+
+	displayName, err := s.validator.ValidateUsername(ctx, username)
+	if err != nil {
+		return Submission{}, fmt.Errorf("%w: %v", ErrTwitchUnavailable, err)
+	}
+
+	now := s.nowFn().UnixNano()
 	id := fmt.Sprintf("str_%d", now)
 	streamer := Streamer{
 		ID:          id,
 		Platform:    "twitch",
-		Username:    username,
-		DisplayName: username,
+		Username:    strings.ToLower(username),
+		DisplayName: displayName,
 		Online:      false,
 		Viewers:     0,
 		AddedBy:     addedBy,
@@ -73,4 +134,39 @@ func (s *Service) Submit(_ context.Context, twitchUsername, addedBy string) (Sub
 	s.mu.Unlock()
 
 	return Submission{ID: id, Status: "pending", Reason: nil}, nil
+}
+
+func IsSupportedStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "pending", "approved", "rejected":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Service) allowSubmission(userID string) bool {
+	const maxSubmissionsPerMinute = 3
+	const window = time.Minute
+
+	key := strings.TrimSpace(userID)
+	if key == "" {
+		key = "anonymous"
+	}
+
+	s.rateLimitMu.Lock()
+	defer s.rateLimitMu.Unlock()
+
+	now := s.nowFn()
+	state := s.rateLimitByKey[key]
+	if state.windowEnds.IsZero() || now.After(state.windowEnds) {
+		state = submissionLimit{count: 0, windowEnds: now.Add(window)}
+	}
+	if state.count >= maxSubmissionsPerMinute {
+		s.rateLimitByKey[key] = state
+		return false
+	}
+	state.count++
+	s.rateLimitByKey[key] = state
+	return true
 }

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -2,30 +2,80 @@ package streamers
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 )
 
-func TestSubmitAndList(t *testing.T) {
-	svc := NewService()
+type validatorStub struct {
+	displayName string
+	err         error
+}
 
-	_, err := svc.Submit(context.Background(), "", "user-1")
-	if err == nil {
-		t.Fatalf("expected validation error")
+func (v validatorStub) ValidateUsername(_ context.Context, _ string) (string, error) {
+	if v.err != nil {
+		return "", v.err
+	}
+	return v.displayName, nil
+}
+
+func TestServiceSubmitValidationAndListing(t *testing.T) {
+	tests := []struct {
+		name          string
+		username      string
+		validator     TwitchValidator
+		expectedError error
+	}{
+		{name: "empty username", username: "", expectedError: ErrInvalidUsername},
+		{name: "validator failure", username: "bad@user", validator: validatorStub{err: errors.New("not found")}, expectedError: ErrTwitchUnavailable},
+		{name: "success", username: "Best_Streamer", validator: validatorStub{displayName: "Best Streamer"}},
 	}
 
-	sub, err := svc.Submit(context.Background(), "best_streamer", "user-1")
-	if err != nil {
-		t.Fatalf("Submit() error = %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewServiceWithValidator(tt.validator)
+			sub, err := svc.Submit(context.Background(), tt.username, "user-1")
+			if tt.expectedError != nil {
+				if !errors.Is(err, tt.expectedError) {
+					t.Fatalf("expected error %v, got %v", tt.expectedError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Submit() error = %v", err)
+			}
+			if sub.Status != "pending" {
+				t.Fatalf("expected pending status, got %s", sub.Status)
+			}
+
+			items := svc.List(context.Background(), "best", "pending", 1)
+			if len(items) != 1 {
+				t.Fatalf("expected one result, got %d", len(items))
+			}
+			if items[0].Username != "best_streamer" {
+				t.Fatalf("unexpected username: %s", items[0].Username)
+			}
+		})
 	}
-	if sub.Status != "pending" {
-		t.Fatalf("expected pending status, got %s", sub.Status)
+}
+
+func TestServiceSubmitRateLimit(t *testing.T) {
+	svc := NewServiceWithValidator(validatorStub{displayName: "Display"})
+	clock := time.Now().UTC()
+	svc.nowFn = func() time.Time { return clock }
+
+	for i := 0; i < 3; i++ {
+		if _, err := svc.Submit(context.Background(), "streamername", "user-1"); err != nil {
+			t.Fatalf("unexpected error on submission %d: %v", i+1, err)
+		}
 	}
 
-	items := svc.List(context.Background(), "best", 1)
-	if len(items) != 1 {
-		t.Fatalf("expected one result, got %d", len(items))
+	if _, err := svc.Submit(context.Background(), "streamername", "user-1"); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("expected rate limit error, got %v", err)
 	}
-	if items[0].Username != "best_streamer" {
-		t.Fatalf("unexpected username: %s", items[0].Username)
+
+	clock = clock.Add(time.Minute + time.Second)
+	if _, err := svc.Submit(context.Background(), "streamername", "user-1"); err != nil {
+		t.Fatalf("expected limiter reset after window, got %v", err)
 	}
 }


### PR DESCRIPTION
### Motivation
- Complete the M2 milestone work for streamer catalog by enabling safe onboarding with Twitch username validation and preventing abuse via rate limits.
- Allow clients and admins to filter streamer listings by moderation status to support moderation workflows and UI needs.

### Description
- Add a `TwitchValidator` interface and a default no-op validator to `internal/streamers.Service`, plus new domain errors (`ErrInvalidStatus`, `ErrRateLimited`, `ErrTwitchUnavailable`) and username normalization on submit.
- Implement per-user submission rate limiting (3 submissions per minute) with windowed counters and surface rate-limit errors as HTTP `429` from `POST /api/streamers`.
- Extend streamer listing to accept a `status` query parameter (`pending|approved|rejected`) and validate it server-side, and update router handling to return `400` for invalid status values and `429` for rate-limited submits.
- Update OpenAPI (`docs/openapi.yaml`) to document the `status` query parameter and the `429` response, add table-driven tests for validation, listing, and rate-limiting in `internal/streamers/service_test.go`, and mark the two M2 checklist items as completed in `docs/implementation_plan.md`.

Checklist (aligned with `docs/implementation_plan.md`):
- [x] Implement streamer onboarding (`POST /api/streamers`) with Twitch validation integration stub and rate limits.
- [x] Expose streamer listings (`GET /api/streamers`) with pagination and moderation states.
- [ ] Create `games` module storing rules, statuses, and admin CRUD endpoints.
- [ ] Introduce admin role enforcement and basic UI scaffolds.

### Testing
- Ran `go test ./...` and unit tests passed (including new `streamers` tests) ✅.
- Ran `golangci-lint run` which failed due to pre-existing unrelated issues in `internal/users/*` (three `errcheck` and one `staticcheck`) and not because of changes in the streamer package ❌.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55c02d780832ca460804d2e5b834b)