### PR TITLE
Add Redis-backed refresh session store, config, docs and tests

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -96,6 +97,12 @@ func main() {
 		logger.Fatal("failed to create auth service", zap.Error(err))
 	}
 
+	cleanupRefreshStore, err := setupRefreshSessionStore(ctx, logger, cfg, authService)
+	if err != nil {
+		logger.Fatal("failed to configure refresh sessions", zap.Error(err))
+	}
+	defer cleanupRefreshStore()
+
 	readyFn := func() bool {
 		if db == nil {
 			return true
@@ -141,4 +148,50 @@ func newLogger(level string) (*zap.Logger, error) {
 	cfg.EncoderConfig.TimeKey = "timestamp"
 	cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	return cfg.Build()
+}
+
+func setupRefreshSessionStore(ctx context.Context, logger *zap.Logger, cfg config.Config, authService *auth.Service) (func(), error) {
+	if !cfg.Auth.Refresh.Enabled {
+		return func() {}, nil
+	}
+
+	if !cfg.Redis.Enabled {
+		logger.Warn("redis is disabled; using in-memory refresh session store")
+		authService.WithRefreshSessionStore(auth.NewInMemoryRefreshSessionStore(cfg.Auth.Refresh.MaxSessionsPerUser))
+		return func() {}, nil
+	}
+
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:         cfg.Redis.Addr,
+		Password:     cfg.Redis.Password,
+		DB:           cfg.Redis.DB,
+		DialTimeout:  cfg.Redis.ConnectTimeout,
+		ReadTimeout:  cfg.Redis.ConnectTimeout,
+		WriteTimeout: cfg.Redis.ConnectTimeout,
+	})
+
+	pingCtx, cancel := context.WithTimeout(ctx, cfg.Redis.ConnectTimeout)
+	defer cancel()
+	if err := redisClient.Ping(pingCtx).Err(); err != nil {
+		_ = redisClient.Close()
+		return nil, fmt.Errorf("ping redis: %w", err)
+	}
+
+	refreshStore, err := auth.NewRedisRefreshSessionStore(redisClient, auth.RefreshStoreConfig{
+		KeyPrefix:          cfg.Auth.Refresh.KeyPrefix,
+		MaxSessionsPerUser: cfg.Auth.Refresh.MaxSessionsPerUser,
+	})
+	if err != nil {
+		_ = redisClient.Close()
+		return nil, err
+	}
+
+	authService.WithRefreshSessionStore(refreshStore)
+	logger.Info("redis refresh session store enabled", zap.String("addr", cfg.Redis.Addr))
+
+	return func() {
+		if err := redisClient.Close(); err != nil {
+			logger.Warn("failed to close redis client", zap.Error(err))
+		}
+	}, nil
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"go.uber.org/zap"
+
+	"github.com/funpot/funpot-go-core/internal/auth"
+	"github.com/funpot/funpot-go-core/internal/config"
+	"github.com/funpot/funpot-go-core/internal/users"
+)
+
+func TestSetupRefreshSessionStoreUsesRedisWhenEnabled(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run() error = %v", err)
+	}
+	defer mr.Close()
+
+	authService := buildAuthServiceForSetupStore(t)
+	cfg := config.Config{
+		Auth: config.AuthConfig{
+			Refresh: config.RefreshConfig{
+				Enabled:            true,
+				KeyPrefix:          "funpot:test",
+				MaxSessionsPerUser: 2,
+			},
+		},
+		Redis: config.RedisConfig{
+			Enabled:        true,
+			Addr:           mr.Addr(),
+			ConnectTimeout: time.Second,
+		},
+	}
+
+	cleanup, err := setupRefreshSessionStore(context.Background(), zap.NewNop(), cfg, authService)
+	if err != nil {
+		t.Fatalf("setupRefreshSessionStore() error = %v", err)
+	}
+	defer cleanup()
+
+	if err := authService.LogoutAll(context.Background(), "user-1", time.Now().UTC()); err != nil {
+		t.Fatalf("LogoutAll() error = %v", err)
+	}
+}
+
+func TestSetupRefreshSessionStoreUsesMemoryFallbackWhenRedisDisabled(t *testing.T) {
+	authService := buildAuthServiceForSetupStore(t)
+	cfg := config.Config{
+		Auth: config.AuthConfig{
+			Refresh: config.RefreshConfig{
+				Enabled:            true,
+				MaxSessionsPerUser: 2,
+			},
+		},
+		Redis: config.RedisConfig{Enabled: false},
+	}
+
+	cleanup, err := setupRefreshSessionStore(context.Background(), zap.NewNop(), cfg, authService)
+	if err != nil {
+		t.Fatalf("setupRefreshSessionStore() error = %v", err)
+	}
+	defer cleanup()
+
+	if err := authService.LogoutAll(context.Background(), "user-1", time.Now().UTC()); err != nil {
+		t.Fatalf("LogoutAll() error = %v", err)
+	}
+}
+
+func TestSetupRefreshSessionStoreNoopWhenRefreshDisabled(t *testing.T) {
+	authService := buildAuthServiceForSetupStore(t)
+	cfg := config.Config{
+		Auth: config.AuthConfig{Refresh: config.RefreshConfig{Enabled: false}},
+	}
+
+	cleanup, err := setupRefreshSessionStore(context.Background(), zap.NewNop(), cfg, authService)
+	if err != nil {
+		t.Fatalf("setupRefreshSessionStore() error = %v", err)
+	}
+	defer cleanup()
+
+	err = authService.LogoutAll(context.Background(), "user-1", time.Now().UTC())
+	if err == nil {
+		t.Fatal("expected error when refresh sessions are disabled")
+	}
+	if err.Error() != "refresh session store is not configured" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func buildAuthServiceForSetupStore(t *testing.T) *auth.Service {
+	t.Helper()
+	repo := users.NewInMemoryRepository()
+	userService := users.NewService(repo)
+	svc, err := auth.NewService(zap.NewNop(), config.AuthConfig{
+		BotToken: "test-bot-token",
+		JWT: config.JWTConfig{
+			Secret: "test-secret",
+			TTL:    15 * time.Minute,
+		},
+		Refresh: config.RefreshConfig{
+			TTL: 24 * time.Hour,
+		},
+	}, userService)
+	if err != nil {
+		t.Fatalf("auth.NewService() error = %v", err)
+	}
+	return svc
+}

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -34,6 +34,11 @@ FUNPOT_AUTH_REFRESH_ENABLED=false
 FUNPOT_AUTH_REFRESH_TTL=720h
 FUNPOT_AUTH_REFRESH_MAX_SESSIONS=5
 FUNPOT_AUTH_REFRESH_KEY_PREFIX=funpot:auth
+FUNPOT_REDIS_ENABLED=false
+FUNPOT_REDIS_ADDR=127.0.0.1:6379
+FUNPOT_REDIS_PASSWORD=
+FUNPOT_REDIS_DB=0
+FUNPOT_REDIS_CONNECT_TIMEOUT=2s
 FUNPOT_ADMIN_USER_IDS=<admin_user_uuid_1>,<admin_user_uuid_2>
 FUNPOT_DATABASE_ENABLED=true
 FUNPOT_DATABASE_HOST=localhost
@@ -139,6 +144,11 @@ Logs are emitted in JSON format using `zap`. Telemetry spans are exported to
 stdout through the OpenTelemetry SDK, and Sentry is initialized when a DSN is
 provided. When `FUNPOT_DATABASE_ENABLED=true`, startup validates PostgreSQL
 connectivity and `/readyz` depends on successful DB ping checks.
+
+When `FUNPOT_AUTH_REFRESH_ENABLED=true`, the service configures refresh-session
+storage automatically. Set `FUNPOT_REDIS_ENABLED=true` to use Redis-backed
+session revocation/rotation, or keep it `false` to use in-memory sessions for
+local smoke tests.
 
 ## Observability Notes
 - Disable Prometheus scraping locally by setting `FUNPOT_TELEMETRY_METRICS_ENABLED=false`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Sentry      SentryConfig
 	Auth        AuthConfig
 	Admin       AdminConfig
+	Redis       RedisConfig
 	Database    DatabaseConfig
 	Features    FeatureConfig
 	Client      ClientConfig
@@ -70,6 +71,15 @@ type RefreshConfig struct {
 	TTL                time.Duration
 	MaxSessionsPerUser int
 	KeyPrefix          string
+}
+
+// RedisConfig controls Redis connectivity for session and realtime features.
+type RedisConfig struct {
+	Enabled        bool
+	Addr           string
+	Password       string
+	DB             int
+	ConnectTimeout time.Duration
 }
 
 // DatabaseConfig controls PostgreSQL connectivity.
@@ -183,6 +193,21 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 
+	redisEnabled, err := getBool("FUNPOT_REDIS_ENABLED", false)
+	if err != nil {
+		return Config{}, err
+	}
+
+	redisDB, err := getInt("FUNPOT_REDIS_DB", 0)
+	if err != nil {
+		return Config{}, err
+	}
+
+	redisConnectTimeout, err := getDuration("FUNPOT_REDIS_CONNECT_TIMEOUT", 2*time.Second)
+	if err != nil {
+		return Config{}, err
+	}
+
 	databaseEnabled, err := getBool("FUNPOT_DATABASE_ENABLED", false)
 	if err != nil {
 		return Config{}, err
@@ -287,6 +312,13 @@ func Load() (Config, error) {
 		Admin: AdminConfig{
 			UserIDs: getCSVStrings("FUNPOT_ADMIN_USER_IDS", nil),
 		},
+		Redis: RedisConfig{
+			Enabled:        redisEnabled,
+			Addr:           getString("FUNPOT_REDIS_ADDR", "127.0.0.1:6379"),
+			Password:       getString("FUNPOT_REDIS_PASSWORD", ""),
+			DB:             redisDB,
+			ConnectTimeout: redisConnectTimeout,
+		},
 		Database: DatabaseConfig{
 			Enabled:         databaseEnabled,
 			Host:            os.Getenv("FUNPOT_DATABASE_HOST"),
@@ -325,6 +357,14 @@ func Load() (Config, error) {
 
 	if cfg.Database.MinOpenConns < 0 || cfg.Database.MaxOpenConns < 1 || cfg.Database.MinOpenConns > cfg.Database.MaxOpenConns {
 		return Config{}, fmt.Errorf("invalid database pool bounds: min=%d max=%d", cfg.Database.MinOpenConns, cfg.Database.MaxOpenConns)
+	}
+
+	if cfg.Redis.Enabled && strings.TrimSpace(cfg.Redis.Addr) == "" {
+		return Config{}, fmt.Errorf("FUNPOT_REDIS_ADDR must be set when FUNPOT_REDIS_ENABLED=true")
+	}
+
+	if cfg.Redis.DB < 0 {
+		return Config{}, fmt.Errorf("FUNPOT_REDIS_DB must be >= 0")
 	}
 
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,6 +25,10 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	t.Setenv("FUNPOT_AUTH_REFRESH_ENABLED", "true")
 	t.Setenv("FUNPOT_AUTH_REFRESH_TTL", "240h")
 	t.Setenv("FUNPOT_AUTH_REFRESH_MAX_SESSIONS", "3")
+	t.Setenv("FUNPOT_REDIS_ENABLED", "true")
+	t.Setenv("FUNPOT_REDIS_ADDR", "localhost:6379")
+	t.Setenv("FUNPOT_REDIS_DB", "1")
+	t.Setenv("FUNPOT_REDIS_CONNECT_TIMEOUT", "3s")
 
 	cfg, err := Load()
 	if err != nil {
@@ -70,6 +74,18 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	if cfg.Auth.Refresh.MaxSessionsPerUser != 3 {
 		t.Fatalf("expected refresh max sessions 3, got %d", cfg.Auth.Refresh.MaxSessionsPerUser)
 	}
+	if !cfg.Redis.Enabled {
+		t.Fatalf("expected redis enabled")
+	}
+	if cfg.Redis.Addr != "localhost:6379" {
+		t.Fatalf("expected redis addr localhost:6379, got %q", cfg.Redis.Addr)
+	}
+	if cfg.Redis.DB != 1 {
+		t.Fatalf("expected redis db 1, got %d", cfg.Redis.DB)
+	}
+	if cfg.Redis.ConnectTimeout != 3*time.Second {
+		t.Fatalf("expected redis connect timeout 3s, got %s", cfg.Redis.ConnectTimeout)
+	}
 }
 
 func TestLoadDatabaseValidation(t *testing.T) {
@@ -96,6 +112,13 @@ func TestLoadDatabaseValidation(t *testing.T) {
 				"FUNPOT_DATABASE_USER":           "funpot",
 				"FUNPOT_DATABASE_MAX_OPEN_CONNS": "2",
 				"FUNPOT_DATABASE_MIN_OPEN_CONNS": "5",
+			},
+		},
+		{
+			name: "invalid redis db",
+			env: map[string]string{
+				"FUNPOT_REDIS_ENABLED": "true",
+				"FUNPOT_REDIS_DB":      "-1",
 			},
 		},
 		{


### PR DESCRIPTION
### Motivation

- Add optional Redis-backed storage for refresh-session revocation/rotation so refresh sessions can be shared and revoked across processes.
- Expose Redis connectivity via configuration so local and production deployments can opt into Redis or use an in-memory fallback for smoke tests.
- Provide automated tests to validate Redis usage, memory fallback, and configuration parsing/validation.

### Description

- Introduce `setupRefreshSessionStore` in `cmd/server/main.go` and wire it into startup to configure refresh-session storage based on `cfg.Auth.Refresh` and `cfg.Redis` settings.
- Add `github.com/redis/go-redis/v9` usage to create and ping a Redis client, and register a `RedisRefreshSessionStore` with the `auth.Service`, with proper cleanup on shutdown.
- Extend configuration (`internal/config/config.go`) with a new `RedisConfig` struct, environment variable parsing for `FUNPOT_REDIS_*`, and validation for required fields when Redis is enabled.
- Update `docs/local_setup.md` to document the new Redis environment variables and the behavior of refresh-session storage, and add unit tests in `cmd/server/main_test.go` and update `internal/config/config_test.go` to cover the new config fields and validation.

### Testing

- Added `cmd/server/main_test.go` unit tests that exercise `setupRefreshSessionStore` with a real Redis instance simulated by `miniredis` and validate memory fallback and noop behavior, and they passed.
- Updated `internal/config/config_test.go` to include tests for Redis parsing and validation, and they passed.
- Ran the test suite with `go test ./...` and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b578533b78832ca9b58e9342c94b11)