### PR TITLE
Fix vet failure in admin router tests

### DIFF
--- a/internal/app/router_admin_test.go
+++ b/internal/app/router_admin_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -14,7 +15,7 @@ import (
 
 func TestMeReturnsIsAdminTrueForAdmin(t *testing.T) {
 	userService := users.NewService(users.NewInMemoryRepository())
-	_, err := userService.SyncTelegramProfile(t.Context(), users.TelegramProfile{ID: 1, Username: "admin"})
+	_, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "admin"})
 	if err != nil {
 		t.Fatalf("userService.SyncTelegramProfile() error = %v", err)
 	}
@@ -44,7 +45,7 @@ func TestMeReturnsIsAdminTrueForAdmin(t *testing.T) {
 
 func TestMeReturnsIsAdminFalseForNonAdmin(t *testing.T) {
 	userService := users.NewService(users.NewInMemoryRepository())
-	_, err := userService.SyncTelegramProfile(t.Context(), users.TelegramProfile{ID: 1, Username: "user"})
+	_, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "user"})
 	if err != nil {
 		t.Fatalf("userService.SyncTelegramProfile() error = %v", err)
 	}


### PR DESCRIPTION
### Motivation
- `go vet` failed for `internal/app` because tests called `t.Context()` which is not available on the used `testing.T` type, causing the package to be marked as failing static checks.

### Description
- Replace `t.Context()` with `context.Background()` in `internal/app/router_admin_test.go` and add the `context` import so the tests compile and satisfy `go vet`.
- This is a test-only change and does not affect production behavior or public APIs.

### Testing
- Ran `go test ./internal/app` and `go vet ./internal/app`, and both commands completed successfully.
- Checklist:
  - [x] Identify vet failure in `internal/app/router_admin_test.go`.
  - [x] Replace `t.Context()` calls with `context.Background()`.
  - [x] Add `context` import and ensure tests compile.
  - [x] Run `go test` and `go vet` for the package and confirm success.
  - [x] Commit the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7160768e8832c9f04a315b0b6069f)