### PR TITLE
Expose isAdmin on /api/me and remove /api/admin/me

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -134,12 +134,11 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `POST /api/auth/refresh` – rotates refresh session and issues a new JWT + refresh token pair.
 - `POST /api/auth/logout` – revokes a single refresh session using refresh token.
 - `POST /api/auth/logout-all` – revokes all refresh sessions for authenticated user.
-- `GET /api/me` – returns the authenticated user's profile when called with the issued JWT.
+- `GET /api/me` – returns the authenticated user's profile plus `isAdmin` flag when called with the issued JWT.
 - `GET /api/config` – exposes client configuration and feature flags for the authenticated user.
 - `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
 - `POST /api/streamers` – submits a Twitch streamer username for moderation/validation.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
-- `GET /api/admin/me` – returns admin capability flags (`isAdmin`) plus admin UI tabs available to the authenticated user.
 - `GET /api/admin/games` – admin-only endpoint listing all configured games.
 - `POST /api/admin/games` – admin-only endpoint creating a game definition.
 - `PUT /api/admin/games/{gameId}` – admin-only endpoint updating a game definition.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -261,20 +261,6 @@ paths:
                 $ref: '#/components/schemas/Game'
         default:
           $ref: '#/components/responses/Error'
-  /api/admin/me:
-    get:
-      summary: Get admin capabilities for current user
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: Admin capability flags
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdminMeResponse'
-        default:
-          $ref: '#/components/responses/Error'
   /api/admin/games/{gameId}:
     put:
       summary: Update game (admin)
@@ -805,6 +791,9 @@ components:
         flags:
           type: object
           additionalProperties: true
+        isAdmin:
+          type: boolean
+          description: Indicates whether the authenticated user has admin privileges.
     ClientConfig:
       type: object
       properties:
@@ -943,17 +932,6 @@ components:
           type: string
           format: date-time
           nullable: true
-    AdminMeResponse:
-      type: object
-      required: [isAdmin, adminTabs]
-      properties:
-        isAdmin:
-          type: boolean
-        adminTabs:
-          type: array
-          items:
-            type: string
-          description: Additional admin UI tabs available to the authenticated user.
     PromptCreateRequest:
       type: object
       required: [stage, template, model, temperature, maxTokens, timeoutMs, retryCount, backoffMs, cooldownMs, minConfidence]

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -91,12 +91,10 @@ type llmDecisionRecordRequest struct {
 	Confidence float64 `json:"confidence"`
 }
 
-type adminMeResponse struct {
-	IsAdmin   bool     `json:"isAdmin"`
-	AdminTabs []string `json:"adminTabs"`
+type meResponse struct {
+	users.Profile
+	IsAdmin bool `json:"isAdmin"`
 }
-
-var defaultAdminTabs = []string{"settings", "games", "prompts"}
 
 // NewHandler wires the base HTTP routes for the service.
 func NewHandler(
@@ -303,7 +301,8 @@ func NewHandler(
 				writeError(w, http.StatusInternalServerError, "failed to load profile")
 				return
 			}
-			writeJSON(w, http.StatusOK, profile)
+			isAdmin := adminService != nil && adminService.IsAdmin(claims.Subject)
+			writeJSON(w, http.StatusOK, meResponse{Profile: profile, IsAdmin: isAdmin})
 		})))
 
 		mux.Handle("/api/config", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -313,29 +312,6 @@ func NewHandler(
 			}
 			writeJSON(w, http.StatusOK, clientConfig)
 		})))
-
-		if adminService != nil {
-			mux.Handle("/api/admin/me", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != http.MethodGet {
-					w.WriteHeader(http.StatusMethodNotAllowed)
-					return
-				}
-
-				claims, ok := auth.ClaimsFromContext(r.Context())
-				if !ok {
-					writeError(w, http.StatusUnauthorized, "missing auth claims")
-					return
-				}
-
-				isAdmin := adminService.IsAdmin(claims.Subject)
-				response := adminMeResponse{IsAdmin: isAdmin, AdminTabs: []string{}}
-				if isAdmin {
-					response.AdminTabs = append(response.AdminTabs, defaultAdminTabs...)
-				}
-
-				writeJSON(w, http.StatusOK, response)
-			})))
-		}
 
 		if streamersService != nil {
 			mux.Handle("/api/streamers", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/router_admin_test.go
+++ b/internal/app/router_admin_test.go
@@ -4,18 +4,24 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
 	"go.uber.org/zap"
 
 	"github.com/funpot/funpot-go-core/internal/admin"
+	"github.com/funpot/funpot-go-core/internal/users"
 )
 
-func TestAdminMeReturnsTrueForAdmin(t *testing.T) {
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, nil, nil, nil, ClientConfigResponse{})
+func TestMeReturnsIsAdminTrueForAdmin(t *testing.T) {
+	userService := users.NewService(users.NewInMemoryRepository())
+	_, err := userService.SyncTelegramProfile(t.Context(), users.TelegramProfile{ID: 1, Username: "admin"})
+	if err != nil {
+		t.Fatalf("userService.SyncTelegramProfile() error = %v", err)
+	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/admin/me", nil)
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), userService, nil, nil, nil, nil, ClientConfigResponse{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 	req.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
 	res := httptest.NewRecorder()
 
@@ -25,8 +31,7 @@ func TestAdminMeReturnsTrueForAdmin(t *testing.T) {
 	}
 
 	var payload struct {
-		IsAdmin   bool     `json:"isAdmin"`
-		AdminTabs []string `json:"adminTabs"`
+		IsAdmin bool `json:"isAdmin"`
 	}
 	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
@@ -35,17 +40,18 @@ func TestAdminMeReturnsTrueForAdmin(t *testing.T) {
 	if !payload.IsAdmin {
 		t.Fatalf("expected isAdmin=true, got %v", payload.IsAdmin)
 	}
-
-	expectedTabs := []string{"settings", "games", "prompts"}
-	if !reflect.DeepEqual(payload.AdminTabs, expectedTabs) {
-		t.Fatalf("expected admin tabs %v, got %v", expectedTabs, payload.AdminTabs)
-	}
 }
 
-func TestAdminMeReturnsFalseForNonAdmin(t *testing.T) {
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, nil, nil, nil, ClientConfigResponse{})
+func TestMeReturnsIsAdminFalseForNonAdmin(t *testing.T) {
+	userService := users.NewService(users.NewInMemoryRepository())
+	_, err := userService.SyncTelegramProfile(t.Context(), users.TelegramProfile{ID: 1, Username: "user"})
+	if err != nil {
+		t.Fatalf("userService.SyncTelegramProfile() error = %v", err)
+	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/admin/me", nil)
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), userService, nil, nil, nil, nil, ClientConfigResponse{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
 	res := httptest.NewRecorder()
 
@@ -55,8 +61,7 @@ func TestAdminMeReturnsFalseForNonAdmin(t *testing.T) {
 	}
 
 	var payload struct {
-		IsAdmin   bool     `json:"isAdmin"`
-		AdminTabs []string `json:"adminTabs"`
+		IsAdmin bool `json:"isAdmin"`
 	}
 	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
@@ -65,8 +70,17 @@ func TestAdminMeReturnsFalseForNonAdmin(t *testing.T) {
 	if payload.IsAdmin {
 		t.Fatalf("expected isAdmin=false, got %v", payload.IsAdmin)
 	}
+}
 
-	if len(payload.AdminTabs) != 0 {
-		t.Fatalf("expected empty adminTabs for non-admin, got %v", payload.AdminTabs)
+func TestAdminMeEndpointRemovedFallsBackToRoot(t *testing.T) {
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, nil, nil, nil, ClientConfigResponse{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/me", nil)
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", res.Code)
 	}
 }


### PR DESCRIPTION
### Motivation
- Consolidate admin discovery into the main user profile endpoint so clients can determine admin status from `GET /api/me` instead of querying a separate admin-only route.
- Reduce duplicate contracts and surface area by removing the now-redundant `GET /api/admin/me` endpoint.

### Description
- Added `isAdmin` to the `GET /api/me` response by returning `meResponse{Profile, IsAdmin}` computed from `adminService.IsAdmin(claims.Subject)` in `internal/app/router.go`.
- Removed the dedicated `/api/admin/me` route and the `adminMeResponse` type from the router.
- Updated router tests in `internal/app/router_admin_test.go` to assert `isAdmin` on `/api/me` for admin and non-admin users and to verify `/api/admin/me` is no longer handled.
- Updated documentation: removed the `/api/admin/me` path from `docs/openapi.yaml` and added `isAdmin` to the `UserProfile` schema, and updated `docs/local_setup.md` to state `/api/me` now includes `isAdmin`.

### Testing
- Ran `go test ./...` and all packages passed (no failing tests after adjustments).
- The router unit tests were updated and exercised the new behavior for admin and non-admin tokens and the removed `/api/admin/me` route.
- Checklist: [x] Add `isAdmin` to `GET /api/me` response; [x] Remove `/api/admin/me` route; [x] Update router tests; [x] Update `docs/openapi.yaml`; [x] Update `docs/local_setup.md`; [ ] Update clients/frontends that call `/api/admin/me` to use `/api/me` instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b711d770f8832c9c37b9a8bb37ae9f)