### PR TITLE
Add Gemini stage classifier integration, config, docs and tests

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	streamWorker := media.NewWorker(
 		buildStreamCapture(cfg, streamersService),
-		media.PromptedStageClassifier{},
+		buildStageClassifier(logger, cfg),
 		promptsService,
 		&media.InMemoryRunStore{},
 		streamersService,
@@ -202,6 +202,25 @@ func buildStreamCapture(cfg config.Config, streamersService *streamers.Service) 
 		OutputDir:      cfg.Streamlink.OutputDir,
 		URLTemplate:    cfg.Streamlink.URLTemplate,
 	}, streamersService, nil)
+}
+
+func buildStageClassifier(logger *zap.Logger, cfg config.Config) media.StageClassifier {
+	if cfg.Gemini.APIKey == "" {
+		logger.Warn("gemini api key is not configured; using deterministic fallback classifier")
+		return media.PromptedStageClassifier{}
+	}
+
+	classifier, err := media.NewGeminiStageClassifier(media.GeminiClassifierConfig{
+		APIKey:         cfg.Gemini.APIKey,
+		BaseURL:        cfg.Gemini.BaseURL,
+		MaxInlineBytes: cfg.Gemini.MaxInlineBytes,
+	})
+	if err != nil {
+		logger.Warn("failed to configure gemini classifier; using deterministic fallback classifier", zap.Error(err))
+		return media.PromptedStageClassifier{}
+	}
+
+	return classifier
 }
 
 func newLogger(level string) (*zap.Logger, error) {

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -45,6 +45,9 @@ FUNPOT_STREAMLINK_QUALITY=best
 FUNPOT_STREAMLINK_CAPTURE_TIMEOUT=12s
 FUNPOT_STREAMLINK_OUTPUT_DIR=tmp/stream_chunks
 FUNPOT_STREAMLINK_URL_TEMPLATE=https://twitch.tv/%s
+FUNPOT_GEMINI_API_KEY=<google_ai_studio_api_key>
+FUNPOT_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
+FUNPOT_GEMINI_MAX_INLINE_BYTES=19922944
 FUNPOT_ADMIN_USER_IDS=<admin_user_uuid_1>,<admin_user_uuid_2>
 FUNPOT_DATABASE_ENABLED=true
 FUNPOT_DATABASE_HOST=localhost
@@ -73,6 +76,10 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 
 > `FUNPOT_STREAMLINK_ENABLED=true` requires the `streamlink` binary to be
 > available in PATH (or pointed to by `FUNPOT_STREAMLINK_BINARY`).
+
+> Set `FUNPOT_GEMINI_API_KEY` to enable real Gemini stage classification. When
+> it is unset, the server falls back to the deterministic placeholder
+> classifier used in early development.
 
 Update this table whenever you introduce a new configuration surface.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Redis       RedisConfig
 	Database    DatabaseConfig
 	Streamlink  StreamlinkConfig
+	Gemini      GeminiConfig
 	Features    FeatureConfig
 	Client      ClientConfig
 }
@@ -35,6 +36,13 @@ type StreamlinkConfig struct {
 	CaptureTimeout time.Duration
 	OutputDir      string
 	URLTemplate    string
+}
+
+// GeminiConfig controls outbound Gemini API integration for stage classification.
+type GeminiConfig struct {
+	APIKey         string
+	BaseURL        string
+	MaxInlineBytes int64
 }
 
 // AdminConfig controls role-based admin access.
@@ -291,6 +299,11 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 
+	geminiMaxInlineBytes, err := getInt64("FUNPOT_GEMINI_MAX_INLINE_BYTES", 19*1024*1024)
+	if err != nil {
+		return Config{}, err
+	}
+
 	featureFlags, err := getFeatureFlags("FUNPOT_FEATURE_FLAGS")
 	if err != nil {
 		return Config{}, err
@@ -408,6 +421,11 @@ func Load() (Config, error) {
 			OutputDir:      getString("FUNPOT_STREAMLINK_OUTPUT_DIR", "tmp/stream_chunks"),
 			URLTemplate:    getString("FUNPOT_STREAMLINK_URL_TEMPLATE", "https://twitch.tv/%s"),
 		},
+		Gemini: GeminiConfig{
+			APIKey:         os.Getenv("FUNPOT_GEMINI_API_KEY"),
+			BaseURL:        getString("FUNPOT_GEMINI_BASE_URL", "https://generativelanguage.googleapis.com"),
+			MaxInlineBytes: geminiMaxInlineBytes,
+		},
 		Features: FeatureConfig{
 			Flags: featureFlags,
 		},
@@ -462,6 +480,10 @@ func Load() (Config, error) {
 		}
 	}
 
+	if cfg.Gemini.MaxInlineBytes < 1 {
+		return Config{}, fmt.Errorf("FUNPOT_GEMINI_MAX_INLINE_BYTES must be > 0")
+	}
+
 	return cfg, nil
 }
 func getString(key, fallback string) string {
@@ -509,6 +531,17 @@ func getInt(key string, fallback int) (int, error) {
 		parsed, err := strconv.Atoi(value)
 		if err != nil {
 			return 0, fmt.Errorf("invalid int for %s: %w", key, err)
+		}
+		return parsed, nil
+	}
+	return fallback, nil
+}
+
+func getInt64(key string, fallback int64) (int64, error) {
+	if value := os.Getenv(key); value != "" {
+		parsed, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid int64 for %s: %w", key, err)
 		}
 		return parsed, nil
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,6 +43,9 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	t.Setenv("FUNPOT_STREAMLINK_CAPTURE_TIMEOUT", "14s")
 	t.Setenv("FUNPOT_STREAMLINK_OUTPUT_DIR", "tmp/chunks")
 	t.Setenv("FUNPOT_STREAMLINK_URL_TEMPLATE", "https://twitch.tv/%s")
+	t.Setenv("FUNPOT_GEMINI_API_KEY", "test-gemini-key")
+	t.Setenv("FUNPOT_GEMINI_BASE_URL", "https://example.test")
+	t.Setenv("FUNPOT_GEMINI_MAX_INLINE_BYTES", "123456")
 
 	cfg, err := Load()
 	if err != nil {
@@ -133,6 +136,15 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	if cfg.Streamlink.CaptureTimeout != 14*time.Second {
 		t.Fatalf("expected streamlink capture timeout 14s, got %s", cfg.Streamlink.CaptureTimeout)
 	}
+	if cfg.Gemini.APIKey != "test-gemini-key" {
+		t.Fatalf("expected gemini api key to be set")
+	}
+	if cfg.Gemini.BaseURL != "https://example.test" {
+		t.Fatalf("expected gemini base url to be set")
+	}
+	if cfg.Gemini.MaxInlineBytes != 123456 {
+		t.Fatalf("expected gemini max inline bytes to be set")
+	}
 }
 
 func TestLoadDatabaseValidation(t *testing.T) {
@@ -191,6 +203,12 @@ func TestLoadDatabaseValidation(t *testing.T) {
 			env: map[string]string{
 				"FUNPOT_STREAMLINK_ENABLED":      "true",
 				"FUNPOT_STREAMLINK_URL_TEMPLATE": "https://twitch.tv/channel",
+			},
+		},
+		{
+			name: "invalid gemini inline limit",
+			env: map[string]string{
+				"FUNPOT_GEMINI_MAX_INLINE_BYTES": "0",
 			},
 		},
 	}

--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -1,0 +1,305 @@
+package media
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrGeminiAPIKeyRequired    = errors.New("gemini api key is required")
+	ErrGeminiChunkRequired     = errors.New("gemini chunk reference is required")
+	ErrGeminiChunkTooLarge     = errors.New("gemini chunk exceeds inline upload limit")
+	ErrGeminiEmptyResponse     = errors.New("gemini returned empty response")
+	ErrGeminiInvalidConfidence = errors.New("gemini confidence must be between 0 and 1")
+)
+
+type GeminiClassifierConfig struct {
+	APIKey         string
+	BaseURL        string
+	MaxInlineBytes int64
+	HTTPClient     *http.Client
+}
+
+type GeminiStageClassifier struct {
+	apiKey         string
+	baseURL        string
+	maxInlineBytes int64
+	httpClient     *http.Client
+}
+
+func NewGeminiStageClassifier(cfg GeminiClassifierConfig) (*GeminiStageClassifier, error) {
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return nil, ErrGeminiAPIKeyRequired
+	}
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		cfg.BaseURL = "https://generativelanguage.googleapis.com"
+	}
+	if cfg.MaxInlineBytes <= 0 {
+		cfg.MaxInlineBytes = 19 * 1024 * 1024
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &GeminiStageClassifier{
+		apiKey:         strings.TrimSpace(cfg.APIKey),
+		baseURL:        strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/"),
+		maxInlineBytes: cfg.MaxInlineBytes,
+		httpClient:     cfg.HTTPClient,
+	}, nil
+}
+
+type geminiGenerateContentRequest struct {
+	Contents         []geminiContent        `json:"contents"`
+	GenerationConfig geminiGenerationConfig `json:"generationConfig"`
+}
+
+type geminiContent struct {
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text       string            `json:"text,omitempty"`
+	InlineData *geminiInlineData `json:"inlineData,omitempty"`
+}
+
+type geminiInlineData struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"`
+}
+
+type geminiGenerationConfig struct {
+	Temperature      float64 `json:"temperature,omitempty"`
+	MaxOutputTokens  int     `json:"maxOutputTokens,omitempty"`
+	ResponseMIMEType string  `json:"responseMimeType,omitempty"`
+}
+
+type geminiGenerateContentResponse struct {
+	Candidates     []geminiCandidate    `json:"candidates"`
+	UsageMetadata  geminiUsageMetadata  `json:"usageMetadata"`
+	PromptFeedback geminiPromptFeedback `json:"promptFeedback"`
+}
+
+type geminiPromptFeedback struct {
+	BlockReason string `json:"blockReason"`
+}
+
+type geminiCandidate struct {
+	Content      geminiContentResponse `json:"content"`
+	FinishReason string                `json:"finishReason"`
+}
+
+type geminiContentResponse struct {
+	Parts []geminiPartResponse `json:"parts"`
+}
+
+type geminiPartResponse struct {
+	Text string `json:"text"`
+}
+
+type geminiUsageMetadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
+}
+
+type geminiStageResponse struct {
+	Label      string  `json:"label"`
+	Confidence float64 `json:"confidence"`
+	Summary    string  `json:"summary,omitempty"`
+}
+
+func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest) (StageClassification, error) {
+	chunkRef := strings.TrimSpace(input.Chunk.Reference)
+	if chunkRef == "" {
+		return StageClassification{}, ErrGeminiChunkRequired
+	}
+	data, mimeType, err := loadGeminiChunk(chunkRef, c.maxInlineBytes)
+	if err != nil {
+		return StageClassification{}, err
+	}
+
+	requestBody := geminiGenerateContentRequest{
+		Contents: []geminiContent{{
+			Parts: []geminiPart{
+				{Text: buildGeminiInstruction(input)},
+				{InlineData: &geminiInlineData{MimeType: mimeType, Data: base64.StdEncoding.EncodeToString(data)}},
+			},
+		}},
+		GenerationConfig: geminiGenerationConfig{
+			Temperature:      input.Prompt.Temperature,
+			MaxOutputTokens:  input.Prompt.MaxTokens,
+			ResponseMIMEType: "application/json",
+		},
+	}
+
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return StageClassification{}, err
+	}
+
+	model := strings.TrimSpace(input.Prompt.Model)
+	if model == "" {
+		model = "gemini-2.0-flash"
+	}
+
+	requestCtx := ctx
+	cancel := func() {}
+	if input.Prompt.TimeoutMS > 0 {
+		requestCtx, cancel = context.WithTimeout(ctx, time.Duration(input.Prompt.TimeoutMS)*time.Millisecond)
+	}
+	defer cancel()
+
+	endpoint := fmt.Sprintf("%s/v1beta/models/%s:generateContent?key=%s", c.baseURL, model, c.apiKey)
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return StageClassification{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	started := time.Now()
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return StageClassification{}, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		return StageClassification{}, err
+	}
+	if resp.StatusCode >= 400 {
+		return StageClassification{}, fmt.Errorf("gemini generateContent failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(responseBody)))
+	}
+
+	var payload geminiGenerateContentResponse
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
+		return StageClassification{}, fmt.Errorf("decode gemini response: %w", err)
+	}
+	rawText := extractGeminiResponseText(payload)
+	if rawText == "" {
+		if payload.PromptFeedback.BlockReason != "" {
+			return StageClassification{}, fmt.Errorf("gemini blocked prompt: %s", payload.PromptFeedback.BlockReason)
+		}
+		return StageClassification{}, ErrGeminiEmptyResponse
+	}
+
+	parsed, err := parseGeminiStageResponse(rawText)
+	if err != nil {
+		return StageClassification{}, err
+	}
+	if parsed.Confidence < 0 || parsed.Confidence > 1 {
+		return StageClassification{}, ErrGeminiInvalidConfidence
+	}
+
+	return StageClassification{
+		Label:       strings.TrimSpace(parsed.Label),
+		Confidence:  parsed.Confidence,
+		RawResponse: strings.TrimSpace(rawText),
+		TokensIn:    payload.UsageMetadata.PromptTokenCount,
+		TokensOut:   payload.UsageMetadata.CandidatesTokenCount,
+		Latency:     time.Since(started),
+	}, nil
+}
+
+func buildGeminiInstruction(input StageRequest) string {
+	return strings.TrimSpace(fmt.Sprintf(`You analyze a livestream chunk for FunPot.
+Stage: %s
+Return ONLY valid JSON with keys: label, confidence, summary.
+- label: short snake_case decision for this stage.
+- confidence: number between 0 and 1.
+- summary: short rationale.
+Use this stage prompt as the source of truth:
+%s`, input.Stage, strings.TrimSpace(input.Prompt.Template)))
+}
+
+func loadGeminiChunk(path string, maxBytes int64) ([]byte, string, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, "", err
+	}
+	if maxBytes > 0 && stat.Size() > maxBytes {
+		return nil, "", fmt.Errorf("%w: size=%d limit=%d", ErrGeminiChunkTooLarge, stat.Size(), maxBytes)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", err
+	}
+	return data, detectChunkMimeType(path), nil
+}
+
+func detectChunkMimeType(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".ts":
+		return "video/mp2t"
+	case ".mp4":
+		return "video/mp4"
+	case ".mp3":
+		return "audio/mpeg"
+	case ".wav":
+		return "audio/wav"
+	}
+	if mimeType := mime.TypeByExtension(ext); mimeType != "" {
+		return mimeType
+	}
+	return "application/octet-stream"
+}
+
+func extractGeminiResponseText(payload geminiGenerateContentResponse) string {
+	for _, candidate := range payload.Candidates {
+		for _, part := range candidate.Content.Parts {
+			if strings.TrimSpace(part.Text) != "" {
+				return strings.TrimSpace(part.Text)
+			}
+		}
+	}
+	return ""
+}
+
+func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {
+	cleaned := strings.TrimSpace(raw)
+	cleaned = strings.TrimPrefix(cleaned, "```json")
+	cleaned = strings.TrimPrefix(cleaned, "```")
+	cleaned = strings.TrimSuffix(cleaned, "```")
+	cleaned = strings.TrimSpace(cleaned)
+
+	var parsed geminiStageResponse
+	if err := json.Unmarshal([]byte(cleaned), &parsed); err == nil {
+		if strings.TrimSpace(parsed.Label) != "" {
+			return parsed, nil
+		}
+	}
+
+	var generic map[string]any
+	if err := json.Unmarshal([]byte(cleaned), &generic); err != nil {
+		return geminiStageResponse{}, fmt.Errorf("parse gemini stage response: %w", err)
+	}
+	parsed.Label = strings.TrimSpace(fmt.Sprint(generic["label"]))
+	parsed.Summary = strings.TrimSpace(fmt.Sprint(generic["summary"]))
+	switch value := generic["confidence"].(type) {
+	case float64:
+		parsed.Confidence = value
+	case string:
+		confidence, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if err != nil {
+			return geminiStageResponse{}, fmt.Errorf("parse gemini confidence: %w", err)
+		}
+		parsed.Confidence = confidence
+	}
+	if parsed.Label == "" {
+		return geminiStageResponse{}, ErrGeminiEmptyResponse
+	}
+	return parsed, nil
+}

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -1,0 +1,128 @@
+package media
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/funpot/funpot-go-core/internal/prompts"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestNewGeminiStageClassifierRequiresAPIKey(t *testing.T) {
+	if _, err := NewGeminiStageClassifier(GeminiClassifierConfig{}); err == nil {
+		t.Fatal("expected missing api key error")
+	}
+}
+
+func TestGeminiStageClassifierClassify(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.ts")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	var gotBody string
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			gotBody = string(body)
+			if req.URL.String() != "https://gemini.test/v1beta/models/gemini-2.0-flash:generateContent?key=gemini-key" {
+				return nil, fmt.Errorf("unexpected url %s", req.URL.String())
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"label\":\"cs_detected\",\"confidence\":0.93,\"summary\":\"Counter-Strike HUD visible\"}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	result, err := classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "detector",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt: prompts.PromptVersion{
+			Stage:       "detector",
+			Template:    "Detect the game being played",
+			Model:       "gemini-2.0-flash",
+			Temperature: 0.2,
+			MaxTokens:   128,
+			TimeoutMS:   1000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+	if result.Label != "cs_detected" {
+		t.Fatalf("expected label cs_detected, got %q", result.Label)
+	}
+	if result.Confidence != 0.93 {
+		t.Fatalf("expected confidence 0.93, got %v", result.Confidence)
+	}
+	if result.TokensIn != 111 || result.TokensOut != 22 {
+		t.Fatalf("unexpected token usage: in=%d out=%d", result.TokensIn, result.TokensOut)
+	}
+	if !strings.Contains(gotBody, `"mimeType":"video/mp2t"`) {
+		t.Fatalf("expected transport stream mime type in request body: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, "Detect the game being played") {
+		t.Fatalf("expected prompt template in request body: %s", gotBody)
+	}
+}
+
+func TestGeminiStageClassifierRejectsLargeChunk(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.ts")
+	if err := os.WriteFile(chunkPath, []byte("12345"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:         "gemini-key",
+		BaseURL:        "https://gemini.test",
+		MaxInlineBytes: 4,
+		HTTPClient:     &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, fmt.Errorf("unexpected request") })},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	_, err = classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "detector",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt: prompts.PromptVersion{
+			Stage:     "detector",
+			Template:  "Detect the game being played",
+			Model:     "gemini-2.0-flash",
+			MaxTokens: 128,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), ErrGeminiChunkTooLarge.Error()) {
+		t.Fatalf("expected large chunk error, got %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation

- Enable optional use of Google Gemini (Generative Language) to perform stage classification on livestream chunks when an API key is provided, falling back to the deterministic classifier otherwise.

### Description

- Add `GeminiConfig` to `internal/config` and parse `FUNPOT_GEMINI_API_KEY`, `FUNPOT_GEMINI_BASE_URL`, and `FUNPOT_GEMINI_MAX_INLINE_BYTES`, including validation and a new `getInt64` helper. 
- Implement `GeminiStageClassifier` in `internal/media/gemini.go` with inline chunk upload, request/response parsing, error handling, and `NewGeminiStageClassifier` constructor. 
- Wire runtime selection in `cmd/server/main.go` via a new `buildStageClassifier` helper that returns a `GeminiStageClassifier` when configured or falls back to `media.PromptedStageClassifier`. 
- Update local setup docs (`docs/local_setup.md`) to document the new environment variables and add unit tests for the classifier and config (`internal/media/gemini_test.go`, updates to `internal/config/config_test.go`).

### Testing

- Ran `go test ./...` which executed unit tests including `TestNewGeminiStageClassifierRequiresAPIKey`, `TestGeminiStageClassifierClassify`, `TestGeminiStageClassifierRejectsLargeChunk`, and updated config tests such as `TestLoadDatabaseConfig` and validation cases, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa90742f4832c9169807f8bfb25cd)