### PR TITLE
Add streamer LLM decision history API slice for M2.1

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -57,8 +57,8 @@ approximate sequencing, and validation criteria.
   Stage D determines result (win / loss / unknown).
 - [ ] Add resilient orchestration with retries, idempotency keys, and dead-letter
   handling for failed LLM jobs.
-- [ ] Publish live LLM status updates to clients via WebSocket channel and
-  provide REST history endpoint for latest decisions.
+- [ ] Publish live LLM status updates to clients via WebSocket channel.
+- [x] Provide REST history endpoint for latest LLM stage decisions.
 - [ ] Introduce Redis-backed refresh session store for admin/user session
   revocation, rotation, and concurrent session controls.
 - [ ] Add observability: per-stage latency, success ratio, token usage, and

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -124,6 +124,59 @@ paths:
                 $ref: '#/components/schemas/Error'
         default:
           $ref: '#/components/responses/Error'
+  /api/streamers/{streamerId}/llm-decisions:
+    get:
+      summary: List latest LLM stage decisions for streamer
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: streamerId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Decision history ordered by latest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LLMDecision'
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Record LLM stage decision for streamer (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: streamerId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LLMDecisionRecordRequest'
+      responses:
+        '201':
+          description: Recorded LLM decision
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMDecision'
+        default:
+          $ref: '#/components/responses/Error'
+
   /api/admin/games:
     get:
       summary: List games (admin)
@@ -730,6 +783,41 @@ components:
         reason:
           type: string
           nullable: true
+
+    LLMDecisionRecordRequest:
+      type: object
+      required: [runId, stage, label, confidence]
+      properties:
+        runId:
+          type: string
+        stage:
+          type: string
+          enum: [stage_a, stage_b, stage_c, stage_d]
+        label:
+          type: string
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+    LLMDecision:
+      type: object
+      properties:
+        id:
+          type: string
+        runId:
+          type: string
+        streamerId:
+          type: string
+        stage:
+          type: string
+          enum: [stage_a, stage_b, stage_c, stage_d]
+        label:
+          type: string
+        confidence:
+          type: number
+        createdAt:
+          type: string
+          format: date-time
     GameUpsertRequest:
       type: object
       required: [slug, title, status]

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -80,6 +80,13 @@ type promptCreateRequest struct {
 	MinConfidence float64 `json:"minConfidence"`
 }
 
+type llmDecisionRecordRequest struct {
+	RunID      string  `json:"runId"`
+	Stage      string  `json:"stage"`
+	Label      string  `json:"label"`
+	Confidence float64 `json:"confidence"`
+}
+
 // NewHandler wires the base HTTP routes for the service.
 func NewHandler(
 	logger *zap.Logger,
@@ -254,6 +261,80 @@ func NewHandler(
 					writeJSON(w, http.StatusOK, submission)
 				default:
 					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/streamers/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				path := strings.TrimPrefix(r.URL.Path, "/api/streamers/")
+				if path == "" {
+					writeError(w, http.StatusNotFound, "streamer route not found")
+					return
+				}
+
+				parts := strings.Split(path, "/")
+				if len(parts) != 2 {
+					writeError(w, http.StatusNotFound, "streamer route not found")
+					return
+				}
+				streamerID := strings.TrimSpace(parts[0])
+				action := strings.TrimSpace(parts[1])
+				if streamerID == "" {
+					writeError(w, http.StatusBadRequest, "streamer id is required")
+					return
+				}
+
+				switch action {
+				case "llm-decisions":
+					switch r.Method {
+					case http.MethodGet:
+						limit, err := strconv.Atoi(strings.TrimSpace(r.URL.Query().Get("limit")))
+						if err != nil && r.URL.Query().Get("limit") != "" {
+							writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+							return
+						}
+						if limit < 0 {
+							writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+							return
+						}
+						writeJSON(w, http.StatusOK, streamersService.ListLLMDecisions(r.Context(), streamerID, limit))
+					case http.MethodPost:
+						claims, ok := auth.ClaimsFromContext(r.Context())
+						if !ok {
+							writeError(w, http.StatusUnauthorized, "missing auth claims")
+							return
+						}
+						if adminService == nil || !adminService.IsAdmin(claims.Subject) {
+							writeError(w, http.StatusForbidden, "admin role is required")
+							return
+						}
+						defer r.Body.Close() //nolint:errcheck
+						body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+						if err != nil {
+							writeError(w, http.StatusBadRequest, "failed to read request body")
+							return
+						}
+						var req llmDecisionRecordRequest
+						if err := json.Unmarshal(body, &req); err != nil {
+							writeError(w, http.StatusBadRequest, "invalid request body")
+							return
+						}
+						item, err := streamersService.RecordLLMDecision(r.Context(), streamers.RecordDecisionRequest{
+							RunID:      req.RunID,
+							StreamerID: streamerID,
+							Stage:      req.Stage,
+							Label:      req.Label,
+							Confidence: req.Confidence,
+						})
+						if err != nil {
+							writeError(w, http.StatusBadRequest, err.Error())
+							return
+						}
+						writeJSON(w, http.StatusCreated, item)
+					default:
+						w.WriteHeader(http.StatusMethodNotAllowed)
+					}
+				default:
+					writeError(w, http.StatusNotFound, "streamer route not found")
 				}
 			})))
 		}

--- a/internal/app/router_streamers_llm_test.go
+++ b/internal/app/router_streamers_llm_test.go
@@ -1,0 +1,92 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/funpot/funpot-go-core/internal/admin"
+	"github.com/funpot/funpot-go-core/internal/streamers"
+)
+
+func TestStreamerLLMDecisionsCreateAndList(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamers.NewService(),
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	adminToken := buildToken(t, "admin-1")
+	body, _ := json.Marshal(map[string]any{
+		"runId":      "run-1",
+		"stage":      "stage_a",
+		"label":      "cs_detected",
+		"confidence": 0.93,
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/streamers/str-1/llm-decisions", bytes.NewReader(body))
+	createReq.Header.Set("Authorization", "Bearer "+adminToken)
+	createRes := httptest.NewRecorder()
+	handler.ServeHTTP(createRes, createReq)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", createRes.Code)
+	}
+
+	userToken := buildToken(t, "user-1")
+	listReq := httptest.NewRequest(http.MethodGet, "/api/streamers/str-1/llm-decisions?limit=1", nil)
+	listReq.Header.Set("Authorization", "Bearer "+userToken)
+	listRes := httptest.NewRecorder()
+	handler.ServeHTTP(listRes, listReq)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listRes.Code)
+	}
+
+	var items []map[string]any
+	if err := json.Unmarshal(listRes.Body.Bytes(), &items); err != nil {
+		t.Fatalf("failed to decode list response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one item, got %d", len(items))
+	}
+}
+
+func TestStreamerLLMDecisionCreateForbiddenForNonAdmin(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamers.NewService(),
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	body, _ := json.Marshal(map[string]any{
+		"runId":      "run-1",
+		"stage":      "stage_a",
+		"label":      "cs_detected",
+		"confidence": 0.93,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/streamers/str-1/llm-decisions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", res.Code)
+	}
+}

--- a/internal/streamers/model.go
+++ b/internal/streamers/model.go
@@ -16,3 +16,21 @@ type Submission struct {
 	Status string  `json:"status"`
 	Reason *string `json:"reason"`
 }
+
+type LLMDecision struct {
+	ID         string  `json:"id"`
+	RunID      string  `json:"runId"`
+	StreamerID string  `json:"streamerId"`
+	Stage      string  `json:"stage"`
+	Label      string  `json:"label"`
+	Confidence float64 `json:"confidence"`
+	CreatedAt  string  `json:"createdAt"`
+}
+
+type RecordDecisionRequest struct {
+	RunID      string
+	StreamerID string
+	Stage      string
+	Label      string
+	Confidence float64
+}

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -40,10 +40,13 @@ type submissionLimit struct {
 type Service struct {
 	mu             sync.RWMutex
 	items          []Streamer
+	decisions      map[string][]LLMDecision
 	validator      TwitchValidator
 	rateLimitMu    sync.Mutex
 	rateLimitByKey map[string]submissionLimit
 	nowFn          func() time.Time
+	counterMu      sync.Mutex
+	counter        int64
 }
 
 func NewService() *Service {
@@ -56,6 +59,7 @@ func NewServiceWithValidator(validator TwitchValidator) *Service {
 	}
 	return &Service{
 		items:          []Streamer{},
+		decisions:      make(map[string][]LLMDecision),
 		validator:      validator,
 		rateLimitByKey: make(map[string]submissionLimit),
 		nowFn: func() time.Time {
@@ -134,6 +138,86 @@ func (s *Service) Submit(ctx context.Context, twitchUsername, addedBy string) (S
 	s.mu.Unlock()
 
 	return Submission{ID: id, Status: "pending", Reason: nil}, nil
+}
+
+func (s *Service) RecordLLMDecision(_ context.Context, req RecordDecisionRequest) (LLMDecision, error) {
+	streamerID := strings.TrimSpace(req.StreamerID)
+	if streamerID == "" {
+		return LLMDecision{}, errors.New("streamerId is required")
+	}
+	runID := strings.TrimSpace(req.RunID)
+	if runID == "" {
+		return LLMDecision{}, errors.New("runId is required")
+	}
+	stage := strings.ToLower(strings.TrimSpace(req.Stage))
+	if !isSupportedStage(stage) {
+		return LLMDecision{}, errors.New("stage must be one of: stage_a, stage_b, stage_c, stage_d")
+	}
+	label := strings.TrimSpace(req.Label)
+	if label == "" {
+		return LLMDecision{}, errors.New("label is required")
+	}
+	if req.Confidence < 0 || req.Confidence > 1 {
+		return LLMDecision{}, errors.New("confidence must be between 0 and 1")
+	}
+
+	s.counterMu.Lock()
+	s.counter++
+	id := fmt.Sprintf("llm_%d", s.counter)
+	s.counterMu.Unlock()
+
+	item := LLMDecision{
+		ID:         id,
+		RunID:      runID,
+		StreamerID: streamerID,
+		Stage:      stage,
+		Label:      label,
+		Confidence: req.Confidence,
+		CreatedAt:  s.nowFn().UTC().Format(time.RFC3339Nano),
+	}
+
+	s.mu.Lock()
+	s.decisions[streamerID] = append(s.decisions[streamerID], item)
+	s.mu.Unlock()
+
+	return item, nil
+}
+
+func (s *Service) ListLLMDecisions(_ context.Context, streamerID string, limit int) []LLMDecision {
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return []LLMDecision{}
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.decisions[key]
+	if len(items) == 0 {
+		return []LLMDecision{}
+	}
+	if limit > len(items) {
+		limit = len(items)
+	}
+
+	start := len(items) - limit
+	out := make([]LLMDecision, 0, limit)
+	for i := len(items) - 1; i >= start; i-- {
+		out = append(out, items[i])
+	}
+	return out
+}
+
+func isSupportedStage(stage string) bool {
+	switch stage {
+	case "stage_a", "stage_b", "stage_c", "stage_d":
+		return true
+	default:
+		return false
+	}
 }
 
 func IsSupportedStatus(status string) bool {

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -79,3 +79,49 @@ func TestServiceSubmitRateLimit(t *testing.T) {
 		t.Fatalf("expected limiter reset after window, got %v", err)
 	}
 }
+
+func TestRecordAndListLLMDecisions(t *testing.T) {
+	svc := NewService()
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	svc.nowFn = func() time.Time { return now }
+
+	_, err := svc.RecordLLMDecision(context.Background(), RecordDecisionRequest{RunID: "run-1", StreamerID: "str-1", Stage: "stage_a", Label: "yes", Confidence: 0.9})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	now = now.Add(time.Second)
+	second, err := svc.RecordLLMDecision(context.Background(), RecordDecisionRequest{RunID: "run-1", StreamerID: "str-1", Stage: "stage_b", Label: "competitive", Confidence: 0.8})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	items := svc.ListLLMDecisions(context.Background(), "str-1", 1)
+	if len(items) != 1 {
+		t.Fatalf("expected one result, got %d", len(items))
+	}
+	if items[0].ID != second.ID {
+		t.Fatalf("expected latest decision first, got %s", items[0].ID)
+	}
+}
+
+func TestRecordLLMDecisionValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		req  RecordDecisionRequest
+	}{
+		{name: "missing streamer", req: RecordDecisionRequest{RunID: "run-1", Stage: "stage_a", Label: "yes", Confidence: 0.9}},
+		{name: "missing run", req: RecordDecisionRequest{StreamerID: "str-1", Stage: "stage_a", Label: "yes", Confidence: 0.9}},
+		{name: "invalid stage", req: RecordDecisionRequest{RunID: "run-1", StreamerID: "str-1", Stage: "bad", Label: "yes", Confidence: 0.9}},
+		{name: "missing label", req: RecordDecisionRequest{RunID: "run-1", StreamerID: "str-1", Stage: "stage_a", Confidence: 0.9}},
+		{name: "invalid confidence", req: RecordDecisionRequest{RunID: "run-1", StreamerID: "str-1", Stage: "stage_a", Label: "yes", Confidence: 1.9}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewService()
+			if _, err := svc.RecordLLMDecision(context.Background(), tt.req); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a REST-based history API and admin ingest for normalized LLM stage decisions to advance M2.1 LLM stream orchestration and enable downstream worker/testing flows.
- Expose a simple in-memory model to record and query per-streamer LLM decisions while keeping the integration surface small and testable.

### Description
- Add domain types `LLMDecision` and `RecordDecisionRequest` and in-memory operations `RecordLLMDecision` / `ListLLMDecisions` to `internal/streamers` with validation for `streamerId`, `runId`, `stage`, `label`, and `confidence`.
- Wire authenticated HTTP endpoints `GET /api/streamers/{streamerId}/llm-decisions?limit=` (any authenticated user) and `POST /api/streamers/{streamerId}/llm-decisions` (admin-only) in `internal/app/router.go` and add `llmDecisionRecordRequest` DTO.
- Add unit and router tests covering recording, listing, access control, and validation (`internal/streamers/service_test.go`, `internal/app/router_streamers_llm_test.go`) and update `docs/openapi.yaml` and `docs/implementation_plan.md` to reflect the new REST history endpoint.
- Progress checklist (M2.1): [x] Provide REST history endpoint for latest LLM stage decisions; [ ] Publish live LLM status updates to clients via WebSocket channel; [ ] Implement stream capture worker pipeline; [ ] Remaining orchestration and observability tasks.

### Testing
- Added unit tests for the streamers service and router and ran `go test ./...` which completed successfully with all packages passing.
- New tests include `TestRecordAndListLLMDecisions`, `TestRecordLLMDecisionValidation`, `TestStreamerLLMDecisionsCreateAndList`, and `TestStreamerLLMDecisionCreateForbiddenForNonAdmin` and they passed under the CI-local test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56464b838832ca43dfb2f018cf061)