### PR TITLE
Add admin tab capabilities to /api/admin/me response

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -139,6 +139,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
 - `POST /api/streamers` – submits a Twitch streamer username for moderation/validation.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
+- `GET /api/admin/me` – returns admin capability flags (`isAdmin`) plus admin UI tabs available to the authenticated user.
 - `GET /api/admin/games` – admin-only endpoint listing all configured games.
 - `POST /api/admin/games` – admin-only endpoint creating a game definition.
 - `PUT /api/admin/games/{gameId}` – admin-only endpoint updating a game definition.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -945,10 +945,15 @@ components:
           nullable: true
     AdminMeResponse:
       type: object
-      required: [isAdmin]
+      required: [isAdmin, adminTabs]
       properties:
         isAdmin:
           type: boolean
+        adminTabs:
+          type: array
+          items:
+            type: string
+          description: Additional admin UI tabs available to the authenticated user.
     PromptCreateRequest:
       type: object
       required: [stage, template, model, temperature, maxTokens, timeoutMs, retryCount, backoffMs, cooldownMs, minConfidence]

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -92,8 +92,11 @@ type llmDecisionRecordRequest struct {
 }
 
 type adminMeResponse struct {
-	IsAdmin bool `json:"isAdmin"`
+	IsAdmin   bool     `json:"isAdmin"`
+	AdminTabs []string `json:"adminTabs"`
 }
+
+var defaultAdminTabs = []string{"settings", "games", "prompts"}
 
 // NewHandler wires the base HTTP routes for the service.
 func NewHandler(
@@ -324,7 +327,13 @@ func NewHandler(
 					return
 				}
 
-				writeJSON(w, http.StatusOK, adminMeResponse{IsAdmin: adminService.IsAdmin(claims.Subject)})
+				isAdmin := adminService.IsAdmin(claims.Subject)
+				response := adminMeResponse{IsAdmin: isAdmin, AdminTabs: []string{}}
+				if isAdmin {
+					response.AdminTabs = append(response.AdminTabs, defaultAdminTabs...)
+				}
+
+				writeJSON(w, http.StatusOK, response)
 			})))
 		}
 

--- a/internal/app/router_admin_test.go
+++ b/internal/app/router_admin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"go.uber.org/zap"
@@ -23,13 +24,21 @@ func TestAdminMeReturnsTrueForAdmin(t *testing.T) {
 		t.Fatalf("expected 200, got %d", res.Code)
 	}
 
-	var payload map[string]bool
+	var payload struct {
+		IsAdmin   bool     `json:"isAdmin"`
+		AdminTabs []string `json:"adminTabs"`
+	}
 	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 
-	if !payload["isAdmin"] {
-		t.Fatalf("expected isAdmin=true, got %v", payload["isAdmin"])
+	if !payload.IsAdmin {
+		t.Fatalf("expected isAdmin=true, got %v", payload.IsAdmin)
+	}
+
+	expectedTabs := []string{"settings", "games", "prompts"}
+	if !reflect.DeepEqual(payload.AdminTabs, expectedTabs) {
+		t.Fatalf("expected admin tabs %v, got %v", expectedTabs, payload.AdminTabs)
 	}
 }
 
@@ -45,12 +54,19 @@ func TestAdminMeReturnsFalseForNonAdmin(t *testing.T) {
 		t.Fatalf("expected 200, got %d", res.Code)
 	}
 
-	var payload map[string]bool
+	var payload struct {
+		IsAdmin   bool     `json:"isAdmin"`
+		AdminTabs []string `json:"adminTabs"`
+	}
 	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 
-	if payload["isAdmin"] {
-		t.Fatalf("expected isAdmin=false, got %v", payload["isAdmin"])
+	if payload.IsAdmin {
+		t.Fatalf("expected isAdmin=false, got %v", payload.IsAdmin)
+	}
+
+	if len(payload.AdminTabs) != 0 {
+		t.Fatalf("expected empty adminTabs for non-admin, got %v", payload.AdminTabs)
 	}
 }


### PR DESCRIPTION
### Motivation
- Provide frontend with explicit admin UI metadata so it can conditionally render additional admin tabs and settings when the authenticated user is an admin.
- Keep the API contract (OpenAPI) and tests in sync with the new response shape to avoid integration surprises.

### Description
- Extend the `/api/admin/me` response type to include `adminTabs []string` alongside `isAdmin`, and return a default tabs list for admins (`settings`, `games`, `prompts`) and an empty array for non-admins.
- Add `defaultAdminTabs` constant and wire logic in `internal/app/router.go` to populate the response based on `admin.Service.IsAdmin`.
- Update OpenAPI spec in `docs/openapi.yaml` to require `adminTabs` in `AdminMeResponse` and document the new field.
- Update `docs/local_setup.md` to describe the `/api/admin/me` endpoint and update router tests in `internal/app/router_admin_test.go` to assert both `isAdmin` and `adminTabs` semantics.

### Testing
- Ran `gofmt` on modified files to ensure formatting; formatting completed successfully.
- Executed unit tests with `go test ./...` and `go test ./internal/app ./cmd/server`, and all tests passed after adjustments (tests initially failed during iteration but were fixed and now succeed).
- Verified the updated router tests validate `isAdmin` true/false and expected `adminTabs` contents for admin and non-admin users.

Checklist
- [x] Update OpenAPI schema for `AdminMeResponse` to include `adminTabs`.
- [x] Implement backend support for `adminTabs` in `/api/admin/me`.
- [x] Update and run router tests to cover the new response contract.
- [x] Update local setup docs to list `/api/admin/me` behavior.
- [ ] Implement frontend admin UI to consume `adminTabs` and render admin-only tabs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5835c9828832cbf0e3eab9da6418d)