### PR TITLE
Add retry/backoff for capture and classification with configurable settings and tests

### DIFF
--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -64,19 +64,24 @@ type Locker interface {
 }
 
 type Worker struct {
-	capture       StreamCapture
-	classifier    StageClassifier
-	prompts       PromptResolver
-	runs          RunStore
-	decisions     DecisionStore
-	locker        Locker
-	lockTTL       time.Duration
-	minConfidence float64
+	capture             StreamCapture
+	classifier          StageClassifier
+	prompts             PromptResolver
+	runs                RunStore
+	decisions           DecisionStore
+	locker              Locker
+	lockTTL             time.Duration
+	minConfidence       float64
+	captureRetryCount   int
+	captureRetryBackoff time.Duration
+	sleepFn             func(context.Context, time.Duration) error
 }
 
 type WorkerConfig struct {
-	LockTTL       time.Duration
-	MinConfidence float64
+	LockTTL             time.Duration
+	MinConfidence       float64
+	CaptureRetryCount   int
+	CaptureRetryBackoff time.Duration
 }
 
 func NewWorker(capture StreamCapture, classifier StageClassifier, promptResolver PromptResolver, runs RunStore, decisions DecisionStore, locker Locker, cfg WorkerConfig) *Worker {
@@ -86,7 +91,25 @@ func NewWorker(capture StreamCapture, classifier StageClassifier, promptResolver
 	if cfg.MinConfidence < 0 || cfg.MinConfidence > 1 {
 		cfg.MinConfidence = 0.5
 	}
-	return &Worker{capture: capture, classifier: classifier, prompts: promptResolver, runs: runs, decisions: decisions, locker: locker, lockTTL: cfg.LockTTL, minConfidence: cfg.MinConfidence}
+	if cfg.CaptureRetryCount < 0 {
+		cfg.CaptureRetryCount = 0
+	}
+	if cfg.CaptureRetryBackoff < 0 {
+		cfg.CaptureRetryBackoff = 0
+	}
+	return &Worker{
+		capture:             capture,
+		classifier:          classifier,
+		prompts:             promptResolver,
+		runs:                runs,
+		decisions:           decisions,
+		locker:              locker,
+		lockTTL:             cfg.LockTTL,
+		minConfidence:       cfg.MinConfidence,
+		captureRetryCount:   cfg.CaptureRetryCount,
+		captureRetryBackoff: cfg.CaptureRetryBackoff,
+		sleepFn:             sleepContext,
+	}
 }
 
 func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (streamers.LLMDecision, error) {
@@ -108,7 +131,7 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 	if len(activePrompts) == 0 {
 		return streamers.LLMDecision{}, prompts.ErrNotFound
 	}
-	chunk, err := w.capture.Capture(ctx, id)
+	chunk, err := w.captureWithRetry(ctx, id)
 	if err != nil {
 		return streamers.LLMDecision{}, err
 	}
@@ -125,8 +148,31 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 	return lastDecision, nil
 }
 
+func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (ChunkRef, error) {
+	attempts := w.captureRetryCount + 1
+	if attempts <= 0 {
+		attempts = 1
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		chunk, err := w.capture.Capture(ctx, streamerID)
+		if err == nil {
+			return chunk, nil
+		}
+		lastErr = err
+		if attempt == attempts {
+			break
+		}
+		if err := w.waitForRetry(ctx, w.captureRetryBackoff, attempt); err != nil {
+			return ChunkRef{}, err
+		}
+	}
+	return ChunkRef{}, lastErr
+}
+
 func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptVersion) (streamers.LLMDecision, error) {
-	result, err := w.classifier.Classify(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt})
+	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt}, activePrompt)
 	if err != nil {
 		return streamers.LLMDecision{}, err
 	}
@@ -154,6 +200,40 @@ func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chu
 	})
 }
 
+func (w *Worker) classifyWithRetry(ctx context.Context, input StageRequest, activePrompt prompts.PromptVersion) (StageClassification, error) {
+	attempts := activePrompt.RetryCount + 1
+	if attempts <= 0 {
+		attempts = 1
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		result, err := w.classifier.Classify(ctx, input)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		if attempt == attempts {
+			break
+		}
+		if err := w.waitForRetry(ctx, time.Duration(activePrompt.BackoffMS)*time.Millisecond, attempt); err != nil {
+			return StageClassification{}, err
+		}
+	}
+	return StageClassification{}, lastErr
+}
+
+func (w *Worker) waitForRetry(ctx context.Context, base time.Duration, attempt int) error {
+	if attempt < 1 || base <= 0 {
+		return nil
+	}
+	backoff := base
+	for i := 1; i < attempt; i++ {
+		backoff *= 2
+	}
+	return w.sleepFn(ctx, backoff)
+}
+
 func effectiveConfidenceThreshold(defaultValue, promptValue float64) float64 {
 	if promptValue > 0 {
 		return promptValue
@@ -170,4 +250,19 @@ func cleanupChunkRef(ref string) {
 		return
 	}
 	_ = os.Remove(path)
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -51,6 +51,37 @@ type fakeDecisionStore struct {
 	items []streamers.RecordDecisionRequest
 }
 
+type flakyCapture struct {
+	failures int
+	calls    int
+	chunk    ChunkRef
+}
+
+func (f *flakyCapture) Capture(_ context.Context, _ string) (ChunkRef, error) {
+	f.calls++
+	if f.calls <= f.failures {
+		return ChunkRef{}, errors.New("capture failed")
+	}
+	return f.chunk, nil
+}
+
+type flakyClassifier struct {
+	failures int
+	calls    map[string]int
+	result   StageClassification
+}
+
+func (f *flakyClassifier) Classify(_ context.Context, input StageRequest) (StageClassification, error) {
+	if f.calls == nil {
+		f.calls = map[string]int{}
+	}
+	f.calls[input.Stage]++
+	if f.calls[input.Stage] <= f.failures {
+		return StageClassification{}, errors.New("temporary llm failure")
+	}
+	return f.result, nil
+}
+
 func (s *fakeDecisionStore) RecordLLMDecision(_ context.Context, req streamers.RecordDecisionRequest) (streamers.LLMDecision, error) {
 	s.items = append(s.items, req)
 	return streamers.LLMDecision{RunID: req.RunID, StreamerID: req.StreamerID, Stage: req.Stage, Label: req.Label, Confidence: req.Confidence}, nil
@@ -128,5 +159,44 @@ func TestWorkerProcessStreamerCleansUpChunkFileOnClassifierError(t *testing.T) {
 	}
 	if _, err := os.Stat(chunkPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected deletion, err=%v", err)
+	}
+}
+
+func TestWorkerProcessStreamerRetriesCapture(t *testing.T) {
+	capture := &flakyCapture{failures: 1, chunk: ChunkRef{Reference: "chunk-1"}}
+	worker := NewWorker(capture, fakeClassifier{results: map[string]StageClassification{"custom": {Label: "ok", Confidence: 0.9}}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5, CaptureRetryCount: 1})
+	worker.sleepFn = func(context.Context, time.Duration) error { return nil }
+
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if capture.calls != 2 {
+		t.Fatalf("capture calls = %d, want 2", capture.calls)
+	}
+}
+
+func TestWorkerProcessStreamerRetriesStageClassification(t *testing.T) {
+	classifier := &flakyClassifier{failures: 1, result: StageClassification{Label: "ok", Confidence: 0.9}}
+	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, classifier, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1, RetryCount: 1, BackoffMS: 10}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+	worker.sleepFn = func(context.Context, time.Duration) error { return nil }
+
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got := classifier.calls["custom"]; got != 2 {
+		t.Fatalf("classifier calls = %d, want 2", got)
+	}
+}
+
+func TestWorkerProcessStreamerReturnsErrorAfterRetryExhausted(t *testing.T) {
+	classifier := &flakyClassifier{failures: 2, result: StageClassification{Label: "ok", Confidence: 0.9}}
+	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, classifier, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1, RetryCount: 1, BackoffMS: 10}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+	worker.sleepFn = func(context.Context, time.Duration) error { return nil }
+
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err == nil {
+		t.Fatal("expected classifier retry exhaustion error")
+	}
+	if got := classifier.calls["custom"]; got != 2 {
+		t.Fatalf("classifier calls = %d, want 2", got)
 	}
 }


### PR DESCRIPTION
### Motivation

- Improve robustness against transient failures in media capture and LLM classification by adding retry and backoff behavior.

### Description

- Add `CaptureRetryCount` and `CaptureRetryBackoff` to `WorkerConfig` and wire them into `Worker` fields `captureRetryCount` and `captureRetryBackoff`. 
- Implement `captureWithRetry` to retry `StreamCapture.Capture` with exponential backoff and replace direct calls to `capture.Capture` in `ProcessStreamer` with this method. 
- Implement `classifyWithRetry` to retry `StageClassifier.Classify` using per-prompt `RetryCount` and `BackoffMS`, and replace direct calls in `processStage` with this method. 
- Add `waitForRetry` and `sleepContext` helpers and make the sleep function injectable via `sleepFn` on `Worker` to allow deterministic testing. 
- Update `NewWorker` to set defaults and to initialize `sleepFn`, and add small refactors to struct field formatting. 
- Add flaky test doubles `flakyCapture` and `flakyClassifier` and new tests covering capture retry, classification retry, and retry exhaustion behavior. 

### Testing

- Ran unit tests including `TestWorkerProcessStreamerRunsAllOrderedStages`, `TestWorkerProcessStreamerCleansUpChunkFileOnSuccess`, `TestWorkerProcessStreamerCleansUpChunkFileOnClassifierError`, `TestWorkerProcessStreamerRetriesCapture`, `TestWorkerProcessStreamerRetriesStageClassification`, and `TestWorkerProcessStreamerReturnsErrorAfterRetryExhausted`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa59b7d08832c9cadd4d4678d9b8e)