### PR TITLE
Admin-protected games CRUD + admin role service

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,10 +10,12 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/funpot/funpot-go-core/internal/admin"
 	"github.com/funpot/funpot-go-core/internal/app"
 	"github.com/funpot/funpot-go-core/internal/auth"
 	"github.com/funpot/funpot-go-core/internal/config"
 	"github.com/funpot/funpot-go-core/internal/events"
+	"github.com/funpot/funpot-go-core/internal/games"
 	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
 	dbpkg "github.com/funpot/funpot-go-core/pkg/database"
@@ -82,7 +84,9 @@ func main() {
 	}
 
 	userService := users.NewService(userRepo)
+	adminService := admin.NewService(cfg.Admin.UserIDs)
 	streamersService := streamers.NewService()
+	gamesService := games.NewService()
 	eventsService := events.NewService(nil)
 
 	authService, err := auth.NewService(logger, cfg.Auth, userService)
@@ -106,8 +110,10 @@ func main() {
 		readyFn,
 		telemetryProvider.MetricsHandler(),
 		authService,
+		adminService,
 		userService,
 		streamersService,
+		gamesService,
 		eventsService,
 		app.ConfigResponseFromConfig(cfg),
 	)

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -39,7 +39,7 @@ approximate sequencing, and validation criteria.
   validation integration stub and rate limits.
 - [x] Expose streamer listings (`GET /api/streamers`) with pagination and
   moderation states.
-- [ ] Create `games` module storing rules, statuses, and admin CRUD endpoints.
+- [x] Create `games` module storing rules, statuses, and admin CRUD endpoints.
 - [ ] Introduce admin role enforcement and basic UI scaffolds.
 - Exit Criteria: authenticated users can register streamers, while admins can
   configure games ready for live events.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -30,6 +30,7 @@ FUNPOT_SENTRY_DEBUG=false
 FUNPOT_AUTH_TELEGRAM_BOT_TOKEN=<telegram_bot_token>
 FUNPOT_AUTH_JWT_SECRET=dev-secret
 FUNPOT_AUTH_JWT_TTL=15m
+FUNPOT_ADMIN_USER_IDS=<admin_user_uuid_1>,<admin_user_uuid_2>
 FUNPOT_DATABASE_ENABLED=true
 FUNPOT_DATABASE_HOST=localhost
 FUNPOT_DATABASE_PORT=5432
@@ -117,6 +118,10 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
 - `POST /api/streamers` – submits a Twitch streamer username for moderation/validation.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
+- `GET /api/admin/games` – admin-only endpoint listing all configured games.
+- `POST /api/admin/games` – admin-only endpoint creating a game definition.
+- `PUT /api/admin/games/{gameId}` – admin-only endpoint updating a game definition.
+- `DELETE /api/admin/games/{gameId}` – admin-only endpoint deleting a game definition.
 
 When database connection fields are unset the server falls back to the in-memory
 repository for user profiles. This is useful for quick smoke tests but bypasses

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -124,18 +124,11 @@ paths:
                 $ref: '#/components/schemas/Error'
         default:
           $ref: '#/components/responses/Error'
-  /api/games:
+  /api/admin/games:
     get:
-      summary: List games for a streamer
+      summary: List games (admin)
       security:
         - bearerAuth: []
-      parameters:
-        - in: query
-          name: streamerId
-          required: true
-          schema:
-            type: string
-            format: uuid
       responses:
         '200':
           description: Game list
@@ -145,6 +138,66 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Game'
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create game (admin)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GameUpsertRequest'
+      responses:
+        '201':
+          description: Created game
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Game'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/games/{gameId}:
+    put:
+      summary: Update game (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: gameId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GameUpsertRequest'
+      responses:
+        '200':
+          description: Updated game
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Game'
+        default:
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Delete game (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: gameId
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Game deleted
         default:
           $ref: '#/components/responses/Error'
   /api/events/live:
@@ -622,6 +675,23 @@ components:
         reason:
           type: string
           nullable: true
+    GameUpsertRequest:
+      type: object
+      required: [slug, title, status]
+      properties:
+        slug:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        rules:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          enum: [draft, active, archived]
     Game:
       type: object
       properties:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/getsentry/sentry-go v0.27.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9v
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -1,0 +1,26 @@
+package admin
+
+import "strings"
+
+// Service handles admin role checks.
+type Service struct {
+	allowed map[string]struct{}
+}
+
+func NewService(userIDs []string) *Service {
+	allowed := make(map[string]struct{}, len(userIDs))
+	for _, userID := range userIDs {
+		if trimmed := strings.TrimSpace(userID); trimmed != "" {
+			allowed[trimmed] = struct{}{}
+		}
+	}
+	return &Service{allowed: allowed}
+}
+
+func (s *Service) IsAdmin(userID string) bool {
+	if s == nil {
+		return false
+	}
+	_, ok := s.allowed[strings.TrimSpace(userID)]
+	return ok
+}

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -12,9 +12,11 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/funpot/funpot-go-core/internal/admin"
 	"github.com/funpot/funpot-go-core/internal/auth"
 	"github.com/funpot/funpot-go-core/internal/config"
 	"github.com/funpot/funpot-go-core/internal/events"
+	"github.com/funpot/funpot-go-core/internal/games"
 	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
 )
@@ -56,14 +58,24 @@ type streamerSubmitRequest struct {
 	TwitchUsername string `json:"twitchUsername"`
 }
 
+type gameUpsertRequest struct {
+	Slug        string   `json:"slug"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Rules       []string `json:"rules"`
+	Status      string   `json:"status"`
+}
+
 // NewHandler wires the base HTTP routes for the service.
 func NewHandler(
 	logger *zap.Logger,
 	readyFn func() bool,
 	metricsHandler http.Handler,
 	authService *auth.Service,
+	adminService *admin.Service,
 	userService *users.Service,
 	streamersService *streamers.Service,
+	gamesService *games.Service,
 	eventsService *events.Service,
 	clientConfig ClientConfigResponse,
 ) http.Handler {
@@ -225,6 +237,128 @@ func NewHandler(
 						return
 					}
 					writeJSON(w, http.StatusOK, submission)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+		}
+
+		if gamesService != nil {
+			mux.Handle("/api/admin/games", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if adminService == nil || !adminService.IsAdmin(claims.Subject) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, gamesService.List(r.Context()))
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req gameUpsertRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					created, err := gamesService.Create(r.Context(), games.UpsertRequest{
+						Slug:        req.Slug,
+						Title:       req.Title,
+						Description: req.Description,
+						Rules:       req.Rules,
+						Status:      req.Status,
+					})
+					if err != nil {
+						switch {
+						case errors.Is(err, games.ErrInvalidSlug), errors.Is(err, games.ErrInvalidTitle), errors.Is(err, games.ErrInvalidStatus), errors.Is(err, games.ErrDuplicateSlug):
+							writeError(w, http.StatusBadRequest, err.Error())
+						default:
+							logger.Error("failed to create game", zap.Error(err))
+							writeError(w, http.StatusInternalServerError, "failed to create game")
+						}
+						return
+					}
+					writeJSON(w, http.StatusCreated, created)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/games/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if adminService == nil || !adminService.IsAdmin(claims.Subject) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+
+				gameID := strings.TrimPrefix(r.URL.Path, "/api/admin/games/")
+				if strings.TrimSpace(gameID) == "" || strings.Contains(gameID, "/") {
+					writeError(w, http.StatusBadRequest, "game id is required")
+					return
+				}
+
+				switch r.Method {
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req gameUpsertRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					updated, err := gamesService.Update(r.Context(), gameID, games.UpsertRequest{
+						Slug:        req.Slug,
+						Title:       req.Title,
+						Description: req.Description,
+						Rules:       req.Rules,
+						Status:      req.Status,
+					})
+					if err != nil {
+						switch {
+						case errors.Is(err, games.ErrInvalidID), errors.Is(err, games.ErrInvalidSlug), errors.Is(err, games.ErrInvalidTitle), errors.Is(err, games.ErrInvalidStatus), errors.Is(err, games.ErrDuplicateSlug):
+							writeError(w, http.StatusBadRequest, err.Error())
+						case errors.Is(err, games.ErrNotFound):
+							writeError(w, http.StatusNotFound, err.Error())
+						default:
+							logger.Error("failed to update game", zap.Error(err))
+							writeError(w, http.StatusInternalServerError, "failed to update game")
+						}
+						return
+					}
+					writeJSON(w, http.StatusOK, updated)
+				case http.MethodDelete:
+					err := gamesService.Delete(r.Context(), gameID)
+					if err != nil {
+						if errors.Is(err, games.ErrInvalidID) {
+							writeError(w, http.StatusBadRequest, err.Error())
+							return
+						}
+						if errors.Is(err, games.ErrNotFound) {
+							writeError(w, http.StatusNotFound, err.Error())
+							return
+						}
+						logger.Error("failed to delete game", zap.Error(err))
+						writeError(w, http.StatusInternalServerError, "failed to delete game")
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
 				default:
 					w.WriteHeader(http.StatusMethodNotAllowed)
 				}

--- a/internal/app/router_games_test.go
+++ b/internal/app/router_games_test.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/funpot/funpot-go-core/internal/admin"
+	"github.com/funpot/funpot-go-core/internal/auth"
+	"github.com/funpot/funpot-go-core/internal/config"
+	"github.com/funpot/funpot-go-core/internal/games"
+	"github.com/funpot/funpot-go-core/internal/users"
+)
+
+func buildAuthService(t *testing.T) *auth.Service {
+	t.Helper()
+	svc, err := auth.NewService(zap.NewNop(), config.AuthConfig{
+		BotToken: "test-bot-token",
+		JWT: config.JWTConfig{
+			Secret: "test-secret",
+			TTL:    time.Hour,
+		},
+	}, users.NewService(users.NewInMemoryRepository()))
+	if err != nil {
+		t.Fatalf("auth.NewService() error = %v", err)
+	}
+	return svc
+}
+
+func buildToken(t *testing.T, userID string) string {
+	t.Helper()
+	issuer, err := auth.NewJWTIssuer("test-secret", time.Hour)
+	if err != nil {
+		t.Fatalf("auth.NewJWTIssuer() error = %v", err)
+	}
+	token, _, err := issuer.Issue(userID, 1, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("issuer.Issue() error = %v", err)
+	}
+	return token
+}
+
+func TestAdminGamesForbiddenForNonAdmin(t *testing.T) {
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, games.NewService(), nil, ClientConfigResponse{})
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/games", nil)
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", res.Code)
+	}
+}
+
+func TestAdminGamesCreateAndList(t *testing.T) {
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, games.NewService(), nil, ClientConfigResponse{})
+	token := buildToken(t, "admin-1")
+
+	body, _ := json.Marshal(map[string]any{"slug": "cs2", "title": "Counter-Strike 2", "status": "draft"})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/games", bytes.NewReader(body))
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createRes := httptest.NewRecorder()
+	handler.ServeHTTP(createRes, createReq)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", createRes.Code)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/games", nil)
+	listReq.Header.Set("Authorization", "Bearer "+token)
+	listRes := httptest.NewRecorder()
+	handler.ServeHTTP(listRes, listReq)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listRes.Code)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,9 +19,15 @@ type Config struct {
 	Telemetry   TelemetryConfig
 	Sentry      SentryConfig
 	Auth        AuthConfig
+	Admin       AdminConfig
 	Database    DatabaseConfig
 	Features    FeatureConfig
 	Client      ClientConfig
+}
+
+// AdminConfig controls role-based admin access.
+type AdminConfig struct {
+	UserIDs []string
 }
 
 // ServerConfig holds HTTP server settings.
@@ -247,6 +253,9 @@ func Load() (Config, error) {
 				Secret: getString("FUNPOT_AUTH_JWT_SECRET", "dev-secret"),
 				TTL:    jwtTTL,
 			},
+		},
+		Admin: AdminConfig{
+			UserIDs: getCSVStrings("FUNPOT_ADMIN_USER_IDS", nil),
 		},
 		Database: DatabaseConfig{
 			Enabled:         databaseEnabled,

--- a/internal/games/model.go
+++ b/internal/games/model.go
@@ -1,0 +1,41 @@
+package games
+
+import "time"
+
+const (
+	StatusDraft    = "draft"
+	StatusActive   = "active"
+	StatusArchived = "archived"
+)
+
+var supportedStatuses = map[string]struct{}{
+	StatusDraft:    {},
+	StatusActive:   {},
+	StatusArchived: {},
+}
+
+// Game contains configurable game rules managed by admins.
+type Game struct {
+	ID          string    `json:"id"`
+	Slug        string    `json:"slug"`
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	Rules       []string  `json:"rules"`
+	Status      string    `json:"status"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+// UpsertRequest describes the payload for creating and updating games.
+type UpsertRequest struct {
+	Slug        string   `json:"slug"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Rules       []string `json:"rules"`
+	Status      string   `json:"status"`
+}
+
+func IsSupportedStatus(value string) bool {
+	_, ok := supportedStatuses[value]
+	return ok
+}

--- a/internal/games/service.go
+++ b/internal/games/service.go
@@ -1,0 +1,150 @@
+package games
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	ErrInvalidID     = errors.New("invalid game id")
+	ErrInvalidSlug   = errors.New("slug is required")
+	ErrInvalidTitle  = errors.New("title is required")
+	ErrInvalidStatus = errors.New("status is invalid")
+	ErrDuplicateSlug = errors.New("slug is already used")
+	ErrNotFound      = errors.New("game not found")
+)
+
+// Service manages admin CRUD operations for games.
+type Service struct {
+	mu    sync.RWMutex
+	games map[string]Game
+}
+
+func NewService() *Service {
+	return &Service{games: make(map[string]Game)}
+}
+
+func (s *Service) List(_ context.Context) []Game {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := make([]Game, 0, len(s.games))
+	for _, game := range s.games {
+		items = append(items, game)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].ID < items[j].ID
+		}
+		return items[i].CreatedAt.Before(items[j].CreatedAt)
+	})
+	return items
+}
+
+func (s *Service) Create(_ context.Context, req UpsertRequest) (Game, error) {
+	now := time.Now().UTC()
+	prepared, err := sanitizeUpsert(req)
+	if err != nil {
+		return Game{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.slugExistsLocked(prepared.Slug, "") {
+		return Game{}, fmt.Errorf("%w: %s", ErrDuplicateSlug, prepared.Slug)
+	}
+	game := Game{
+		ID:          uuid.NewString(),
+		Slug:        prepared.Slug,
+		Title:       prepared.Title,
+		Description: prepared.Description,
+		Rules:       prepared.Rules,
+		Status:      prepared.Status,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	s.games[game.ID] = game
+	return game, nil
+}
+
+func (s *Service) Update(_ context.Context, id string, req UpsertRequest) (Game, error) {
+	if strings.TrimSpace(id) == "" {
+		return Game{}, ErrInvalidID
+	}
+	prepared, err := sanitizeUpsert(req)
+	if err != nil {
+		return Game{}, err
+	}
+	now := time.Now().UTC()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.games[id]
+	if !ok {
+		return Game{}, ErrNotFound
+	}
+	if s.slugExistsLocked(prepared.Slug, id) {
+		return Game{}, fmt.Errorf("%w: %s", ErrDuplicateSlug, prepared.Slug)
+	}
+	current.Slug = prepared.Slug
+	current.Title = prepared.Title
+	current.Description = prepared.Description
+	current.Rules = prepared.Rules
+	current.Status = prepared.Status
+	current.UpdatedAt = now
+	s.games[id] = current
+	return current, nil
+}
+
+func (s *Service) Delete(_ context.Context, id string) error {
+	if strings.TrimSpace(id) == "" {
+		return ErrInvalidID
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.games[id]; !ok {
+		return ErrNotFound
+	}
+	delete(s.games, id)
+	return nil
+}
+
+func sanitizeUpsert(req UpsertRequest) (UpsertRequest, error) {
+	prepared := UpsertRequest{
+		Slug:        strings.ToLower(strings.TrimSpace(req.Slug)),
+		Title:       strings.TrimSpace(req.Title),
+		Description: strings.TrimSpace(req.Description),
+		Status:      strings.ToLower(strings.TrimSpace(req.Status)),
+	}
+	for _, rule := range req.Rules {
+		if trimmed := strings.TrimSpace(rule); trimmed != "" {
+			prepared.Rules = append(prepared.Rules, trimmed)
+		}
+	}
+	if prepared.Slug == "" {
+		return UpsertRequest{}, ErrInvalidSlug
+	}
+	if prepared.Title == "" {
+		return UpsertRequest{}, ErrInvalidTitle
+	}
+	if !IsSupportedStatus(prepared.Status) {
+		return UpsertRequest{}, ErrInvalidStatus
+	}
+	return prepared, nil
+}
+
+func (s *Service) slugExistsLocked(slug string, exceptID string) bool {
+	for _, game := range s.games {
+		if game.ID != exceptID && game.Slug == slug {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/games/service_test.go
+++ b/internal/games/service_test.go
@@ -1,0 +1,75 @@
+package games
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestServiceCreateValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		req  UpsertRequest
+		err  error
+	}{
+		{name: "missing slug", req: UpsertRequest{Title: "CS2", Status: StatusDraft}, err: ErrInvalidSlug},
+		{name: "missing title", req: UpsertRequest{Slug: "cs2", Status: StatusDraft}, err: ErrInvalidTitle},
+		{name: "invalid status", req: UpsertRequest{Slug: "cs2", Title: "CS2", Status: "unknown"}, err: ErrInvalidStatus},
+	}
+
+	svc := NewService()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.Create(context.Background(), tt.req)
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("expected %v, got %v", tt.err, err)
+			}
+		})
+	}
+}
+
+func TestServiceCRUD(t *testing.T) {
+	svc := NewService()
+	ctx := context.Background()
+
+	created, err := svc.Create(ctx, UpsertRequest{
+		Slug:        " cs2 ",
+		Title:       "Counter-Strike 2",
+		Description: "  shooter  ",
+		Rules:       []string{" rule 1 ", "", " rule 2 "},
+		Status:      "ACTIVE",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created.Slug != "cs2" || created.Status != StatusActive {
+		t.Fatalf("unexpected normalized game: %+v", created)
+	}
+	if len(created.Rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(created.Rules))
+	}
+
+	if _, err := svc.Create(ctx, UpsertRequest{Slug: "cs2", Title: "Duplicate", Status: StatusDraft}); !errors.Is(err, ErrDuplicateSlug) {
+		t.Fatalf("expected duplicate slug error, got %v", err)
+	}
+
+	updated, err := svc.Update(ctx, created.ID, UpsertRequest{Slug: "cs2-premier", Title: "CS2 Premier", Status: StatusArchived})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated.Slug != "cs2-premier" || updated.Status != StatusArchived {
+		t.Fatalf("unexpected updated game: %+v", updated)
+	}
+
+	games := svc.List(ctx)
+	if len(games) != 1 {
+		t.Fatalf("expected one game, got %d", len(games))
+	}
+
+	if err := svc.Delete(ctx, created.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if err := svc.Delete(ctx, created.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected not found on second delete, got %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide an admin-managed games CRUD surface so platform operators can define and maintain game rules and statuses (`draft|active|archived`) as part of M2 work. 
- Enforce admin role checks for sensitive endpoints and expose a clear backend contract for future admin UI and orchestration work. 

### Description
- Add an in-memory `internal/games` module with `Game` model, validation/normalization, and an admin CRUD `Service` plus unit tests (`internal/games/model.go`, `internal/games/service.go`, `internal/games/service_test.go`).
- Add a simple `internal/admin` service that checks admin status from configured user IDs and wire it into app startup and routing (`internal/admin/service.go`, `cmd/server/main.go`, `internal/config/config.go`).
- Expose admin-only HTTP endpoints with JWT+admin enforcement: `GET /api/admin/games`, `POST /api/admin/games`, `PUT /api/admin/games/{gameId}`, `DELETE /api/admin/games/{gameId}` and implement request/response handling and error codes in the router (`internal/app/router.go`).
- Update configuration and docs: introduce `FUNPOT_ADMIN_USER_IDS` in `docs/local_setup.md`, add admin games contract to `docs/openapi.yaml`, and mark the M2 games item completed in `docs/implementation_plan.md`.

Progress checklist (scope-relevant M2 items):
- [x] Create `games` module storing rules, statuses, and admin CRUD endpoints.
- [x] Introduce admin role enforcement (backend API layer).
- [ ] Basic UI scaffolds (out of scope for this backend iteration).

### Testing
- Ran `go test ./...` and all test packages passed (games service and router tests included). 
- Ran `gofmt -w` on modified files and updated module dependencies (`go get github.com/google/uuid` + `go mod tidy`) to satisfy new code; `go test` succeeded after dependency update. 
- Added unit tests for the games service and HTTP tests for admin routes and confirmed they succeed under `go test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55f946340832c8d39a1a248f83ecd)