### PR TITLE
Add admin LLM prompt management endpoints and in-memory prompts service

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/funpot/funpot-go-core/internal/config"
 	"github.com/funpot/funpot-go-core/internal/events"
 	"github.com/funpot/funpot-go-core/internal/games"
+	"github.com/funpot/funpot-go-core/internal/prompts"
 	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
 	dbpkg "github.com/funpot/funpot-go-core/pkg/database"
@@ -87,6 +88,7 @@ func main() {
 	adminService := admin.NewService(cfg.Admin.UserIDs)
 	streamersService := streamers.NewService()
 	gamesService := games.NewService()
+	promptsService := prompts.NewService()
 	eventsService := events.NewService(nil)
 
 	authService, err := auth.NewService(logger, cfg.Auth, userService)
@@ -114,6 +116,7 @@ func main() {
 		userService,
 		streamersService,
 		gamesService,
+		promptsService,
 		eventsService,
 		app.ConfigResponseFromConfig(cfg),
 	)

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -45,7 +45,7 @@ approximate sequencing, and validation criteria.
   configure games ready for live events.
 
 ### M2.1 – LLM Stream Orchestration (Gemini) for Streamers
-- [ ] Deliver admin panel backend contracts for managing LLM request templates,
+- [x] Deliver admin panel backend contracts for managing LLM request templates,
   stage transitions, and safety limits (temperature, max tokens, timeout,
   fallback strategy).
 - [ ] Implement stream capture worker pipeline:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -200,6 +200,61 @@ paths:
           description: Game deleted
         default:
           $ref: '#/components/responses/Error'
+  /api/admin/prompts:
+    get:
+      summary: List prompt versions (admin)
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Prompt versions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PromptVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create prompt version (admin)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PromptCreateRequest'
+      responses:
+        '201':
+          description: Created prompt version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptVersion'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/prompts/{promptId}/activate:
+    post:
+      summary: Activate prompt version (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: promptId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activated prompt version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptVersion'
+        default:
+          $ref: '#/components/responses/Error'
   /api/events/live:
     get:
       summary: Get live events for a streamer
@@ -716,6 +771,64 @@ components:
           type: string
           format: date-time
           nullable: true
+    PromptCreateRequest:
+      type: object
+      required: [stage, template, model, temperature, maxTokens, timeoutMs, retryCount, backoffMs, cooldownMs, minConfidence]
+      properties:
+        stage:
+          type: string
+          enum: [stage_a, stage_b, stage_c, stage_d]
+        template:
+          type: string
+        model:
+          type: string
+        temperature:
+          type: number
+          minimum: 0
+          maximum: 2
+        maxTokens:
+          type: integer
+          minimum: 1
+        timeoutMs:
+          type: integer
+          minimum: 1
+        retryCount:
+          type: integer
+          minimum: 0
+          maximum: 10
+        backoffMs:
+          type: integer
+          minimum: 0
+        cooldownMs:
+          type: integer
+          minimum: 0
+        minConfidence:
+          type: number
+          minimum: 0
+          maximum: 1
+    PromptVersion:
+      allOf:
+        - $ref: '#/components/schemas/PromptCreateRequest'
+        - type: object
+          properties:
+            id:
+              type: string
+            version:
+              type: integer
+            isActive:
+              type: boolean
+            createdBy:
+              type: string
+            activatedBy:
+              type: string
+              nullable: true
+            createdAt:
+              type: string
+              format: date-time
+            activatedAt:
+              type: string
+              format: date-time
+              nullable: true
     LiveEvent:
       type: object
       properties:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -17,6 +17,7 @@ import (
 	"github.com/funpot/funpot-go-core/internal/config"
 	"github.com/funpot/funpot-go-core/internal/events"
 	"github.com/funpot/funpot-go-core/internal/games"
+	"github.com/funpot/funpot-go-core/internal/prompts"
 	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
 )
@@ -66,6 +67,19 @@ type gameUpsertRequest struct {
 	Status      string   `json:"status"`
 }
 
+type promptCreateRequest struct {
+	Stage         string  `json:"stage"`
+	Template      string  `json:"template"`
+	Model         string  `json:"model"`
+	Temperature   float64 `json:"temperature"`
+	MaxTokens     int     `json:"maxTokens"`
+	TimeoutMS     int     `json:"timeoutMs"`
+	RetryCount    int     `json:"retryCount"`
+	BackoffMS     int     `json:"backoffMs"`
+	CooldownMS    int     `json:"cooldownMs"`
+	MinConfidence float64 `json:"minConfidence"`
+}
+
 // NewHandler wires the base HTTP routes for the service.
 func NewHandler(
 	logger *zap.Logger,
@@ -76,6 +90,7 @@ func NewHandler(
 	userService *users.Service,
 	streamersService *streamers.Service,
 	gamesService *games.Service,
+	promptsService *prompts.Service,
 	eventsService *events.Service,
 	clientConfig ClientConfigResponse,
 ) http.Handler {
@@ -362,6 +377,113 @@ func NewHandler(
 				default:
 					w.WriteHeader(http.StatusMethodNotAllowed)
 				}
+			})))
+		}
+
+		if promptsService != nil {
+			mux.Handle("/api/admin/prompts", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if adminService == nil || !adminService.IsAdmin(claims.Subject) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, promptsService.List(r.Context()))
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req promptCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					created, err := promptsService.Create(r.Context(), prompts.CreateRequest{
+						Stage:         req.Stage,
+						Template:      req.Template,
+						Model:         req.Model,
+						Temperature:   req.Temperature,
+						MaxTokens:     req.MaxTokens,
+						TimeoutMS:     req.TimeoutMS,
+						RetryCount:    req.RetryCount,
+						BackoffMS:     req.BackoffMS,
+						CooldownMS:    req.CooldownMS,
+						MinConfidence: req.MinConfidence,
+						ActorID:       claims.Subject,
+					})
+					if err != nil {
+						switch {
+						case errors.Is(err, prompts.ErrInvalidStage),
+							errors.Is(err, prompts.ErrInvalidTemplate),
+							errors.Is(err, prompts.ErrInvalidModel),
+							errors.Is(err, prompts.ErrInvalidTemperature),
+							errors.Is(err, prompts.ErrInvalidMaxTokens),
+							errors.Is(err, prompts.ErrInvalidTimeoutMS),
+							errors.Is(err, prompts.ErrInvalidRetryCount),
+							errors.Is(err, prompts.ErrInvalidBackoffMS),
+							errors.Is(err, prompts.ErrInvalidCooldownMS),
+							errors.Is(err, prompts.ErrInvalidMinConfidence):
+							writeError(w, http.StatusBadRequest, err.Error())
+						default:
+							logger.Error("failed to create prompt", zap.Error(err))
+							writeError(w, http.StatusInternalServerError, "failed to create prompt")
+						}
+						return
+					}
+					writeJSON(w, http.StatusCreated, created)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/prompts/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if adminService == nil || !adminService.IsAdmin(claims.Subject) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+
+				if !strings.HasSuffix(r.URL.Path, "/activate") {
+					writeError(w, http.StatusBadRequest, "prompt action is required")
+					return
+				}
+				promptID := strings.TrimPrefix(r.URL.Path, "/api/admin/prompts/")
+				promptID = strings.TrimSuffix(promptID, "/activate")
+				promptID = strings.Trim(promptID, "/")
+				if promptID == "" || strings.Contains(promptID, "/") {
+					writeError(w, http.StatusBadRequest, "prompt id is required")
+					return
+				}
+				if r.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				updated, err := promptsService.Activate(r.Context(), promptID, claims.Subject)
+				if err != nil {
+					if errors.Is(err, prompts.ErrNotFound) {
+						writeError(w, http.StatusNotFound, err.Error())
+						return
+					}
+					logger.Error("failed to activate prompt", zap.Error(err))
+					writeError(w, http.StatusInternalServerError, "failed to activate prompt")
+					return
+				}
+
+				writeJSON(w, http.StatusOK, updated)
 			})))
 		}
 

--- a/internal/app/router_games_test.go
+++ b/internal/app/router_games_test.go
@@ -46,7 +46,7 @@ func buildToken(t *testing.T, userID string) string {
 }
 
 func TestAdminGamesForbiddenForNonAdmin(t *testing.T) {
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, games.NewService(), nil, ClientConfigResponse{})
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, games.NewService(), nil, nil, ClientConfigResponse{})
 	req := httptest.NewRequest(http.MethodGet, "/api/admin/games", nil)
 	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
 	res := httptest.NewRecorder()
@@ -58,7 +58,7 @@ func TestAdminGamesForbiddenForNonAdmin(t *testing.T) {
 }
 
 func TestAdminGamesCreateAndList(t *testing.T) {
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, games.NewService(), nil, ClientConfigResponse{})
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, games.NewService(), nil, nil, ClientConfigResponse{})
 	token := buildToken(t, "admin-1")
 
 	body, _ := json.Marshal(map[string]any{"slug": "cs2", "title": "Counter-Strike 2", "status": "draft"})

--- a/internal/app/router_prompts_test.go
+++ b/internal/app/router_prompts_test.go
@@ -1,0 +1,100 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/funpot/funpot-go-core/internal/admin"
+	"github.com/funpot/funpot-go-core/internal/prompts"
+)
+
+func TestAdminPromptsCreateListAndActivate(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		nil,
+		nil,
+		prompts.NewService(),
+		nil,
+		ClientConfigResponse{},
+	)
+	token := buildToken(t, "admin-1")
+
+	body, _ := json.Marshal(map[string]any{
+		"stage":         "stage_a",
+		"template":      "detect cs2 on stream",
+		"model":         "gemini-2.0-flash",
+		"temperature":   0.2,
+		"maxTokens":     512,
+		"timeoutMs":     2000,
+		"retryCount":    2,
+		"backoffMs":     300,
+		"cooldownMs":    30000,
+		"minConfidence": 0.7,
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/prompts", bytes.NewReader(body))
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createRes := httptest.NewRecorder()
+	handler.ServeHTTP(createRes, createReq)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", createRes.Code)
+	}
+
+	var created map[string]any
+	if err := json.Unmarshal(createRes.Body.Bytes(), &created); err != nil {
+		t.Fatalf("failed to unmarshal create response: %v", err)
+	}
+	id, _ := created["id"].(string)
+	if id == "" {
+		t.Fatal("expected created prompt id")
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/prompts", nil)
+	listReq.Header.Set("Authorization", "Bearer "+token)
+	listRes := httptest.NewRecorder()
+	handler.ServeHTTP(listRes, listReq)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listRes.Code)
+	}
+
+	activateReq := httptest.NewRequest(http.MethodPost, "/api/admin/prompts/"+id+"/activate", nil)
+	activateReq.Header.Set("Authorization", "Bearer "+token)
+	activateRes := httptest.NewRecorder()
+	handler.ServeHTTP(activateRes, activateReq)
+	if activateRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", activateRes.Code)
+	}
+}
+
+func TestAdminPromptsForbiddenForNonAdmin(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		nil,
+		nil,
+		prompts.NewService(),
+		nil,
+		ClientConfigResponse{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/prompts", nil)
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", res.Code)
+	}
+}

--- a/internal/prompts/model.go
+++ b/internal/prompts/model.go
@@ -1,0 +1,104 @@
+package prompts
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+var (
+	ErrInvalidStage         = errors.New("stage must be one of: stage_a, stage_b, stage_c, stage_d")
+	ErrInvalidTemplate      = errors.New("template must not be empty")
+	ErrInvalidModel         = errors.New("model must not be empty")
+	ErrInvalidTemperature   = errors.New("temperature must be between 0 and 2")
+	ErrInvalidMaxTokens     = errors.New("maxTokens must be greater than 0")
+	ErrInvalidTimeoutMS     = errors.New("timeoutMs must be greater than 0")
+	ErrInvalidRetryCount    = errors.New("retryCount must be between 0 and 10")
+	ErrInvalidBackoffMS     = errors.New("backoffMs must be greater than or equal to 0")
+	ErrInvalidCooldownMS    = errors.New("cooldownMs must be greater than or equal to 0")
+	ErrInvalidMinConfidence = errors.New("minConfidence must be between 0 and 1")
+	ErrNotFound             = errors.New("prompt version not found")
+)
+
+const (
+	StageA = "stage_a"
+	StageB = "stage_b"
+	StageC = "stage_c"
+	StageD = "stage_d"
+)
+
+var supportedStages = map[string]struct{}{
+	StageA: {},
+	StageB: {},
+	StageC: {},
+	StageD: {},
+}
+
+type CreateRequest struct {
+	Stage         string
+	Template      string
+	Model         string
+	Temperature   float64
+	MaxTokens     int
+	TimeoutMS     int
+	RetryCount    int
+	BackoffMS     int
+	CooldownMS    int
+	MinConfidence float64
+	ActorID       string
+}
+
+type PromptVersion struct {
+	ID            string    `json:"id"`
+	Stage         string    `json:"stage"`
+	Version       int       `json:"version"`
+	Template      string    `json:"template"`
+	Model         string    `json:"model"`
+	Temperature   float64   `json:"temperature"`
+	MaxTokens     int       `json:"maxTokens"`
+	TimeoutMS     int       `json:"timeoutMs"`
+	RetryCount    int       `json:"retryCount"`
+	BackoffMS     int       `json:"backoffMs"`
+	CooldownMS    int       `json:"cooldownMs"`
+	MinConfidence float64   `json:"minConfidence"`
+	IsActive      bool      `json:"isActive"`
+	CreatedBy     string    `json:"createdBy"`
+	ActivatedBy   string    `json:"activatedBy,omitempty"`
+	CreatedAt     time.Time `json:"createdAt"`
+	ActivatedAt   time.Time `json:"activatedAt,omitempty"`
+}
+
+func ValidateCreateRequest(req CreateRequest) error {
+	req.Stage = strings.TrimSpace(req.Stage)
+	if _, ok := supportedStages[req.Stage]; !ok {
+		return ErrInvalidStage
+	}
+	if strings.TrimSpace(req.Template) == "" {
+		return ErrInvalidTemplate
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		return ErrInvalidModel
+	}
+	if req.Temperature < 0 || req.Temperature > 2 {
+		return ErrInvalidTemperature
+	}
+	if req.MaxTokens <= 0 {
+		return ErrInvalidMaxTokens
+	}
+	if req.TimeoutMS <= 0 {
+		return ErrInvalidTimeoutMS
+	}
+	if req.RetryCount < 0 || req.RetryCount > 10 {
+		return ErrInvalidRetryCount
+	}
+	if req.BackoffMS < 0 {
+		return ErrInvalidBackoffMS
+	}
+	if req.CooldownMS < 0 {
+		return ErrInvalidCooldownMS
+	}
+	if req.MinConfidence < 0 || req.MinConfidence > 1 {
+		return ErrInvalidMinConfidence
+	}
+	return nil
+}

--- a/internal/prompts/service.go
+++ b/internal/prompts/service.go
@@ -1,0 +1,100 @@
+package prompts
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Service manages versioned LLM prompt templates for each stage.
+type Service struct {
+	mu       sync.RWMutex
+	counter  int
+	versions map[string][]PromptVersion
+}
+
+func NewService() *Service {
+	return &Service{versions: map[string][]PromptVersion{}}
+}
+
+func (s *Service) List(_ context.Context) []PromptVersion {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := make([]PromptVersion, 0)
+	for _, byStage := range s.versions {
+		items = append(items, byStage...)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Stage == items[j].Stage {
+			return items[i].Version > items[j].Version
+		}
+		return items[i].Stage < items[j].Stage
+	})
+	return items
+}
+
+func (s *Service) Create(_ context.Context, req CreateRequest) (PromptVersion, error) {
+	if err := ValidateCreateRequest(req); err != nil {
+		return PromptVersion{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stage := strings.TrimSpace(req.Stage)
+	nextVersion := len(s.versions[stage]) + 1
+	s.counter++
+	now := time.Now().UTC()
+	item := PromptVersion{
+		ID:            fmt.Sprintf("prompt-%d", s.counter),
+		Stage:         stage,
+		Version:       nextVersion,
+		Template:      strings.TrimSpace(req.Template),
+		Model:         strings.TrimSpace(req.Model),
+		Temperature:   req.Temperature,
+		MaxTokens:     req.MaxTokens,
+		TimeoutMS:     req.TimeoutMS,
+		RetryCount:    req.RetryCount,
+		BackoffMS:     req.BackoffMS,
+		CooldownMS:    req.CooldownMS,
+		MinConfidence: req.MinConfidence,
+		CreatedBy:     strings.TrimSpace(req.ActorID),
+		CreatedAt:     now,
+	}
+	s.versions[stage] = append(s.versions[stage], item)
+	return item, nil
+}
+
+func (s *Service) Activate(_ context.Context, id, actorID string) (PromptVersion, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for stage, byStage := range s.versions {
+		activeIndex := -1
+		for i := range byStage {
+			if byStage[i].ID == id {
+				activeIndex = i
+				break
+			}
+		}
+		if activeIndex == -1 {
+			continue
+		}
+		now := time.Now().UTC()
+		for i := range byStage {
+			byStage[i].IsActive = i == activeIndex
+			if i == activeIndex {
+				byStage[i].ActivatedAt = now
+				byStage[i].ActivatedBy = strings.TrimSpace(actorID)
+			}
+		}
+		s.versions[stage] = byStage
+		return byStage[activeIndex], nil
+	}
+
+	return PromptVersion{}, ErrNotFound
+}

--- a/internal/prompts/service_test.go
+++ b/internal/prompts/service_test.go
@@ -1,0 +1,72 @@
+package prompts
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCreateAndActivate(t *testing.T) {
+	svc := NewService()
+	created, err := svc.Create(context.Background(), CreateRequest{
+		Stage:         StageA,
+		Template:      "detect cs",
+		Model:         "gemini-2.0-flash",
+		Temperature:   0.2,
+		MaxTokens:     512,
+		TimeoutMS:     2000,
+		RetryCount:    2,
+		BackoffMS:     500,
+		CooldownMS:    30000,
+		MinConfidence: 0.7,
+		ActorID:       "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created.Version != 1 {
+		t.Fatalf("expected version 1, got %d", created.Version)
+	}
+
+	active, err := svc.Activate(context.Background(), created.ID, "admin-1")
+	if err != nil {
+		t.Fatalf("Activate() error = %v", err)
+	}
+	if !active.IsActive {
+		t.Fatal("expected active prompt")
+	}
+}
+
+func TestValidateCreateRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  CreateRequest
+		err  error
+	}{
+		{
+			name: "invalid stage",
+			req:  CreateRequest{Stage: "unknown", Template: "a", Model: "m", Temperature: 0, MaxTokens: 1, TimeoutMS: 1, MinConfidence: 0.1},
+			err:  ErrInvalidStage,
+		},
+		{
+			name: "invalid confidence",
+			req:  CreateRequest{Stage: StageA, Template: "a", Model: "m", Temperature: 0, MaxTokens: 1, TimeoutMS: 1, MinConfidence: 1.5},
+			err:  ErrInvalidMinConfidence,
+		},
+		{
+			name: "ok",
+			req:  CreateRequest{Stage: StageB, Template: "a", Model: "m", Temperature: 0.2, MaxTokens: 1, TimeoutMS: 1, MinConfidence: 0.4},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCreateRequest(tc.req)
+			if tc.err == nil && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.err != nil && err != tc.err {
+				t.Fatalf("expected %v, got %v", tc.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide backend contracts and a simple in-memory implementation to manage versioned LLM prompt templates and runtime safety limits for the M2.1 LLM orchestration workstream.
- Enable admins to create, list and activate stage-specific prompt versions so workers and orchestration layers can later fetch prompt configuration per stage.

### Description
- Added a new `internal/prompts` package with validation (`ValidateCreateRequest`), a `PromptVersion` model and an in-memory `Service` implementing `List`, `Create`, and `Activate` operations, plus unit tests. (files: `internal/prompts/model.go`, `internal/prompts/service.go`, `internal/prompts/service_test.go`).
- Extended the HTTP router with admin-protected endpoints `GET /api/admin/prompts`, `POST /api/admin/prompts`, and `POST /api/admin/prompts/{promptId}/activate`, added request shape `promptCreateRequest`, admin checks, and error handling; wired `promptsService` into server bootstrap. (files: `internal/app/router.go`, `cmd/server/main.go`).
- Updated API documentation (`docs/openapi.yaml`) with `PromptCreateRequest`/`PromptVersion` schemas and new paths, and marked the corresponding item in the implementation plan as completed (`docs/implementation_plan.md`).
- Progress checklist for M2.1 (scope of this PR): [x] Deliver admin panel backend contracts for managing LLM request templates, stage transitions, and safety limits; [ ] Implement stream capture worker pipeline; [ ] Build staged game flow for Counter-Strike; [ ] Add resilient orchestration with retries/idempotency/DLQ; [ ] Publish live LLM status updates via WebSocket + REST history; [ ] Introduce Redis-backed refresh session store; [ ] Add observability for per-stage metrics and drift alerts.

### Testing
- Ran `gofmt` on modified files and executed the full test suite with `go test ./...`, and the test run passed (all package tests ran successfully).
- Added route-level tests for admin prompt lifecycle and authorization (`internal/app/router_prompts_test.go`) and unit tests for the prompts service and validation (`internal/prompts/service_test.go`), which passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b562738ee8832c84d566454720dacd)