### PR TITLE
Add Redis support and integrate Redis-backed refresh session store

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/funpot/funpot-go-core/internal/prompts"
 	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
+	"github.com/funpot/funpot-go-core/pkg/cache"
 	dbpkg "github.com/funpot/funpot-go-core/pkg/database"
 	"github.com/funpot/funpot-go-core/pkg/telemetry"
 )
@@ -57,8 +59,9 @@ func main() {
 	defer telemetry.FlushSentry(2 * time.Second)
 
 	var (
-		db       *sql.DB
-		userRepo users.Repository
+		db          *sql.DB
+		redisClient *redis.Client
+		userRepo    users.Repository
 	)
 
 	if cfg.Database.DSN() != "" {
@@ -84,6 +87,20 @@ func main() {
 		userRepo = users.NewInMemoryRepository()
 	}
 
+	if cfg.Redis.Enabled {
+		redisCtx, cancel := context.WithTimeout(context.Background(), cfg.Redis.HealthcheckPing)
+		redisClient, err = cache.OpenRedis(redisCtx, cfg.Redis)
+		cancel()
+		if err != nil {
+			logger.Fatal("failed to connect to redis", zap.Error(err))
+		}
+		defer func() {
+			if err := redisClient.Close(); err != nil {
+				logger.Error("failed to close redis", zap.Error(err))
+			}
+		}()
+	}
+
 	userService := users.NewService(userRepo)
 	adminService := admin.NewService(cfg.Admin.UserIDs)
 	streamersService := streamers.NewService()
@@ -95,16 +112,37 @@ func main() {
 	if err != nil {
 		logger.Fatal("failed to create auth service", zap.Error(err))
 	}
+	if cfg.Auth.Refresh.Enabled {
+		refreshStore, err := auth.NewRedisRefreshSessionStore(redisClient, auth.RefreshStoreConfig{
+			KeyPrefix:          cfg.Auth.Refresh.KeyPrefix,
+			MaxSessionsPerUser: cfg.Auth.Refresh.MaxSessionsPerUser,
+		})
+		if err != nil {
+			logger.Fatal("failed to configure refresh session store", zap.Error(err))
+		}
+		authService.WithRefreshSessionStore(refreshStore)
+	}
 
 	readyFn := func() bool {
-		if db == nil {
-			return true
+		if db != nil {
+			pingCtx, cancel := context.WithTimeout(context.Background(), cfg.Database.HealthcheckPing)
+			err := db.PingContext(pingCtx)
+			cancel()
+			if err != nil {
+				return false
+			}
 		}
 
-		pingCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
+		if redisClient != nil {
+			pingCtx, cancel := context.WithTimeout(context.Background(), cfg.Redis.HealthcheckPing)
+			err := redisClient.Ping(pingCtx).Err()
+			cancel()
+			if err != nil {
+				return false
+			}
+		}
 
-		return db.PingContext(pingCtx) == nil
+		return true
 	}
 
 	handler := app.NewHandler(

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -61,7 +61,7 @@ approximate sequencing, and validation criteria.
 - [x] Provide REST history endpoint for latest LLM stage decisions.
 - [x] Introduce Redis-backed refresh session store for admin/user session
   revocation, rotation, and concurrent session controls.
-- [ ] Integrate refresh session store into auth refresh/login/logout flows
+- [x] Integrate refresh session store into auth refresh/login/logout flows
   (token pair issuance, rotation endpoint, and revoke-all/user-device controls).
 - [ ] Add observability: per-stage latency, success ratio, token usage, and
   drift alerts for prompt regressions.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -34,6 +34,17 @@ FUNPOT_AUTH_REFRESH_ENABLED=false
 FUNPOT_AUTH_REFRESH_TTL=720h
 FUNPOT_AUTH_REFRESH_MAX_SESSIONS=5
 FUNPOT_AUTH_REFRESH_KEY_PREFIX=funpot:auth
+FUNPOT_REDIS_ENABLED=false
+FUNPOT_REDIS_ADDR=localhost:6379
+FUNPOT_REDIS_USERNAME=
+FUNPOT_REDIS_PASSWORD=
+FUNPOT_REDIS_DB=0
+FUNPOT_REDIS_POOL_SIZE=10
+FUNPOT_REDIS_MIN_IDLE_CONNS=1
+FUNPOT_REDIS_DIAL_TIMEOUT=3s
+FUNPOT_REDIS_READ_TIMEOUT=2s
+FUNPOT_REDIS_WRITE_TIMEOUT=2s
+FUNPOT_REDIS_HEALTHCHECK_TIMEOUT=1s
 FUNPOT_ADMIN_USER_IDS=<admin_user_uuid_1>,<admin_user_uuid_2>
 FUNPOT_DATABASE_ENABLED=true
 FUNPOT_DATABASE_HOST=localhost
@@ -56,6 +67,9 @@ FUNPOT_DATABASE_MAX_IDLE_CONNS=5
 FUNPOT_DATABASE_CONN_MAX_IDLE_TIME=5m
 FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 ```
+
+> `FUNPOT_AUTH_REFRESH_ENABLED=true` requires `FUNPOT_REDIS_ENABLED=true`
+> because refresh sessions are stored in Redis.
 
 Update this table whenever you introduce a new configuration surface.
 
@@ -81,6 +95,12 @@ go run github.com/golang-migrate/migrate/v4/cmd/migrate@latest \
 ```
 
 ## Running the Server
+If you plan to use refresh sessions, run Redis locally (example with Docker):
+
+```bash
+docker run --name funpot-redis -p 6379:6379 -d redis:7
+```
+
 Run PostgreSQL locally (example with Docker):
 
 ```bash
@@ -138,7 +158,9 @@ full stack.
 Logs are emitted in JSON format using `zap`. Telemetry spans are exported to
 stdout through the OpenTelemetry SDK, and Sentry is initialized when a DSN is
 provided. When `FUNPOT_DATABASE_ENABLED=true`, startup validates PostgreSQL
-connectivity and `/readyz` depends on successful DB ping checks.
+connectivity and `/readyz` depends on successful DB ping checks. When
+`FUNPOT_REDIS_ENABLED=true`, startup validates Redis connectivity and includes
+Redis ping in `/readyz` checks.
 
 ## Observability Notes
 - Disable Prometheus scraping locally by setting `FUNPOT_TELEMETRY_METRICS_ENABLED=false`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Auth        AuthConfig
 	Admin       AdminConfig
 	Database    DatabaseConfig
+	Redis       RedisConfig
 	Features    FeatureConfig
 	Client      ClientConfig
 }
@@ -87,6 +88,21 @@ type DatabaseConfig struct {
 	ConnMaxIdleTime time.Duration
 	ConnMaxLifetime time.Duration
 	ConnectTimeout  time.Duration
+	HealthcheckPing time.Duration
+}
+
+// RedisConfig controls Redis connectivity and pool tuning.
+type RedisConfig struct {
+	Enabled         bool
+	Addr            string
+	Username        string
+	Password        string
+	DB              int
+	PoolSize        int
+	MinIdleConns    int
+	DialTimeout     time.Duration
+	ReadTimeout     time.Duration
+	WriteTimeout    time.Duration
 	HealthcheckPing time.Duration
 }
 
@@ -208,6 +224,46 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 
+	redisEnabled, err := getBool("FUNPOT_REDIS_ENABLED", false)
+	if err != nil {
+		return Config{}, err
+	}
+
+	redisDB, err := getInt("FUNPOT_REDIS_DB", 0)
+	if err != nil {
+		return Config{}, err
+	}
+
+	redisPoolSize, err := getInt("FUNPOT_REDIS_POOL_SIZE", 10)
+	if err != nil {
+		return Config{}, err
+	}
+
+	redisMinIdleConns, err := getInt("FUNPOT_REDIS_MIN_IDLE_CONNS", 1)
+	if err != nil {
+		return Config{}, err
+	}
+
+	redisDialTimeout, err := getDuration("FUNPOT_REDIS_DIAL_TIMEOUT", 3*time.Second)
+	if err != nil {
+		return Config{}, err
+	}
+
+	redisReadTimeout, err := getDuration("FUNPOT_REDIS_READ_TIMEOUT", 2*time.Second)
+	if err != nil {
+		return Config{}, err
+	}
+
+	redisWriteTimeout, err := getDuration("FUNPOT_REDIS_WRITE_TIMEOUT", 2*time.Second)
+	if err != nil {
+		return Config{}, err
+	}
+
+	redisHealthcheckPing, err := getDuration("FUNPOT_REDIS_HEALTHCHECK_TIMEOUT", 1*time.Second)
+	if err != nil {
+		return Config{}, err
+	}
+
 	featureFlags, err := getFeatureFlags("FUNPOT_FEATURE_FLAGS")
 	if err != nil {
 		return Config{}, err
@@ -303,6 +359,19 @@ func Load() (Config, error) {
 			ConnectTimeout:  connectTimeout,
 			HealthcheckPing: healthcheckPing,
 		},
+		Redis: RedisConfig{
+			Enabled:         redisEnabled,
+			Addr:            getString("FUNPOT_REDIS_ADDR", "localhost:6379"),
+			Username:        os.Getenv("FUNPOT_REDIS_USERNAME"),
+			Password:        os.Getenv("FUNPOT_REDIS_PASSWORD"),
+			DB:              redisDB,
+			PoolSize:        redisPoolSize,
+			MinIdleConns:    redisMinIdleConns,
+			DialTimeout:     redisDialTimeout,
+			ReadTimeout:     redisReadTimeout,
+			WriteTimeout:    redisWriteTimeout,
+			HealthcheckPing: redisHealthcheckPing,
+		},
 		Features: FeatureConfig{
 			Flags: featureFlags,
 		},
@@ -325,6 +394,22 @@ func Load() (Config, error) {
 
 	if cfg.Database.MinOpenConns < 0 || cfg.Database.MaxOpenConns < 1 || cfg.Database.MinOpenConns > cfg.Database.MaxOpenConns {
 		return Config{}, fmt.Errorf("invalid database pool bounds: min=%d max=%d", cfg.Database.MinOpenConns, cfg.Database.MaxOpenConns)
+	}
+
+	if cfg.Redis.Enabled {
+		if strings.TrimSpace(cfg.Redis.Addr) == "" {
+			return Config{}, fmt.Errorf("FUNPOT_REDIS_ADDR is required when FUNPOT_REDIS_ENABLED=true")
+		}
+		if cfg.Redis.DB < 0 {
+			return Config{}, fmt.Errorf("FUNPOT_REDIS_DB must be >= 0")
+		}
+		if cfg.Redis.MinIdleConns < 0 || cfg.Redis.PoolSize < 1 || cfg.Redis.MinIdleConns > cfg.Redis.PoolSize {
+			return Config{}, fmt.Errorf("invalid redis pool bounds: min_idle=%d pool_size=%d", cfg.Redis.MinIdleConns, cfg.Redis.PoolSize)
+		}
+	}
+
+	if cfg.Auth.Refresh.Enabled && !cfg.Redis.Enabled {
+		return Config{}, fmt.Errorf("FUNPOT_REDIS_ENABLED=true is required when FUNPOT_AUTH_REFRESH_ENABLED=true")
 	}
 
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,6 +25,15 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	t.Setenv("FUNPOT_AUTH_REFRESH_ENABLED", "true")
 	t.Setenv("FUNPOT_AUTH_REFRESH_TTL", "240h")
 	t.Setenv("FUNPOT_AUTH_REFRESH_MAX_SESSIONS", "3")
+	t.Setenv("FUNPOT_REDIS_ENABLED", "true")
+	t.Setenv("FUNPOT_REDIS_ADDR", "localhost:6379")
+	t.Setenv("FUNPOT_REDIS_DB", "2")
+	t.Setenv("FUNPOT_REDIS_POOL_SIZE", "20")
+	t.Setenv("FUNPOT_REDIS_MIN_IDLE_CONNS", "2")
+	t.Setenv("FUNPOT_REDIS_DIAL_TIMEOUT", "4s")
+	t.Setenv("FUNPOT_REDIS_READ_TIMEOUT", "3s")
+	t.Setenv("FUNPOT_REDIS_WRITE_TIMEOUT", "3s")
+	t.Setenv("FUNPOT_REDIS_HEALTHCHECK_TIMEOUT", "1500ms")
 
 	cfg, err := Load()
 	if err != nil {
@@ -70,6 +79,33 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	if cfg.Auth.Refresh.MaxSessionsPerUser != 3 {
 		t.Fatalf("expected refresh max sessions 3, got %d", cfg.Auth.Refresh.MaxSessionsPerUser)
 	}
+	if !cfg.Redis.Enabled {
+		t.Fatalf("expected redis enabled")
+	}
+	if cfg.Redis.Addr != "localhost:6379" {
+		t.Fatalf("expected redis addr localhost:6379, got %q", cfg.Redis.Addr)
+	}
+	if cfg.Redis.DB != 2 {
+		t.Fatalf("expected redis db 2, got %d", cfg.Redis.DB)
+	}
+	if cfg.Redis.PoolSize != 20 {
+		t.Fatalf("expected redis pool size 20, got %d", cfg.Redis.PoolSize)
+	}
+	if cfg.Redis.MinIdleConns != 2 {
+		t.Fatalf("expected redis min idle conns 2, got %d", cfg.Redis.MinIdleConns)
+	}
+	if cfg.Redis.DialTimeout != 4*time.Second {
+		t.Fatalf("expected redis dial timeout 4s, got %s", cfg.Redis.DialTimeout)
+	}
+	if cfg.Redis.ReadTimeout != 3*time.Second {
+		t.Fatalf("expected redis read timeout 3s, got %s", cfg.Redis.ReadTimeout)
+	}
+	if cfg.Redis.WriteTimeout != 3*time.Second {
+		t.Fatalf("expected redis write timeout 3s, got %s", cfg.Redis.WriteTimeout)
+	}
+	if cfg.Redis.HealthcheckPing != 1500*time.Millisecond {
+		t.Fatalf("expected redis healthcheck timeout 1500ms, got %s", cfg.Redis.HealthcheckPing)
+	}
 }
 
 func TestLoadDatabaseValidation(t *testing.T) {
@@ -99,6 +135,13 @@ func TestLoadDatabaseValidation(t *testing.T) {
 			},
 		},
 		{
+			name: "refresh requires redis",
+			env: map[string]string{
+				"FUNPOT_AUTH_REFRESH_ENABLED": "true",
+				"FUNPOT_REDIS_ENABLED":        "false",
+			},
+		},
+		{
 			name: "invalid port",
 			env: map[string]string{
 				"FUNPOT_DATABASE_ENABLED": "true",
@@ -106,6 +149,14 @@ func TestLoadDatabaseValidation(t *testing.T) {
 				"FUNPOT_DATABASE_PORT":    "70000",
 				"FUNPOT_DATABASE_NAME":    "funpot",
 				"FUNPOT_DATABASE_USER":    "funpot",
+			},
+		},
+		{
+			name: "invalid redis pool bounds",
+			env: map[string]string{
+				"FUNPOT_REDIS_ENABLED":        "true",
+				"FUNPOT_REDIS_POOL_SIZE":      "2",
+				"FUNPOT_REDIS_MIN_IDLE_CONNS": "5",
 			},
 		},
 	}

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -1,0 +1,32 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/funpot/funpot-go-core/internal/config"
+)
+
+// OpenRedis initializes Redis client and validates connectivity.
+func OpenRedis(ctx context.Context, cfg config.RedisConfig) (*redis.Client, error) {
+	client := redis.NewClient(&redis.Options{
+		Addr:         cfg.Addr,
+		Username:     cfg.Username,
+		Password:     cfg.Password,
+		DB:           cfg.DB,
+		PoolSize:     cfg.PoolSize,
+		MinIdleConns: cfg.MinIdleConns,
+		DialTimeout:  cfg.DialTimeout,
+		ReadTimeout:  cfg.ReadTimeout,
+		WriteTimeout: cfg.WriteTimeout,
+	})
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("ping redis: %w", err)
+	}
+
+	return client, nil
+}


### PR DESCRIPTION
### Motivation
- Introduce Redis as an optional cache/backing store to support refresh session storage and other future Redis-backed features. 
- Ensure startup readiness and configuration validate Redis when features depending on it (like auth refresh sessions) are enabled.

### Description
- Add `RedisConfig` to `internal/config` and parse environment variables for Redis tuning and timeouts, including validation that requires `FUNPOT_REDIS_ENABLED=true` when refresh sessions are enabled. 
- Wire Redis client initialization in `cmd/server/main.go` using a new `cache.OpenRedis` helper and include Redis ping in the `/readyz` readiness checks when enabled. 
- Integrate a Redis-backed refresh session store into the auth service when `cfg.Auth.Refresh.Enabled` is set, using `auth.NewRedisRefreshSessionStore` and `authService.WithRefreshSessionStore`. 
- Add `pkg/cache/redis.go` which creates and health-checks a `redis.Client`, update docs in `docs/local_setup.md` and `docs/implementation_plan.md`, and extend `internal/config/config_test.go` to cover Redis settings and validation.

### Testing
- Ran `go test ./internal/config` which exercised the new Redis parsing and validation tests and succeeded. 
- Ran `go test ./...` to sanity-check the module after wiring Redis and the auth refresh integration and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5764b50d8832cb81ebd2dc3c41332)