### PR TITLE
Fix vet failure in auth router tests

### DIFF
--- a/internal/app/router_auth_refresh_test.go
+++ b/internal/app/router_auth_refresh_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -20,7 +21,7 @@ func TestAuthRefreshEndpointRotatesTokens(t *testing.T) {
 
 	now := time.Now().UTC()
 	refreshToken := "session-1.secret-1"
-	if err := store.Create(t.Context(), auth.RefreshSession{
+	if err := store.Create(context.Background(), auth.RefreshSession{
 		SessionID:   "session-1",
 		UserID:      "user-1",
 		TelegramID:  42,
@@ -59,7 +60,7 @@ func TestAuthLogoutAllEndpoint(t *testing.T) {
 	store := auth.NewInMemoryRefreshSessionStore(5)
 	authService.WithRefreshSessionStore(store)
 	now := time.Now().UTC()
-	if err := store.Create(t.Context(), auth.RefreshSession{
+	if err := store.Create(context.Background(), auth.RefreshSession{
 		SessionID:   "session-2",
 		UserID:      "user-1",
 		TelegramID:  42,
@@ -81,7 +82,7 @@ func TestAuthLogoutAllEndpoint(t *testing.T) {
 		t.Fatalf("expected 200, got %d (%s)", res.Code, res.Body.String())
 	}
 
-	session, err := store.Get(t.Context(), "session-2")
+	session, err := store.Get(context.Background(), "session-2")
 	if err != nil {
 		t.Fatalf("store.Get() error = %v", err)
 	}


### PR DESCRIPTION
### Motivation
- `go vet` and CI were failing because tests used `t.Context()`, which is not available in older Go versions used by the pipeline.

### Description
- Replace calls to `t.Context()` with `context.Background()` in `internal/app/router_auth_refresh_test.go` and add the `context` import so tests compile on older Go versions.

### Testing
- Ran `go test ./internal/app` and `go vet ./internal/app`, and both completed successfully.

Checklist:
- [x] Root cause identified (use of `t.Context()` incompatible with older Go).
- [x] Tests updated in `internal/app/router_auth_refresh_test.go`.
- [x] `go test` for `internal/app` passed.
- [x] `go vet` for `internal/app` passed.
- [x] Changes committed.
- [x] PR draft created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5734835d0832cbfa00205527d2699)