### PR TITLE
Add detailed logging for streamer onboarding, capture, scheduler and worker

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -105,12 +105,18 @@ func main() {
 	userService := users.NewService(userRepo)
 	adminService := admin.NewService(cfg.Admin.UserIDs)
 	streamersService := streamers.NewService()
+	streamersService.SetLogger(logger.Named("streamers"))
 	gamesService := games.NewService()
 	promptsService := prompts.NewService()
 	eventsService := events.NewService(nil)
 
+	streamCapture := buildStreamCapture(cfg, streamersService)
+	if configurableCapture, ok := streamCapture.(interface{ SetLogger(*zap.Logger) }); ok {
+		configurableCapture.SetLogger(logger.Named("stream_capture"))
+	}
+
 	streamWorker := media.NewWorker(
-		buildStreamCapture(cfg, streamersService),
+		streamCapture,
 		buildStageClassifier(logger, cfg),
 		promptsService,
 		&media.InMemoryRunStore{},
@@ -118,7 +124,9 @@ func main() {
 		media.NewInMemoryLocker(),
 		media.WorkerConfig{LockTTL: 15 * time.Second, MinConfidence: 0.5},
 	)
+	streamWorker.SetLogger(logger.Named("stream_worker"))
 	streamScheduler := media.NewScheduler(streamWorker, 10*time.Second)
+	streamScheduler.SetLogger(logger.Named("stream_scheduler"))
 	streamersService.SetSubmissionHook(func(_ context.Context, streamerID string) error {
 		return streamScheduler.Start(streamerID)
 	})

--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 var (
@@ -48,6 +50,7 @@ type StreamlinkCaptureConfig struct {
 // StreamlinkCaptureAdapter captures live stream bytes via streamlink and stores each
 // polling cycle into a local chunk file reference.
 type StreamlinkCaptureAdapter struct {
+	logger   *zap.Logger
 	cfg      StreamlinkCaptureConfig
 	resolver StreamlinkChannelResolver
 	runner   StreamlinkCommandRunner
@@ -73,26 +76,46 @@ func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver Streamlin
 	if runner == nil {
 		runner = execStreamlinkRunner{}
 	}
-	return &StreamlinkCaptureAdapter{cfg: cfg, resolver: resolver, runner: runner, nowFn: time.Now}
+	return &StreamlinkCaptureAdapter{logger: zap.NewNop(), cfg: cfg, resolver: resolver, runner: runner, nowFn: time.Now}
+}
+
+func (a *StreamlinkCaptureAdapter) SetLogger(logger *zap.Logger) {
+	if a == nil {
+		return
+	}
+	if logger == nil {
+		a.logger = zap.NewNop()
+		return
+	}
+	a.logger = logger
 }
 
 func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID string) (ChunkRef, error) {
+	logger := a.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	id := strings.TrimSpace(streamerID)
 	if id == "" {
+		logger.Warn("stream capture rejected empty streamer id")
 		return ChunkRef{}, ErrStreamerIDRequired
 	}
+	logger.Info("starting stream capture", zap.String("streamerID", id))
 
 	channel := id
 	if a.resolver != nil {
 		resolved, err := a.resolver.ResolveStreamlinkChannel(ctx, id)
 		if err != nil {
+			logger.Error("failed to resolve streamlink channel", zap.String("streamerID", id), zap.Error(err))
 			return ChunkRef{}, fmt.Errorf("%w: %v", ErrStreamlinkChannelResolve, err)
 		}
 		channel = strings.TrimSpace(resolved)
 	}
 	if channel == "" {
+		logger.Warn("stream capture resolved empty channel", zap.String("streamerID", id))
 		return ChunkRef{}, fmt.Errorf("%w: empty channel", ErrStreamlinkChannelResolve)
 	}
+	logger.Info("stream capture channel resolved", zap.String("streamerID", id), zap.String("channel", channel))
 
 	chunkDir := filepath.Join(a.cfg.OutputDir, sanitizeToken(id))
 	if err := os.MkdirAll(chunkDir, 0o755); err != nil {
@@ -114,6 +137,7 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 	args := []string{"--stdout", streamURL, a.cfg.Quality}
 
 	var stderr strings.Builder
+	logger.Info("executing streamlink capture", zap.String("streamerID", id), zap.String("binaryPath", a.cfg.BinaryPath), zap.String("streamURL", streamURL), zap.String("quality", a.cfg.Quality), zap.String("chunkPath", chunkPath))
 	runErr := a.runner.Run(captureCtx, file, &stderr, a.cfg.BinaryPath, args...)
 
 	stat, err := file.Stat()
@@ -121,6 +145,7 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 		return ChunkRef{}, err
 	}
 	if stat.Size() <= 0 {
+		logger.Warn("stream capture produced empty chunk", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.String("stderr", strings.TrimSpace(stderr.String())), zap.Error(runErr))
 		if runErr != nil {
 			return ChunkRef{}, fmt.Errorf("%w: %v (stderr=%s)", ErrStreamlinkNoData, runErr, strings.TrimSpace(stderr.String()))
 		}
@@ -128,9 +153,11 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 	}
 
 	if runErr != nil && !errors.Is(captureCtx.Err(), context.DeadlineExceeded) && !errors.Is(runErr, context.DeadlineExceeded) {
+		logger.Error("streamlink capture command failed", zap.String("streamerID", id), zap.String("stderr", strings.TrimSpace(stderr.String())), zap.Error(runErr))
 		return ChunkRef{}, fmt.Errorf("streamlink command failed: %w (stderr=%s)", runErr, strings.TrimSpace(stderr.String()))
 	}
 
+	logger.Info("stream capture completed", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.Int64("bytes", stat.Size()))
 	return ChunkRef{Reference: chunkPath}, nil
 }
 

--- a/internal/media/scheduler.go
+++ b/internal/media/scheduler.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 var ErrSchedulerStreamerIDRequired = errors.New("streamerID is required")
@@ -24,6 +26,7 @@ func (a streamProcessorAdapter) ProcessStreamer(ctx context.Context, streamerID 
 }
 
 type Scheduler struct {
+	logger    *zap.Logger
 	processor StreamProcessor
 	interval  time.Duration
 
@@ -42,30 +45,55 @@ func NewSchedulerWithProcessor(processor StreamProcessor, interval time.Duration
 	if interval <= 0 {
 		interval = 10 * time.Second
 	}
-	return &Scheduler{processor: processor, interval: interval, jobs: make(map[string]context.CancelFunc)}
+	return &Scheduler{logger: zap.NewNop(), processor: processor, interval: interval, jobs: make(map[string]context.CancelFunc)}
+}
+
+func (s *Scheduler) SetLogger(logger *zap.Logger) {
+	if s == nil {
+		return
+	}
+	if logger == nil {
+		s.logger = zap.NewNop()
+		return
+	}
+	s.logger = logger
 }
 
 func (s *Scheduler) Start(streamerID string) error {
+	logger := s.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	id := strings.TrimSpace(streamerID)
 	if id == "" {
+		logger.Warn("scheduler rejected empty streamer id")
 		return ErrSchedulerStreamerIDRequired
 	}
 
 	s.mu.Lock()
 	if _, exists := s.jobs[id]; exists {
 		s.mu.Unlock()
+		logger.Info("scheduler already running for streamer", zap.String("streamerID", id))
 		return nil
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	s.jobs[id] = cancel
 	s.mu.Unlock()
 
+	logger.Info("scheduler started for streamer", zap.String("streamerID", id), zap.Duration("interval", s.interval))
 	go s.run(ctx, id)
 	return nil
 }
 
 func (s *Scheduler) run(ctx context.Context, streamerID string) {
-	defer s.remove(streamerID)
+	logger := s.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	defer func() {
+		s.remove(streamerID)
+		logger.Info("scheduler stopped for streamer", zap.String("streamerID", streamerID))
+	}()
 
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
@@ -74,6 +102,7 @@ func (s *Scheduler) run(ctx context.Context, streamerID string) {
 	for {
 		select {
 		case <-ctx.Done():
+			logger.Info("scheduler context cancelled", zap.String("streamerID", streamerID))
 			return
 		case <-ticker.C:
 			s.runCycle(ctx, streamerID)
@@ -82,10 +111,20 @@ func (s *Scheduler) run(ctx context.Context, streamerID string) {
 }
 
 func (s *Scheduler) runCycle(ctx context.Context, streamerID string) {
+	logger := s.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	if s.processor == nil {
+		logger.Warn("scheduler skipped cycle because processor is not configured", zap.String("streamerID", streamerID))
 		return
 	}
-	_ = s.processor.ProcessStreamer(ctx, streamerID)
+	logger.Info("scheduler cycle triggered", zap.String("streamerID", streamerID))
+	if err := s.processor.ProcessStreamer(ctx, streamerID); err != nil {
+		logger.Error("scheduler cycle failed", zap.String("streamerID", streamerID), zap.Error(err))
+		return
+	}
+	logger.Info("scheduler cycle completed", zap.String("streamerID", streamerID))
 }
 
 func (s *Scheduler) Stop(streamerID string) {

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/funpot/funpot-go-core/internal/prompts"
 	"github.com/funpot/funpot-go-core/internal/streamers"
 )
@@ -64,6 +66,7 @@ type Locker interface {
 }
 
 type Worker struct {
+	logger              *zap.Logger
 	capture             StreamCapture
 	classifier          StageClassifier
 	prompts             PromptResolver
@@ -98,6 +101,7 @@ func NewWorker(capture StreamCapture, classifier StageClassifier, promptResolver
 		cfg.CaptureRetryBackoff = 0
 	}
 	return &Worker{
+		logger:              zap.NewNop(),
 		capture:             capture,
 		classifier:          classifier,
 		prompts:             promptResolver,
@@ -112,39 +116,71 @@ func NewWorker(capture StreamCapture, classifier StageClassifier, promptResolver
 	}
 }
 
+func (w *Worker) SetLogger(logger *zap.Logger) {
+	if w == nil {
+		return
+	}
+	if logger == nil {
+		w.logger = zap.NewNop()
+		return
+	}
+	w.logger = logger
+}
+
 func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (streamers.LLMDecision, error) {
+	logger := w.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	id := strings.TrimSpace(streamerID)
 	if id == "" {
+		logger.Warn("worker rejected empty streamer id")
 		return streamers.LLMDecision{}, ErrStreamerIDRequired
 	}
+	logger.Info("streamer processing cycle started", zap.String("streamerID", id))
 	lockKey := fmt.Sprintf("stream-capture:%s", id)
 	if !w.locker.TryLock(lockKey, w.lockTTL) {
+		logger.Info("streamer processing skipped because worker is busy", zap.String("streamerID", id), zap.String("lockKey", lockKey))
 		return streamers.LLMDecision{}, ErrStreamerBusy
 	}
-	defer w.locker.Unlock(lockKey)
+	logger.Info("streamer processing lock acquired", zap.String("streamerID", id), zap.String("lockKey", lockKey), zap.Duration("lockTTL", w.lockTTL))
+	defer func() {
+		w.locker.Unlock(lockKey)
+		logger.Info("streamer processing lock released", zap.String("streamerID", id), zap.String("lockKey", lockKey))
+	}()
 
 	runID, err := w.runs.CreateRun(ctx, id)
 	if err != nil {
+		logger.Error("failed to create analysis run", zap.String("streamerID", id), zap.Error(err))
 		return streamers.LLMDecision{}, err
 	}
+	logger.Info("analysis run created", zap.String("streamerID", id), zap.String("runID", runID))
 	activePrompts := w.prompts.ListActive(ctx)
 	if len(activePrompts) == 0 {
+		logger.Warn("no active prompts found for streamer processing", zap.String("streamerID", id))
 		return streamers.LLMDecision{}, prompts.ErrNotFound
 	}
+	logger.Info("active prompts loaded for streamer processing", zap.String("streamerID", id), zap.Int("promptCount", len(activePrompts)))
 	chunk, err := w.captureWithRetry(ctx, id)
 	if err != nil {
+		logger.Error("stream chunk capture failed", zap.String("streamerID", id), zap.Error(err))
 		return streamers.LLMDecision{}, err
 	}
+	logger.Info("stream chunk captured", zap.String("streamerID", id), zap.String("chunkRef", chunk.Reference))
 	defer cleanupChunkRef(chunk.Reference)
 
 	var lastDecision streamers.LLMDecision
 	for _, activePrompt := range activePrompts {
+		logger.Info("processing prompt stage", zap.String("streamerID", id), zap.String("runID", runID), zap.String("stage", activePrompt.Stage), zap.String("promptVersionID", activePrompt.ID))
 		decision, err := w.processStage(ctx, runID, id, chunk, activePrompt)
 		if err != nil {
+			logger.Error("prompt stage processing failed", zap.String("streamerID", id), zap.String("runID", runID), zap.String("stage", activePrompt.Stage), zap.Error(err))
 			return streamers.LLMDecision{}, err
 		}
+		logger.Info("prompt stage processed", zap.String("streamerID", id), zap.String("runID", runID), zap.String("stage", decision.Stage), zap.String("label", decision.Label), zap.Float64("confidence", decision.Confidence))
 		lastDecision = decision
 	}
+	logger.Info("streamer processing cycle completed", zap.String("streamerID", id), zap.String("runID", runID), zap.String("finalStage", lastDecision.Stage), zap.String("finalLabel", lastDecision.Label), zap.Float64("finalConfidence", lastDecision.Confidence))
 	return lastDecision, nil
 }
 

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 var (
@@ -39,6 +41,7 @@ type submissionLimit struct {
 }
 
 type Service struct {
+	logger         *zap.Logger
 	mu             sync.RWMutex
 	items          []Streamer
 	decisions      map[string][]LLMDecision
@@ -61,6 +64,7 @@ func NewServiceWithValidator(validator TwitchValidator) *Service {
 		validator = noopTwitchValidator{}
 	}
 	return &Service{
+		logger:         zap.NewNop(),
 		items:          []Streamer{},
 		decisions:      make(map[string][]LLMDecision),
 		validator:      validator,
@@ -69,6 +73,17 @@ func NewServiceWithValidator(validator TwitchValidator) *Service {
 			return time.Now().UTC()
 		},
 	}
+}
+
+func (s *Service) SetLogger(logger *zap.Logger) {
+	if s == nil {
+		return
+	}
+	if logger == nil {
+		s.logger = zap.NewNop()
+		return
+	}
+	s.logger = logger
 }
 
 func (s *Service) SetSubmissionHook(hook func(context.Context, string) error) {
@@ -140,7 +155,16 @@ func (s *Service) ResolveStreamlinkChannel(_ context.Context, streamerID string)
 
 func (s *Service) Submit(ctx context.Context, twitchUsername, addedBy string) (Submission, error) {
 	username := strings.TrimSpace(twitchUsername)
+	logger := s.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	logger.Info("streamer submission received",
+		zap.String("twitchUsername", username),
+		zap.String("addedBy", strings.TrimSpace(addedBy)),
+	)
 	if username == "" {
+		logger.Warn("streamer submission rejected: missing username", zap.String("addedBy", strings.TrimSpace(addedBy)))
 		return Submission{}, ErrInvalidUsername
 	}
 	if !IsSupportedStatus("pending") {
@@ -148,13 +172,16 @@ func (s *Service) Submit(ctx context.Context, twitchUsername, addedBy string) (S
 	}
 
 	if !s.allowSubmission(addedBy) {
+		logger.Warn("streamer submission rate limited", zap.String("twitchUsername", username), zap.String("addedBy", strings.TrimSpace(addedBy)))
 		return Submission{}, ErrRateLimited
 	}
 
 	displayName, err := s.validator.ValidateUsername(ctx, username)
 	if err != nil {
+		logger.Warn("streamer submission validation failed", zap.String("twitchUsername", username), zap.Error(err))
 		return Submission{}, fmt.Errorf("%w: %v", ErrTwitchUnavailable, err)
 	}
+	logger.Info("streamer submission validated", zap.String("twitchUsername", username), zap.String("displayName", displayName))
 
 	now := s.nowFn().UnixNano()
 	id := fmt.Sprintf("str_%d", now)
@@ -173,8 +200,12 @@ func (s *Service) Submit(ctx context.Context, twitchUsername, addedBy string) (S
 	s.items = append(s.items, streamer)
 	s.mu.Unlock()
 
+	logger.Info("streamer stored and awaiting worker scheduling", zap.String("streamerID", id), zap.String("status", streamer.Status))
+
 	if hook := s.submissionHook(); hook != nil {
+		logger.Info("starting streamer submission hook", zap.String("streamerID", id))
 		if err := hook(ctx, id); err != nil {
+			logger.Error("streamer submission hook failed", zap.String("streamerID", id), zap.Error(err))
 			s.mu.Lock()
 			if n := len(s.items); n > 0 && s.items[n-1].ID == id {
 				s.items = s.items[:n-1]
@@ -182,8 +213,10 @@ func (s *Service) Submit(ctx context.Context, twitchUsername, addedBy string) (S
 			s.mu.Unlock()
 			return Submission{}, err
 		}
+		logger.Info("streamer submission hook completed", zap.String("streamerID", id))
 	}
 
+	logger.Info("streamer submission completed", zap.String("streamerID", id), zap.String("status", "pending"))
 	return Submission{ID: id, Status: "pending", Reason: nil}, nil
 }
 


### PR DESCRIPTION
### Motivation
- Improve observability of the streamer onboarding -> analysis flow so operators can trace what happens when a new streamer is submitted and during subsequent automated analysis.

### Description
- Add structured `zap` logs and a `SetLogger` API to the streamer service to record submission receipt, validation, persistence, scheduler handoff, hook start/completion, and rollback on hook error (`internal/streamers/service.go`).
- Add `zap` lifecycle logs to the media worker to record lock acquisition/release, run creation, active prompt discovery, chunk capture results, per-stage prompt processing, and final decision output (`internal/media/worker.go`).
- Add scheduler lifecycle logs to the media scheduler for start/stop, cycle triggers, failures, and completions, plus a `SetLogger` method (`internal/media/scheduler.go`).
- Add detailed Streamlink capture logs for channel resolution, command execution, empty-chunk and failure cases, and successful chunk creation, and wire the main server logger into the capture/worker/scheduler/streamers components (`internal/media/adapters.go`, `cmd/server/main.go`).
- Checklist aligned with M2.1 from `docs/implementation_plan.md`: [x] after streamer added, handoff into scheduler/worker is logged; [x] 10s scheduler cycles are logged; [x] stream chunk capture attempts/outcomes are logged; [x] prompt-stage execution and final classification decisions are logged; [ ] persisted decision/publication behavior unchanged in this iteration.

### Testing
- Ran `go test -count=1 ./internal/streamers` and the package tests passed. 
- Ran `go test -count=1 ./internal/media` and the package tests passed. 
- Ran `go test -count=1 ./cmd/server` which timed out in this environment so server package checks were not fully completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babe9542d0832cb5165fcde56f1743)