### PR TITLE
Implement Stage A worker pipeline, normalization, in-memory stores, and docs backlog

### DIFF
--- a/docs/llm_stream_orchestration_plan.md
+++ b/docs/llm_stream_orchestration_plan.md
@@ -161,3 +161,102 @@ Primary usage:
 2. How often should Streamlink chunks be sampled (e.g., every 15s / 30s / 60s)?
 3. Should result determination rely only on LLM, or also optional external match APIs later?
 4. What freshness SLA do we target on streamer page (e.g., update every <=10 seconds)?
+
+## Execution backlog (next two iterations)
+
+This backlog continues implementation according to `docs/implementation_plan.md` (M2.1)
+and is ordered to ship a vertical slice before hardening.
+
+### Iteration A — End-to-end pipeline baseline
+
+Goal: produce and persist Stage A decisions for active streamers from real worker
+cycles.
+
+#### A1. Worker pipeline skeleton
+- [ ] Introduce `internal/media/stream_capture_worker.go` (or equivalent module package)
+  with cycle orchestration:
+  - acquire streamer lock,
+  - fetch fragment via streamlink adapter,
+  - enqueue Gemini stage call,
+  - persist normalized stage decision.
+- [ ] Add streamlink adapter interface to isolate process execution and allow tests.
+- [ ] Add DB model/repository for `stream_analysis_runs` and link to stage decisions.
+
+Definition of done:
+- one worker pass creates `run` + `Stage A` record for a test streamer;
+- duplicate cycle for the same lock window is rejected.
+
+#### A2. Stage A normalization and storage
+- [ ] Implement Stage A parser mapping model output to:
+  `cs_detected | not_cs | uncertain`.
+- [ ] Add confidence threshold and cooldown handling for `not_cs` branch.
+- [ ] Persist `raw_response`, `normalized_label`, `confidence`, `latency_ms`,
+  `tokens_in`, `tokens_out`.
+
+Definition of done:
+- parser is covered by table-driven tests for valid/invalid responses;
+- confidence fallback path stores `uncertain` and does not crash the cycle.
+
+#### A3. Baseline telemetry for pipeline
+- [ ] Add metrics for stage latency and stage success/fail counters.
+- [ ] Add structured logs with `run_id`, `streamer_id`, `stage`, and `attempt`.
+
+Definition of done:
+- metrics are visible in local `/metrics` output and include stage labels;
+- failure logs are correlated by `run_id`.
+
+### Iteration B — Full staged flow + reliability
+
+Goal: complete M2.1 exit criteria with staged flow, WS updates, and resilient
+orchestration.
+
+#### B1. Stage B/C/D workflow
+- [ ] Implement stage gate transitions:
+  - Stage B runs only after `Stage A = cs_detected`.
+  - Stage C runs only after match type is known/accepted.
+  - Stage D runs only after `Stage C = finished`.
+- [ ] Implement normalization enums:
+  - B: `competitive | faceit | premier | casual | unknown`
+  - C: `pregame | in_progress | finished | unknown`
+  - D: `win | loss | draw | unknown`
+
+Definition of done:
+- deterministic stage transition unit tests pass;
+- each stage emits decision records with prompt version linkage.
+
+#### B2. Retry, idempotency, dead-letter
+- [ ] Add per-stage retry policy with exponential backoff.
+- [ ] Add idempotency keys (`streamer_id + stage + window`) with Redis TTL.
+- [ ] Add DLQ payload format and reprocessing admin command.
+
+Definition of done:
+- transient failures are retried and eventually either succeed or move to DLQ;
+- duplicate job delivery does not create duplicate terminal decisions.
+
+#### B3. Realtime and session integration
+- [ ] Publish `LLM_STAGE_UPDATED` from worker path to WS hub.
+- [ ] Add reconnect backfill flow (`GET status` + `GET llm-decisions`).
+- [ ] Integrate Redis refresh session store in auth login/refresh/logout endpoints:
+  - token pair issuance,
+  - rotate on refresh,
+  - revoke-by-device,
+  - revoke-all sessions.
+
+Definition of done:
+- websocket clients receive near-real-time stage updates;
+- refresh token replay is rejected after rotation;
+- revoke-all immediately invalidates prior refresh sessions.
+
+## Delivery checklist mapped to `docs/implementation_plan.md`
+
+### M2.1 completion checklist
+- [ ] Implement stream capture worker pipeline.
+- [ ] Build staged CS game flow (A/B/C/D).
+- [ ] Add retries, idempotency, and dead-letter handling.
+- [ ] Publish live LLM status updates via WebSocket.
+- [ ] Integrate refresh session store into auth flows.
+- [ ] Add observability (latency, success ratio, token usage, drift alerts).
+
+### Next milestone preview (M3)
+- [ ] Start `/internal/worker/events` ingestion only after M2.1 checklist is
+  completed.

--- a/internal/media/stage_a.go
+++ b/internal/media/stage_a.go
@@ -1,0 +1,24 @@
+package media
+
+import "strings"
+
+const (
+	StageALabelCSDetected StageALabel = "cs_detected"
+	StageALabelNotCS      StageALabel = "not_cs"
+	StageALabelUncertain  StageALabel = "uncertain"
+)
+
+type StageALabel string
+
+// NormalizeStageALabel maps classifier output into a strict stage A enum.
+func NormalizeStageALabel(raw string) StageALabel {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case string(StageALabelCSDetected), "cs", "counter-strike", "counter strike", "yes", "true":
+		return StageALabelCSDetected
+	case string(StageALabelNotCS), "not-cs", "no", "false":
+		return StageALabelNotCS
+	default:
+		return StageALabelUncertain
+	}
+}

--- a/internal/media/stage_a_test.go
+++ b/internal/media/stage_a_test.go
@@ -1,0 +1,28 @@
+package media
+
+import "testing"
+
+func TestNormalizeStageALabel(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want StageALabel
+	}{
+		{name: "exact cs", raw: "cs_detected", want: StageALabelCSDetected},
+		{name: "alias cs", raw: "Counter-Strike", want: StageALabelCSDetected},
+		{name: "boolean yes", raw: "true", want: StageALabelCSDetected},
+		{name: "exact not cs", raw: "not_cs", want: StageALabelNotCS},
+		{name: "boolean no", raw: "false", want: StageALabelNotCS},
+		{name: "unknown", raw: "maybe", want: StageALabelUncertain},
+		{name: "empty", raw: "   ", want: StageALabelUncertain},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeStageALabel(tt.raw)
+			if got != tt.want {
+				t.Fatalf("NormalizeStageALabel(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/media/store_memory.go
+++ b/internal/media/store_memory.go
@@ -1,0 +1,50 @@
+package media
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type InMemoryRunStore struct {
+	counter atomic.Int64
+}
+
+func (s *InMemoryRunStore) CreateRun(_ context.Context, streamerID string) (string, error) {
+	id := s.counter.Add(1)
+	return fmt.Sprintf("run_%s_%d", streamerID, id), nil
+}
+
+type InMemoryLocker struct {
+	mu    sync.Mutex
+	locks map[string]time.Time
+	nowFn func() time.Time
+}
+
+func NewInMemoryLocker() *InMemoryLocker {
+	return &InMemoryLocker{
+		locks: make(map[string]time.Time),
+		nowFn: func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func (l *InMemoryLocker) TryLock(key string, ttl time.Duration) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.nowFn()
+	expiresAt, ok := l.locks[key]
+	if ok && now.Before(expiresAt) {
+		return false
+	}
+	l.locks[key] = now.Add(ttl)
+	return true
+}
+
+func (l *InMemoryLocker) Unlock(key string) {
+	l.mu.Lock()
+	delete(l.locks, key)
+	l.mu.Unlock()
+}

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -1,0 +1,124 @@
+package media
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/funpot/funpot-go-core/internal/streamers"
+)
+
+var (
+	ErrStreamerIDRequired = errors.New("streamerID is required")
+	ErrStreamerBusy       = errors.New("streamer is already being processed")
+)
+
+type ChunkRef struct {
+	Reference string
+}
+
+type StageAClassification struct {
+	Label       string
+	Confidence  float64
+	RawResponse string
+	TokensIn    int
+	TokensOut   int
+	Latency     time.Duration
+}
+
+type StreamCapture interface {
+	Capture(ctx context.Context, streamerID string) (ChunkRef, error)
+}
+
+type StageAClassifier interface {
+	Classify(ctx context.Context, input ChunkRef) (StageAClassification, error)
+}
+
+type RunStore interface {
+	CreateRun(ctx context.Context, streamerID string) (string, error)
+}
+
+type DecisionStore interface {
+	RecordLLMDecision(ctx context.Context, req streamers.RecordDecisionRequest) (streamers.LLMDecision, error)
+}
+
+type Locker interface {
+	TryLock(key string, ttl time.Duration) bool
+	Unlock(key string)
+}
+
+type Worker struct {
+	capture       StreamCapture
+	classifier    StageAClassifier
+	runs          RunStore
+	decisions     DecisionStore
+	locker        Locker
+	lockTTL       time.Duration
+	minConfidence float64
+}
+
+type WorkerConfig struct {
+	LockTTL       time.Duration
+	MinConfidence float64
+}
+
+func NewWorker(capture StreamCapture, classifier StageAClassifier, runs RunStore, decisions DecisionStore, locker Locker, cfg WorkerConfig) *Worker {
+	if cfg.LockTTL <= 0 {
+		cfg.LockTTL = 30 * time.Second
+	}
+	if cfg.MinConfidence < 0 || cfg.MinConfidence > 1 {
+		cfg.MinConfidence = 0.5
+	}
+	return &Worker{
+		capture:       capture,
+		classifier:    classifier,
+		runs:          runs,
+		decisions:     decisions,
+		locker:        locker,
+		lockTTL:       cfg.LockTTL,
+		minConfidence: cfg.MinConfidence,
+	}
+}
+
+func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (streamers.LLMDecision, error) {
+	id := strings.TrimSpace(streamerID)
+	if id == "" {
+		return streamers.LLMDecision{}, ErrStreamerIDRequired
+	}
+
+	lockKey := fmt.Sprintf("stream-capture:%s", id)
+	if !w.locker.TryLock(lockKey, w.lockTTL) {
+		return streamers.LLMDecision{}, ErrStreamerBusy
+	}
+	defer w.locker.Unlock(lockKey)
+
+	runID, err := w.runs.CreateRun(ctx, id)
+	if err != nil {
+		return streamers.LLMDecision{}, err
+	}
+
+	chunk, err := w.capture.Capture(ctx, id)
+	if err != nil {
+		return streamers.LLMDecision{}, err
+	}
+
+	result, err := w.classifier.Classify(ctx, chunk)
+	if err != nil {
+		return streamers.LLMDecision{}, err
+	}
+
+	label := NormalizeStageALabel(result.Label)
+	if result.Confidence < w.minConfidence {
+		label = StageALabelUncertain
+	}
+
+	return w.decisions.RecordLLMDecision(ctx, streamers.RecordDecisionRequest{
+		RunID:      runID,
+		StreamerID: id,
+		Stage:      "stage_a",
+		Label:      string(label),
+		Confidence: result.Confidence,
+	})
+}

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -1,0 +1,111 @@
+package media
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/funpot/funpot-go-core/internal/streamers"
+)
+
+type fakeCapture struct {
+	chunk ChunkRef
+	err   error
+}
+
+func (f fakeCapture) Capture(_ context.Context, _ string) (ChunkRef, error) {
+	if f.err != nil {
+		return ChunkRef{}, f.err
+	}
+	return f.chunk, nil
+}
+
+type fakeClassifier struct {
+	result StageAClassification
+	err    error
+}
+
+func (f fakeClassifier) Classify(_ context.Context, _ ChunkRef) (StageAClassification, error) {
+	if f.err != nil {
+		return StageAClassification{}, f.err
+	}
+	return f.result, nil
+}
+
+type fakeDecisionStore struct {
+	last streamers.RecordDecisionRequest
+}
+
+func (s *fakeDecisionStore) RecordLLMDecision(_ context.Context, req streamers.RecordDecisionRequest) (streamers.LLMDecision, error) {
+	s.last = req
+	return streamers.LLMDecision{RunID: req.RunID, StreamerID: req.StreamerID, Stage: req.Stage, Label: req.Label, Confidence: req.Confidence}, nil
+}
+
+func TestWorkerProcessStreamerStageASuccess(t *testing.T) {
+	locker := NewInMemoryLocker()
+	runs := &InMemoryRunStore{}
+	decisions := &fakeDecisionStore{}
+
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		fakeClassifier{result: StageAClassification{Label: "cs_detected", Confidence: 0.91}},
+		runs,
+		decisions,
+		locker,
+		WorkerConfig{MinConfidence: 0.5},
+	)
+
+	got, err := worker.ProcessStreamer(context.Background(), "str-1")
+	if err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got.Label != string(StageALabelCSDetected) {
+		t.Fatalf("label = %q, want %q", got.Label, StageALabelCSDetected)
+	}
+	if got.Stage != "stage_a" {
+		t.Fatalf("stage = %q, want stage_a", got.Stage)
+	}
+	if decisions.last.StreamerID != "str-1" {
+		t.Fatalf("recorded streamer = %q", decisions.last.StreamerID)
+	}
+}
+
+func TestWorkerProcessStreamerLowConfidenceFallsBackToUncertain(t *testing.T) {
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		fakeClassifier{result: StageAClassification{Label: "cs_detected", Confidence: 0.21}},
+		&InMemoryRunStore{},
+		&fakeDecisionStore{},
+		NewInMemoryLocker(),
+		WorkerConfig{MinConfidence: 0.5},
+	)
+
+	got, err := worker.ProcessStreamer(context.Background(), "str-1")
+	if err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got.Label != string(StageALabelUncertain) {
+		t.Fatalf("label = %q, want %q", got.Label, StageALabelUncertain)
+	}
+}
+
+func TestWorkerProcessStreamerBusy(t *testing.T) {
+	locker := NewInMemoryLocker()
+	if ok := locker.TryLock("stream-capture:str-1", 1000000000); !ok {
+		t.Fatalf("expected initial lock acquisition to succeed")
+	}
+
+	worker := NewWorker(
+		fakeCapture{},
+		fakeClassifier{result: StageAClassification{Label: "cs_detected", Confidence: 0.9}},
+		&InMemoryRunStore{},
+		&fakeDecisionStore{},
+		locker,
+		WorkerConfig{},
+	)
+
+	_, err := worker.ProcessStreamer(context.Background(), "str-1")
+	if !errors.Is(err, ErrStreamerBusy) {
+		t.Fatalf("error = %v, want %v", err, ErrStreamerBusy)
+	}
+}


### PR DESCRIPTION
### Motivation
- Ship an end-to-end Stage A vertical slice to produce and persist LLM decisions for active streamers as part of the M2.1 implementation plan. 
- Add a lightweight in-memory runtime for local development and unit testing of capture, classification, locking, and decision persistence. 

### Description
- Add `internal/media` worker that orchestrates a capture -> classify -> record flow with interfaces `StreamCapture`, `StageAClassifier`, `RunStore`, `DecisionStore`, and `Locker`, and applies a confidence threshold before normalizing labels. 
- Implement Stage A label normalization in `stage_a.go` with enums `cs_detected | not_cs | uncertain` and mapping helpers in `NormalizeStageALabel`. 
- Provide simple in-memory implementations for run creation and locking in `store_memory.go` and wire them into `worker.go` behavior that creates runs, acquires locks, captures chunks, calls classifier, and records decisions. 
- Add unit tests for normalization (`stage_a_test.go`) and worker behavior (`worker_test.go`) covering success, low-confidence fallback, and lock contention scenarios. 
- Extend `docs/llm_stream_orchestration_plan.md` with an execution backlog and iteration roadmap describing the iteration A/B tasks and M2.1 checklist. 

### Testing
- Ran unit tests in the media package with `go test ./internal/media -v`, and all tests passed. 
- `TestNormalizeStageALabel` verifies expected label mappings and edge cases and succeeded. 
- `TestWorkerProcessStreamerStageASuccess`, `TestWorkerProcessStreamerLowConfidenceFallsBackToUncertain`, and `TestWorkerProcessStreamerBusy` validate worker orchestration, confidence fallback, and locking behavior and all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5732ebafc832cb2a5a921079d2078)