### PR TITLE
Auto-activate initial stream prompt and preserve prompt position

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -606,6 +606,7 @@ func NewHandler(
 					}
 					created, err := promptsService.Create(r.Context(), prompts.CreateRequest{
 						Stage:         req.Stage,
+						Position:      req.Position,
 						Template:      req.Template,
 						Model:         req.Model,
 						Temperature:   req.Temperature,

--- a/internal/app/router_prompts_test.go
+++ b/internal/app/router_prompts_test.go
@@ -58,6 +58,12 @@ func TestAdminPromptsCreateListAndActivate(t *testing.T) {
 	if id == "" {
 		t.Fatal("expected created prompt id")
 	}
+	if created["isActive"] != true {
+		t.Fatalf("expected first created prompt to be active automatically, got %#v", created["isActive"])
+	}
+	if position, ok := created["position"].(float64); !ok || int(position) != 1 {
+		t.Fatalf("expected position 1 in response, got %#v", created["position"])
+	}
 
 	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/prompts", nil)
 	listReq.Header.Set("Authorization", "Bearer "+token)

--- a/internal/prompts/service.go
+++ b/internal/prompts/service.go
@@ -108,6 +108,11 @@ func (s *Service) Create(_ context.Context, req CreateRequest) (PromptVersion, e
 		CreatedBy:     strings.TrimSpace(req.ActorID),
 		CreatedAt:     now,
 	}
+	if len(s.versions[stage]) == 0 {
+		item.IsActive = true
+		item.ActivatedAt = now
+		item.ActivatedBy = strings.TrimSpace(req.ActorID)
+	}
 	s.versions[stage] = append(s.versions[stage], item)
 	return item, nil
 }

--- a/internal/prompts/service_test.go
+++ b/internal/prompts/service_test.go
@@ -30,6 +30,9 @@ func TestCreateAndActivate(t *testing.T) {
 	if created.Position != 1 {
 		t.Fatalf("expected position 1, got %d", created.Position)
 	}
+	if !created.IsActive {
+		t.Fatal("expected first prompt version to become active automatically")
+	}
 
 	active, err := svc.Activate(context.Background(), created.ID, "admin-1")
 	if err != nil {
@@ -92,5 +95,32 @@ func TestListActiveOrdersByPosition(t *testing.T) {
 	}
 	if items[0].Stage != "detector" || items[1].Stage != "queue" || items[2].Stage != "result" {
 		t.Fatalf("unexpected order: %#v", items)
+	}
+}
+
+func TestCreateAutoActivatesFirstPromptPerStageOnly(t *testing.T) {
+	svc := NewService()
+	first, err := svc.Create(context.Background(), CreateRequest{Stage: "detector", Position: 1, Template: "first", Model: "m", Temperature: 0.1, MaxTokens: 1, TimeoutMS: 1, MinConfidence: 0.4, ActorID: "admin-1"})
+	if err != nil {
+		t.Fatalf("Create(first) error = %v", err)
+	}
+	second, err := svc.Create(context.Background(), CreateRequest{Stage: "detector", Position: 1, Template: "second", Model: "m", Temperature: 0.1, MaxTokens: 1, TimeoutMS: 1, MinConfidence: 0.4, ActorID: "admin-2"})
+	if err != nil {
+		t.Fatalf("Create(second) error = %v", err)
+	}
+
+	if !first.IsActive {
+		t.Fatal("expected first prompt to be active")
+	}
+	if second.IsActive {
+		t.Fatal("expected later prompt versions to require explicit activation")
+	}
+
+	active, err := svc.GetActiveByStage(context.Background(), "detector")
+	if err != nil {
+		t.Fatalf("GetActiveByStage() error = %v", err)
+	}
+	if active.ID != first.ID {
+		t.Fatalf("active id = %q, want %q", active.ID, first.ID)
 	}
 }


### PR DESCRIPTION
### Motivation
- Streamer analysis was not starting when only one prompt existed because the worker only processes active prompts and the first created prompt remained inactive. 
- The admin API did not preserve a submitted `position`, which could break prompt ordering used by orchestration.

### Description
- Make the first `PromptVersion` created for a given `stage` auto-active by setting `IsActive`, `ActivatedAt`, and `ActivatedBy` in `internal/prompts/service.go` when no prior versions exist. 
- Preserve the `position` submitted via the admin endpoint by forwarding `req.Position` into `prompts.Create` in `internal/app/router.go`. 
- Add coverage to verify the new behavior in `internal/prompts/service_test.go` and the handler test in `internal/app/router_prompts_test.go`.

### Testing
- Ran unit tests with `go test` for the affected packages and they passed: `./internal/prompts`, `./internal/app`, `./internal/streamers`, and `./internal/media` all succeeded. 
- Implementation-plan checklist (M2.1) status aligned to this change: 
  - [x] Auto-start Streamlink analysis job after `POST /api/streamers` success. 
  - [ ] Fixed 10-second capture cadence with lock/idempotency protections. 
  - [x] Resolve the active global game-detection prompt from admin configuration. 
  - [x] Resolve the active per-game scenario and the active prompt for its current step. 
  - [x] Worker payload includes prompt text + runtime params (model, temperature, token limits) for the resolved step. 
  - [ ] Persist chunk metadata, LLM request/response refs, normalized stage decision, confidence, and transition outcome. 
  - [ ] Publish realtime `LLM_STAGE_UPDATED` events and provide REST backfill/history. 
  - [ ] Add retry/backoff + DLQ behavior for Streamlink and LLM failures. 
  - [ ] Add observability for chunk lag, stage latency, and per-streamer failure rate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babad6e1c0832cb6b818e367019e24)