### PR TITLE
Docs: introduce global game-detector and per-game scenario model for LLM orchestration (M2.1)

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -18,16 +18,19 @@ stream analysis immediately after a streamer is added:
 
 - Trigger background orchestration when a streamer is created/activated.
 - Capture stream fragments every **10 seconds** via Streamlink.
-- For each fragment, call LLM with the **active admin-managed prompt**
-  (stage-specific, versioned template).
+- For each fragment, first call the **active global game-detection prompt**
+  managed by admins.
+- When a game is detected, resolve the **active admin-managed scenario** for that
+  game and execute its stage prompts/transition rules step-by-step.
 - Persist run/stage outputs and broadcast state updates to clients.
 
 ### Priority checklist (must be tracked in status updates)
 - [ ] Auto-start Streamlink analysis job after `POST /api/streamers` success.
 - [ ] Fixed 10-second capture cadence with lock/idempotency protections.
-- [ ] Prompt resolution from admin configuration (`active` prompt version per stage).
-- [ ] Worker payload includes prompt text + runtime params (model, temperature, token limits).
-- [ ] Persist chunk metadata, LLM request/response refs, normalized stage decision, confidence.
+- [ ] Resolve the active global game-detection prompt from admin configuration.
+- [ ] Resolve the active per-game scenario and the active prompt for its current step.
+- [ ] Worker payload includes prompt text + runtime params (model, temperature, token limits) for the resolved step.
+- [ ] Persist chunk metadata, LLM request/response refs, normalized stage decision, confidence, and transition outcome.
 - [ ] Publish realtime `LLM_STAGE_UPDATED` events and provide REST backfill/history.
 - [ ] Add retry/backoff + DLQ behavior for Streamlink and LLM failures.
 - [ ] Add observability for chunk lag, stage latency, and per-streamer failure rate.
@@ -70,11 +73,16 @@ stream analysis immediately after a streamer is added:
   fallback strategy).
 - [ ] Implement stream capture worker pipeline:
   `streamlink -> media chunking -> Gemini request -> normalized stage result`.
-- [ ] Build staged game flow for Counter-Strike:
-  Stage A detects stream context (is streamer playing CS or not),
-  Stage B classifies match type (competitive / faceit / other),
-  Stage C tracks live match state (pre-game / in-progress / finished),
-  Stage D determines result (win / loss / unknown).
+- [ ] Implement global game detection prompt execution before game-specific flows.
+- [ ] Build admin-managed per-game scenario flows (initially Counter-Strike),
+  where each next step is selected from the previous LLM answer / normalized
+  transition outcome.
+- [ ] Ship the initial Counter-Strike scenario:
+  scenario entry after global detector returns Counter-Strike;
+  Step 1 identifies whether a new ranked match is starting and whether it is
+  competitive / faceit / other;
+  Step 2 waits for match completion when the scenario branch requires it;
+  Step 3 determines match result (win / loss / unknown) for the active branch.
 - [ ] Add resilient orchestration with retries, idempotency keys, and dead-letter
   handling for failed LLM jobs.
 - [ ] Publish live LLM status updates to clients via WebSocket channel.
@@ -85,9 +93,9 @@ stream analysis immediately after a streamer is added:
   (token pair issuance, rotation endpoint, and revoke-all/user-device controls).
 - [ ] Add observability: per-stage latency, success ratio, token usage, and
   drift alerts for prompt regressions.
-- Exit Criteria: admin can tune prompts per stage, worker pipeline produces
-  stage results for active streamers, and users observe near-real-time status
-  updates on streamer pages.
+- Exit Criteria: admin can tune the global detector plus per-game scenario
+  prompts/transitions, worker pipeline produces scenario step results for active
+  streamers, and users observe near-real-time status updates on streamer pages.
 
 ### M3 – Events Lifecycle & Realtime Delivery
 - [ ] Implement `/internal/worker/events` ingestion with validation, dedupe, and

--- a/docs/llm_stream_orchestration_plan.md
+++ b/docs/llm_stream_orchestration_plan.md
@@ -2,9 +2,9 @@
 
 ## Goal
 Design and implement an MVP where:
-1. Admin configures LLM stage prompts and runtime limits.
+1. Admin configures a global game-detection prompt plus per-game scenario prompts and runtime limits.
 2. Background workers read livestream fragments via Streamlink.
-3. Workers send staged requests to Gemini and store normalized decisions.
+3. Workers first detect the game, then execute the active per-game scenario step-by-step and store normalized decisions/transitions.
 4. Users open streamer page and observe live LLM status updates.
 
 ## Scope of this iteration
@@ -16,46 +16,67 @@ Design and implement an MVP where:
 - Treat the following as the top-priority slice for immediate delivery:
   - streamer added -> analysis job starts automatically;
   - Streamlink captures/reads fragment each 10 seconds;
-  - each fragment is sent to Gemini with active admin-managed prompt;
-  - decisions are persisted and published to websocket consumers.
+  - each fragment is sent first to the active global game-detection prompt, then to the active game-scenario step prompt when applicable;
+  - decisions and step transitions are persisted and published to websocket consumers.
 
 ## Product flow (high level)
 1. User (regular user or admin) adds streamer via `POST /api/streamers`.
 2. Worker scheduler picks active streamers and starts analysis cycle (or an immediate bootstrap job right after streamer creation).
-3. Pipeline runs stage-by-stage (gating by previous stage output).
-4. Stage outputs are persisted and broadcast to clients.
-5. UI shows timeline + current stage state for each streamer.
+3. Every fragment first goes through the active global game-detection prompt.
+4. If a supported game is detected, the worker resolves the active admin-managed scenario for that game.
+5. The scenario runs step-by-step, and each next step is chosen from the previous normalized LLM answer / transition rule.
+6. Step outputs are persisted and broadcast to clients.
+7. UI shows timeline + current game/scenario state for each streamer.
 
-## Stage model (Counter-Strike)
+## Scenario model
 
-### Stage A — Game detection
-Question: Is streamer currently playing Counter-Strike?
-- Output enum: `cs_detected | not_cs | uncertain`
-- If `not_cs`: pipeline pauses for cooldown period.
-- If `uncertain`: retry policy and confidence threshold apply.
+### Global detector (always-on entrypoint)
+Question: What game is currently on the stream?
+- Output enum should map into known games, e.g. `counter_strike | dota2 | valorant | unknown`.
+- If output is `unknown`, pipeline stays on the global detector and retries on the next capture window.
+- If output matches a configured game scenario, the worker loads that scenario and enters its first step.
 
-### Stage B — Match type detection
-Question: If CS detected, what match mode?
-- Output enum: `competitive | faceit | premier | casual | unknown`
-- Required for downstream logic (different prompts/rules).
+### Per-game scenarios
+- Each game can have one active scenario at a time.
+- A scenario contains ordered or graph-based steps.
+- Each step references an active admin-managed prompt version plus runtime config.
+- Each step declares transition rules: which normalized answer(s) move to which next step, pause state, terminal state, or fallback.
+- Admin must be able to create, edit, activate, deactivate, and delete scenarios/steps/transitions.
 
-### Stage C — Match state detection
-Question: Current game state?
-- Output enum: `pregame | in_progress | finished | unknown`
-- Pipeline proceeds to Stage D only when `finished` (or explicit terminal signal).
+## Counter-Strike scenario (initial target)
 
-### Stage D — Match result detection
-Question: Did streamer win?
+### CS Step 1 — Match entry / queue type detection
+Question: Is a new ranked Counter-Strike match starting, and if so is it competitive, faceit, premier, or other?
+- Output enum: `competitive | faceit | premier | other | no_ranked_match | uncertain`
+- If `no_ranked_match`: scenario waits and retries on the next capture window.
+- If `faceit` / `competitive` / `premier`: transition into the corresponding active branch.
+
+### CS Step 2 — Match progress / completion wait
+Question: Has the tracked match finished yet?
+- Output enum: `in_progress | finished | uncertain`
+- If `in_progress`: stay on the same step and keep polling.
+- If `finished`: transition to result detection.
+
+### CS Step 3 — Match result detection
+Question: Did the streamer win the tracked match?
 - Output enum: `win | loss | draw | unknown`
-- Stores final decision and confidence; opens next cycle.
+- Stores final decision and confidence, then returns control to the global detector for the next cycle.
+
+## Transition rules
+- Every scenario step must define normalized outputs and the next action for each output.
+- Transitions may point to another step, remain on the current step, pause with cooldown, or end the scenario run.
+- The worker should never infer a next step outside admin-configured transition rules.
+- Admin changes must be versioned/auditable so historical decisions keep prompt linkage.
 
 ## Admin capabilities (backend requirements)
 Admin scope in MVP is focused on LLM prompt/config management; broader admin tools are expected in later milestones.
-- Manage prompt templates by stage (`versioned`, `is_active`).
+- Manage the always-on global game-detection prompt (`versioned`, `is_active`).
+- Manage per-game scenarios, their steps, and transition rules.
+- Attach an active prompt template/version to each scenario step.
 - Configure model/runtime params (`model`, `temperature`, `max_tokens`, `timeout_ms`).
 - Configure orchestration controls (`retry_count`, `backoff_ms`, `cooldown_ms`, `min_confidence`).
-- Enable/disable stage or entire pipeline per streamer/game.
-- View audit trail: who changed prompt/version and when.
+- Enable/disable a whole scenario, a branch, or an individual step per game.
+- View audit trail: who changed prompt/version/scenario/transition and when.
 
 ## Security: should admin rely only on Telegram ID?
 Short answer: **Telegram ID alone is not enough**.
@@ -117,12 +138,14 @@ Primary usage:
 - `source` (`streamlink`)
 - `status` (`running|completed|failed|partial`)
 
-### Stage decision
-- `id`, `run_id`, `stage`
+### Scenario step decision
+- `id`, `run_id`, `scenario_id`, `step_id`
+- `game_key`
 - `prompt_version_id`
 - `input_ref` (clip/chunk reference)
 - `raw_response` (json/text)
 - `normalized_label`
+- `transition_key`, `next_step_id`
 - `confidence`
 - `latency_ms`, `tokens_in`, `tokens_out`
 - `error_code`, `error_message`
@@ -130,31 +153,33 @@ Primary usage:
 
 ## API/WSS plan (MVP)
 - `POST /api/streamers` — add streamer (available to authenticated users, not admin-only).
-- `GET /api/streamers/:id/status` — current aggregated stage status.
-- `GET /api/streamers/:id/llm-decisions?limit=` — decision history.
+- `GET /api/streamers/:id/status` — current aggregated game/scenario status.
+- `GET /api/streamers/:id/llm-decisions?limit=` — detector + scenario step decision history.
 - `GET /api/admin/prompts` / `POST /api/admin/prompts` / `POST /api/admin/prompts/:id/activate`.
-- `WS /ws` event `LLM_STAGE_UPDATED` with payload `{streamerId, stage, label, confidence, ts}`.
+- `GET /api/admin/scenarios` / `POST /api/admin/scenarios` / scenario step/transition management endpoints.
+- `WS /ws` event `LLM_STAGE_UPDATED` with payload `{streamerId, gameKey, scenarioId, stepId, label, confidence, ts}`.
 
 ## Phased implementation
 
 ### Phase 1 — Admin + prompt management
 - Add admin authorization middleware and role checks.
-- Add prompt template CRUD + activation.
-- Add audit logging for prompt changes.
+- Add global detector prompt CRUD + activation.
+- Add per-game scenario/step/transition CRUD + activation.
+- Add audit logging for prompt/scenario changes.
 
 ### Phase 2 — Worker orchestration skeleton
 - Scheduler selects active streamers.
 - Streamlink chunk fetch + storage reference.
-- Gemini client wrapper + normalized parser per stage.
+- Gemini client wrapper + normalized parser for detector and scenario steps.
 
 ### Phase 3 — Realtime delivery
-- Persist stage decisions.
+- Persist detector + scenario step decisions.
 - Publish WS events and expose REST status/history.
 - Add reconnect/backfill logic for client timeline.
 
 ### Phase 4 — Reliability & observability
 - Retries/backoff, DLQ, idempotency guards.
-- Metrics: per-stage latency, success/fail ratio, token usage.
+- Metrics: detector/scenario-step latency, success/fail ratio, token usage.
 - Alerts on model drift / error spikes.
 
 ## Risks and mitigations
@@ -164,7 +189,7 @@ Primary usage:
 - Prompt regressions -> versioning, canary activation, rollback to previous prompt.
 
 ## Open questions before coding
-1. Is Faceit detection mandatory in MVP or can it be `unknown` fallback in first release?
+1. Which non-CS games must the global detector recognize in MVP versus return as `unknown`?
 2. Fixed for current priority scope: Streamlink chunks must be sampled every 10 seconds (revisit only after baseline stability).
 3. Should result determination rely only on LLM, or also optional external match APIs later?
 4. What freshness SLA do we target on streamer page (e.g., update every <=10 seconds)?
@@ -176,37 +201,37 @@ and is ordered to ship a vertical slice before hardening.
 
 ### Iteration A — End-to-end pipeline baseline
 
-Goal: produce and persist Stage A decisions for active streamers from real worker
-cycles.
+Goal: produce and persist global game-detector decisions for active streamers from real worker cycles, then enter the first configured game scenario step when a supported game is found.
 
 #### A1. Worker pipeline skeleton
 - [ ] Introduce `internal/media/stream_capture_worker.go` (or equivalent module package)
   with cycle orchestration:
   - acquire streamer lock,
   - fetch fragment via streamlink adapter every 10 seconds,
-  - resolve active admin prompt for current stage and call Gemini,
-  - persist normalized stage decision.
+  - resolve the active global detector prompt and call Gemini,
+  - if a supported game is detected, resolve the active scenario + current step prompt,
+  - persist normalized detector/step decision and transition outcome.
 - [ ] Add streamlink adapter interface to isolate process execution and allow tests.
 - [ ] Add DB model/repository for `stream_analysis_runs` and link to stage decisions.
 
 Definition of done:
-- one worker pass creates `run` + `Stage A` record for a test streamer;
+- one worker pass creates `run` + global detector record for a test streamer;
 - duplicate cycle for the same lock window is rejected.
 
-#### A2. Stage A normalization and storage
-- [ ] Implement Stage A parser mapping model output to:
-  `cs_detected | not_cs | uncertain`.
-- [ ] Add confidence threshold and cooldown handling for `not_cs` branch.
+#### A2. Global detector normalization and storage
+- [ ] Implement global detector parser mapping model output to supported game keys
+  plus `unknown`.
+- [ ] Add confidence threshold and cooldown handling for `unknown` branch.
 - [ ] Persist `raw_response`, `normalized_label`, `confidence`, `latency_ms`,
-  `tokens_in`, `tokens_out`.
+  `tokens_in`, `tokens_out`, and chosen scenario transition.
 
 Definition of done:
 - parser is covered by table-driven tests for valid/invalid responses;
-- confidence fallback path stores `uncertain` and does not crash the cycle.
+- confidence fallback path stores `unknown` and does not crash the cycle.
 
 #### A3. Baseline telemetry for pipeline
-- [ ] Add metrics for stage latency and stage success/fail counters.
-- [ ] Add structured logs with `run_id`, `streamer_id`, `stage`, and `attempt`.
+- [ ] Add metrics for detector/scenario-step latency and success/fail counters.
+- [ ] Add structured logs with `run_id`, `streamer_id`, `game_key`, `scenario_id`, `step_id`, and `attempt`.
 
 Definition of done:
 - metrics are visible in local `/metrics` output and include stage labels;
@@ -217,23 +242,24 @@ Definition of done:
 Goal: complete M2.1 exit criteria with staged flow, WS updates, and resilient
 orchestration.
 
-#### B1. Stage B/C/D workflow
-- [ ] Implement stage gate transitions:
-  - Stage B runs only after `Stage A = cs_detected`.
-  - Stage C runs only after match type is known/accepted.
-  - Stage D runs only after `Stage C = finished`.
-- [ ] Implement normalization enums:
-  - B: `competitive | faceit | premier | casual | unknown`
-  - C: `pregame | in_progress | finished | unknown`
-  - D: `win | loss | draw | unknown`
+#### B1. Scenario workflow + transitions
+- [ ] Implement admin-defined transition engine:
+  - load active scenario for the detected game,
+  - execute the current step,
+  - choose next step strictly from normalized output + transition config.
+- [ ] Implement the initial Counter-Strike scenario normalization enums:
+  - Step 1: `competitive | faceit | premier | other | no_ranked_match | uncertain`
+  - Step 2: `in_progress | finished | uncertain`
+  - Step 3: `win | loss | draw | unknown`
+- [ ] Support branch-specific behavior, e.g. Faceit branch waits for completion then asks for result.
 
 Definition of done:
-- deterministic stage transition unit tests pass;
-- each stage emits decision records with prompt version linkage.
+- deterministic transition unit tests pass;
+- each detector/scenario step emits decision records with prompt version linkage.
 
 #### B2. Retry, idempotency, dead-letter
-- [ ] Add per-stage retry policy with exponential backoff.
-- [ ] Add idempotency keys (`streamer_id + stage + window`) with Redis TTL.
+- [ ] Add per-detector/per-step retry policy with exponential backoff.
+- [ ] Add idempotency keys (`streamer_id + scenario_or_detector + step + window`) with Redis TTL.
 - [ ] Add DLQ payload format and reprocessing admin command.
 
 Definition of done:
@@ -250,14 +276,14 @@ Definition of done:
   - revoke-all sessions.
 
 Definition of done:
-- websocket clients receive near-real-time stage updates;
+- websocket clients receive near-real-time detector/scenario-step updates;
 - refresh token replay is rejected after rotation;
 - revoke-all immediately invalidates prior refresh sessions.
 
 ## Delivery checklist mapped to `docs/implementation_plan.md`
 
 ### M2.1 completion checklist
-- [ ] Implement stream capture worker pipeline.
+- [ ] Implement stream capture worker pipeline with global detector + per-game scenario routing.
 - [ ] Build staged CS game flow (A/B/C/D).
 - [ ] Add retries, idempotency, and dead-letter handling.
 - [ ] Publish live LLM status updates via WebSocket.


### PR DESCRIPTION
### Motivation
- Clarify and extend the LLM stream orchestration design to support a global game-detection step that routes to admin-managed per-game scenarios. 
- Ensure the worker pipeline, data contracts, admin surface, and telemetry explicitly cover detector + scenario step semantics for M2.1.
- Provide a concrete initial Counter-Strike scenario and updated exit criteria to guide implementation and testing.

### Description
- Updated `docs/implementation_plan.md` to require an always-on global game-detection prompt and resolution of per-game scenarios/steps before executing downstream prompts. 
- Expanded `docs/llm_stream_orchestration_plan.md` with a scenario model: a global detector entrypoint, per-game scenarios/steps, transition rules, and the initial Counter-Strike scenario (three-step flow: entry/queue type detection, match progress wait, result detection).
- Revised data contract names and fields to include scenario context (e.g. `scenario_id`, `step_id`, `game_key`, `transition_key`, `next_step_id`) and clarified persistence expectations for detector + scenario step decisions. 
- Added API/admin surface changes to docs such as `GET /api/admin/scenarios`, scenario/step/transition CRUD and activation, and enriched WebSocket event payloads for detector/scenario updates. 

### Testing
- This is a documentation-only change; no code-level unit tests were modified. 
- CI documentation and linters were run as part of the change and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba93d600c0832cacceb81a2ab3388b)