### PR TITLE
Add streamer LLM status endpoint with aggregation logic and tests

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -147,6 +147,8 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/config` – exposes client configuration and feature flags for the authenticated user.
 - `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
 - `POST /api/streamers` – submits a Twitch streamer username for moderation/validation.
+- `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM detector/scenario status for a streamer.
+- `GET /api/streamers/{streamerId}/llm-decisions?limit=` – returns recent detector/scenario decision history for a streamer.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
 - `GET /api/admin/games` – admin-only endpoint listing all configured games.
 - `POST /api/admin/games` – admin-only endpoint creating a game definition.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -173,6 +173,26 @@ paths:
                 $ref: '#/components/schemas/Error'
         default:
           $ref: '#/components/responses/Error'
+  /api/streamers/{streamerId}/status:
+    get:
+      summary: Get aggregated LLM status for streamer
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: streamerId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Aggregated detector/scenario status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMStatus'
+        default:
+          $ref: '#/components/responses/Error'
   /api/streamers/{streamerId}/llm-decisions:
     get:
       summary: List latest LLM stage decisions for streamer
@@ -856,6 +876,34 @@ components:
         reason:
           type: string
           nullable: true
+
+    LLMStatus:
+      type: object
+      required: [streamerId, state, latestByStage]
+      properties:
+        streamerId:
+          type: string
+        state:
+          type: string
+          enum: [idle, active]
+        currentRunId:
+          type: string
+        currentStage:
+          type: string
+        currentLabel:
+          type: string
+        currentConfidence:
+          type: number
+          format: double
+        detectedGameKey:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+        latestByStage:
+          type: array
+          items:
+            $ref: '#/components/schemas/LLMDecision'
 
     LLMDecisionRecordRequest:
       type: object

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -397,6 +397,12 @@ func NewHandler(
 				}
 
 				switch action {
+				case "status":
+					if r.Method != http.MethodGet {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					writeJSON(w, http.StatusOK, streamersService.GetLLMStatus(r.Context(), streamerID))
 				case "llm-decisions":
 					switch r.Method {
 					case http.MethodGet:

--- a/internal/app/router_streamers_status_test.go
+++ b/internal/app/router_streamers_status_test.go
@@ -1,0 +1,116 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/funpot/funpot-go-core/internal/admin"
+	"github.com/funpot/funpot-go-core/internal/streamers"
+)
+
+func TestStreamerStatusReturnsAggregatedLLMState(t *testing.T) {
+	streamersService := streamers.NewService()
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamersService,
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	adminToken := buildToken(t, "admin-1")
+	for _, payload := range []map[string]any{
+		{
+			"runId":           "run-1",
+			"stage":           "stage_a",
+			"label":           "cs_detected",
+			"confidence":      0.94,
+			"promptVersionId": "prompt-a",
+		},
+		{
+			"runId":           "run-1",
+			"stage":           "stage_b",
+			"label":           "competitive",
+			"confidence":      0.77,
+			"promptVersionId": "prompt-b",
+		},
+	} {
+		body, _ := json.Marshal(payload)
+		req := httptest.NewRequest(http.MethodPost, "/api/streamers/str-1/llm-decisions", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+adminToken)
+		res := httptest.NewRecorder()
+		handler.ServeHTTP(res, req)
+		if res.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d", res.Code)
+		}
+	}
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/api/streamers/str-1/status", nil)
+	statusReq.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	statusRes := httptest.NewRecorder()
+	handler.ServeHTTP(statusRes, statusReq)
+	if statusRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", statusRes.Code)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(statusRes.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode status response: %v", err)
+	}
+	if got["state"] != "active" {
+		t.Fatalf("expected active state, got %#v", got)
+	}
+	if got["currentStage"] != "stage_b" || got["currentLabel"] != "competitive" {
+		t.Fatalf("expected latest decision to drive current status, got %#v", got)
+	}
+	if got["detectedGameKey"] != "counter_strike" {
+		t.Fatalf("expected detected game to be inferred from stage_a, got %#v", got)
+	}
+	latestByStage, ok := got["latestByStage"].([]any)
+	if !ok || len(latestByStage) != 2 {
+		t.Fatalf("expected two latest stage snapshots, got %#v", got["latestByStage"])
+	}
+}
+
+func TestStreamerStatusReturnsIdleWhenNoDecisionsYet(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamers.NewService(),
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/streamers/str-idle/status", nil)
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(res.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode status response: %v", err)
+	}
+	if got["state"] != "idle" {
+		t.Fatalf("expected idle state, got %#v", got)
+	}
+}

--- a/internal/streamers/model.go
+++ b/internal/streamers/model.go
@@ -38,6 +38,18 @@ type LLMDecision struct {
 	CreatedAt       string  `json:"createdAt"`
 }
 
+type LLMStatus struct {
+	StreamerID        string        `json:"streamerId"`
+	State             string        `json:"state"`
+	CurrentRunID      string        `json:"currentRunId,omitempty"`
+	CurrentStage      string        `json:"currentStage,omitempty"`
+	CurrentLabel      string        `json:"currentLabel,omitempty"`
+	CurrentConfidence float64       `json:"currentConfidence,omitempty"`
+	DetectedGameKey   string        `json:"detectedGameKey,omitempty"`
+	UpdatedAt         string        `json:"updatedAt,omitempty"`
+	LatestByStage     []LLMDecision `json:"latestByStage"`
+}
+
 type RecordDecisionRequest struct {
 	RunID           string
 	StreamerID      string

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -20,6 +20,13 @@ var (
 
 var twitchUsernamePattern = regexp.MustCompile(`^[a-zA-Z0-9_]{4,25}$`)
 
+var stageOrder = map[string]int{
+	"stage_a": 0,
+	"stage_b": 1,
+	"stage_c": 2,
+	"stage_d": 3,
+}
+
 type TwitchValidator interface {
 	ValidateUsername(ctx context.Context, username string) (displayName string, err error)
 }
@@ -240,6 +247,7 @@ func (s *Service) RecordLLMDecision(_ context.Context, req RecordDecisionRequest
 
 	return item, nil
 }
+
 func (s *Service) ListLLMDecisions(_ context.Context, streamerID string, limit int) []LLMDecision {
 	key := strings.TrimSpace(streamerID)
 	if key == "" {
@@ -266,6 +274,70 @@ func (s *Service) ListLLMDecisions(_ context.Context, streamerID string, limit i
 		out = append(out, items[i])
 	}
 	return out
+}
+
+func (s *Service) GetLLMStatus(_ context.Context, streamerID string) LLMStatus {
+	key := strings.TrimSpace(streamerID)
+	status := LLMStatus{StreamerID: key, State: "idle", LatestByStage: []LLMDecision{}}
+	if key == "" {
+		return status
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.decisions[key]
+	if len(items) == 0 {
+		return status
+	}
+
+	latest := items[len(items)-1]
+	status.CurrentRunID = latest.RunID
+	status.CurrentStage = latest.Stage
+	status.CurrentLabel = latest.Label
+	status.CurrentConfidence = latest.Confidence
+	status.UpdatedAt = latest.CreatedAt
+	status.State = "active"
+	status.DetectedGameKey = inferDetectedGameKey(items)
+
+	latestByStage := make(map[string]LLMDecision, len(stageOrder))
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		if _, exists := latestByStage[item.Stage]; exists {
+			continue
+		}
+		latestByStage[item.Stage] = item
+		if len(latestByStage) == len(stageOrder) {
+			break
+		}
+	}
+
+	ordered := make([]LLMDecision, 0, len(latestByStage))
+	for _, stage := range []string{"stage_a", "stage_b", "stage_c", "stage_d"} {
+		if item, ok := latestByStage[stage]; ok {
+			ordered = append(ordered, item)
+		}
+	}
+	status.LatestByStage = ordered
+	return status
+}
+
+func inferDetectedGameKey(items []LLMDecision) string {
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		if item.Stage != "stage_a" {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(item.Label)) {
+		case "cs_detected":
+			return "counter_strike"
+		case "dota_detected":
+			return "dota_2"
+		case "valorant_detected":
+			return "valorant"
+		}
+	}
+	return ""
 }
 
 func isSupportedStage(stage string) bool {

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -145,3 +145,38 @@ func TestRecordLLMDecisionValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetLLMStatusAggregatesLatestStageSnapshots(t *testing.T) {
+	svc := NewService()
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	svc.nowFn = func() time.Time { return now }
+
+	if _, err := svc.RecordLLMDecision(context.Background(), RecordDecisionRequest{RunID: "run-1", StreamerID: "str-1", Stage: "stage_a", Label: "cs_detected", Confidence: 0.9}); err != nil {
+		t.Fatalf("unexpected error recording stage_a: %v", err)
+	}
+	now = now.Add(time.Second)
+	if _, err := svc.RecordLLMDecision(context.Background(), RecordDecisionRequest{RunID: "run-1", StreamerID: "str-1", Stage: "stage_b", Label: "competitive", Confidence: 0.8}); err != nil {
+		t.Fatalf("unexpected error recording stage_b: %v", err)
+	}
+	now = now.Add(time.Second)
+	if _, err := svc.RecordLLMDecision(context.Background(), RecordDecisionRequest{RunID: "run-2", StreamerID: "str-1", Stage: "stage_a", Label: "uncertain", Confidence: 0.4}); err != nil {
+		t.Fatalf("unexpected error recording second stage_a: %v", err)
+	}
+
+	status := svc.GetLLMStatus(context.Background(), "str-1")
+	if status.State != "active" {
+		t.Fatalf("expected active state, got %#v", status)
+	}
+	if status.CurrentRunID != "run-2" || status.CurrentStage != "stage_a" || status.CurrentLabel != "uncertain" {
+		t.Fatalf("unexpected current status: %#v", status)
+	}
+	if status.DetectedGameKey != "counter_strike" {
+		t.Fatalf("expected detected game from latest positive stage_a, got %#v", status)
+	}
+	if len(status.LatestByStage) != 2 {
+		t.Fatalf("expected two stage snapshots, got %#v", status.LatestByStage)
+	}
+	if status.LatestByStage[0].Stage != "stage_a" || status.LatestByStage[1].Stage != "stage_b" {
+		t.Fatalf("expected snapshots ordered by stage, got %#v", status.LatestByStage)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a read-only aggregated view of LLM detector/scenario state per streamer so clients can query current run/stage/label and recent decisions.
- Surface the new endpoint in API docs and local developer docs so it is discoverable and typed in the OpenAPI spec.

### Description
- Added a new `LLMStatus` model and `GetLLMStatus` service on `internal/streamers` that computes current state, `latestByStage`, `detectedGameKey`, and other metadata from recorded `LLMDecision` items, including an `inferDetectedGameKey` helper and `stageOrder` map.
- Added HTTP routing for `GET /api/streamers/{streamerId}/status` in `internal/app/router.go` and wired it to `streamersService.GetLLMStatus` with auth enforcement.
- Extended the OpenAPI spec (`docs/openapi.yaml`) and local setup docs (`docs/local_setup.md`) to document the new endpoints and returned schema.
- Added unit tests for the service (`TestGetLLMStatusAggregatesLatestStageSnapshots`) and router-level integration tests (`TestStreamerStatusReturnsAggregatedLLMState`, `TestStreamerStatusReturnsIdleWhenNoDecisionsYet`) to validate aggregation, game inference, ordering, and idle behavior.

### Testing
- Ran the new and existing unit tests including `TestGetLLMStatusAggregatesLatestStageSnapshots` and router tests `TestStreamerStatusReturnsAggregatedLLMState` and `TestStreamerStatusReturnsIdleWhenNoDecisionsYet` via `go test ./...`, and they passed.
- Existing `ListLLMDecisions` and `RecordLLMDecision` tests were executed as part of the test suite and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9c4a2244832c835652ba0e8dfe23)