### PR TITLE
Use Twitch nickname for streamer onboarding

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -153,7 +153,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/me` – returns the authenticated user's profile plus `isAdmin` flag when called with the issued JWT.
 - `GET /api/config` – exposes client configuration and feature flags for the authenticated user.
 - `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
-- `POST /api/streamers` – submits a Twitch streamer username for moderation/validation.
+- `POST /api/streamers` – submits a Twitch streamer nickname for moderation/validation and Streamlink usage.
 - `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM detector/scenario status for a streamer.
 - `GET /api/streamers/{streamerId}/llm-decisions?limit=` – returns recent detector/scenario decision history for a streamer.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -154,9 +154,9 @@ paths:
           application/json:
             schema:
               type: object
-              required: [twitchUsername]
+              required: [twitchNickname]
               properties:
-                twitchUsername:
+                twitchNickname:
                   type: string
       responses:
         '200':
@@ -677,12 +677,12 @@ paths:
           application/json:
             schema:
               type: object
-              required: [streamerId, twitchUsername]
+              required: [streamerId, twitchNickname]
               properties:
                 streamerId:
                   type: string
                   format: uuid
-                twitchUsername:
+                twitchNickname:
                   type: string
       responses:
         '200':
@@ -850,7 +850,7 @@ components:
         platform:
           type: string
           enum: [twitch]
-        username:
+        twitchNickname:
           type: string
         displayName:
           type: string

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -60,6 +60,7 @@ type configLimits struct {
 }
 
 type streamerSubmitRequest struct {
+	TwitchNickname string `json:"twitchNickname"`
 	TwitchUsername string `json:"twitchUsername"`
 }
 
@@ -358,7 +359,12 @@ func NewHandler(
 						writeError(w, http.StatusUnauthorized, "missing auth claims")
 						return
 					}
-					submission, err := streamersService.Submit(r.Context(), req.TwitchUsername, claims.Subject)
+					nickname := strings.TrimSpace(req.TwitchNickname)
+					if nickname == "" {
+						nickname = strings.TrimSpace(req.TwitchUsername)
+					}
+
+					submission, err := streamersService.Submit(r.Context(), nickname, claims.Subject)
 					if err != nil {
 						if errors.Is(err, streamers.ErrInvalidUsername) || errors.Is(err, streamers.ErrTwitchUnavailable) {
 							writeError(w, http.StatusBadRequest, err.Error())

--- a/internal/app/router_streamers_submit_test.go
+++ b/internal/app/router_streamers_submit_test.go
@@ -1,0 +1,84 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/funpot/funpot-go-core/internal/admin"
+	"github.com/funpot/funpot-go-core/internal/streamers"
+)
+
+func TestSubmitStreamerUsesTwitchNickname(t *testing.T) {
+	streamersService := streamers.NewService()
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamersService,
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	body := bytes.NewBufferString(`{"twitchNickname":"Best_Streamer"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/streamers", body)
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+
+	items := streamersService.List(req.Context(), "best_streamer", "pending", 1)
+	if len(items) != 1 {
+		t.Fatalf("expected one streamer, got %d", len(items))
+	}
+	if items[0].TwitchNickname != "best_streamer" {
+		t.Fatalf("expected stored twitchNickname best_streamer, got %q", items[0].TwitchNickname)
+	}
+}
+
+func TestSubmitStreamerFallsBackToLegacyTwitchUsername(t *testing.T) {
+	streamersService := streamers.NewService()
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamersService,
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	payload, _ := json.Marshal(map[string]string{"twitchUsername": "LegacyName"})
+	req := httptest.NewRequest(http.MethodPost, "/api/streamers", bytes.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+
+	items := streamersService.List(req.Context(), "legacyname", "pending", 1)
+	if len(items) != 1 {
+		t.Fatalf("expected one streamer, got %d", len(items))
+	}
+	if items[0].TwitchNickname != "legacyname" {
+		t.Fatalf("expected stored twitchNickname legacyname, got %q", items[0].TwitchNickname)
+	}
+}

--- a/internal/streamers/model.go
+++ b/internal/streamers/model.go
@@ -1,14 +1,14 @@
 package streamers
 
 type Streamer struct {
-	ID          string `json:"id"`
-	Platform    string `json:"platform"`
-	Username    string `json:"username"`
-	DisplayName string `json:"displayName"`
-	Online      bool   `json:"online"`
-	Viewers     int    `json:"viewers"`
-	AddedBy     string `json:"addedBy"`
-	Status      string `json:"status"`
+	ID             string `json:"id"`
+	Platform       string `json:"platform"`
+	TwitchNickname string `json:"twitchNickname"`
+	DisplayName    string `json:"displayName"`
+	Online         bool   `json:"online"`
+	Viewers        int    `json:"viewers"`
+	AddedBy        string `json:"addedBy"`
+	Status         string `json:"status"`
 }
 
 type Submission struct {

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	ErrInvalidUsername   = errors.New("twitchUsername is required")
+	ErrInvalidUsername   = errors.New("twitchNickname is required")
 	ErrInvalidStatus     = errors.New("status filter is invalid")
 	ErrRateLimited       = errors.New("submission rate limit exceeded")
 	ErrTwitchUnavailable = errors.New("failed to validate twitch username")
@@ -109,7 +109,7 @@ func (s *Service) List(_ context.Context, query, status string, page int) []Stre
 	statusFilter := strings.ToLower(strings.TrimSpace(status))
 	matches := make([]Streamer, 0, len(s.items))
 	for _, item := range s.items {
-		if needle != "" && !strings.Contains(strings.ToLower(item.Username), needle) && !strings.Contains(strings.ToLower(item.DisplayName), needle) {
+		if needle != "" && !strings.Contains(strings.ToLower(item.TwitchNickname), needle) && !strings.Contains(strings.ToLower(item.DisplayName), needle) {
 			continue
 		}
 		if statusFilter != "" && strings.ToLower(item.Status) != statusFilter {
@@ -143,8 +143,8 @@ func (s *Service) ResolveStreamlinkChannel(_ context.Context, streamerID string)
 
 	for _, item := range s.items {
 		if item.ID == id {
-			if username := strings.TrimSpace(item.Username); username != "" {
-				return username, nil
+			if nickname := strings.TrimSpace(item.TwitchNickname); nickname != "" {
+				return nickname, nil
 			}
 			break
 		}
@@ -153,17 +153,17 @@ func (s *Service) ResolveStreamlinkChannel(_ context.Context, streamerID string)
 	return "", ErrNotFound
 }
 
-func (s *Service) Submit(ctx context.Context, twitchUsername, addedBy string) (Submission, error) {
-	username := strings.TrimSpace(twitchUsername)
+func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (Submission, error) {
+	nickname := strings.TrimSpace(twitchNickname)
 	logger := s.logger
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 	logger.Info("streamer submission received",
-		zap.String("twitchUsername", username),
+		zap.String("twitchNickname", nickname),
 		zap.String("addedBy", strings.TrimSpace(addedBy)),
 	)
-	if username == "" {
+	if nickname == "" {
 		logger.Warn("streamer submission rejected: missing username", zap.String("addedBy", strings.TrimSpace(addedBy)))
 		return Submission{}, ErrInvalidUsername
 	}
@@ -172,28 +172,28 @@ func (s *Service) Submit(ctx context.Context, twitchUsername, addedBy string) (S
 	}
 
 	if !s.allowSubmission(addedBy) {
-		logger.Warn("streamer submission rate limited", zap.String("twitchUsername", username), zap.String("addedBy", strings.TrimSpace(addedBy)))
+		logger.Warn("streamer submission rate limited", zap.String("twitchNickname", nickname), zap.String("addedBy", strings.TrimSpace(addedBy)))
 		return Submission{}, ErrRateLimited
 	}
 
-	displayName, err := s.validator.ValidateUsername(ctx, username)
+	displayName, err := s.validator.ValidateUsername(ctx, nickname)
 	if err != nil {
-		logger.Warn("streamer submission validation failed", zap.String("twitchUsername", username), zap.Error(err))
+		logger.Warn("streamer submission validation failed", zap.String("twitchNickname", nickname), zap.Error(err))
 		return Submission{}, fmt.Errorf("%w: %v", ErrTwitchUnavailable, err)
 	}
-	logger.Info("streamer submission validated", zap.String("twitchUsername", username), zap.String("displayName", displayName))
+	logger.Info("streamer submission validated", zap.String("twitchNickname", nickname), zap.String("displayName", displayName))
 
 	now := s.nowFn().UnixNano()
 	id := fmt.Sprintf("str_%d", now)
 	streamer := Streamer{
-		ID:          id,
-		Platform:    "twitch",
-		Username:    strings.ToLower(username),
-		DisplayName: displayName,
-		Online:      false,
-		Viewers:     0,
-		AddedBy:     addedBy,
-		Status:      "pending",
+		ID:             id,
+		Platform:       "twitch",
+		TwitchNickname: strings.ToLower(nickname),
+		DisplayName:    displayName,
+		Online:         false,
+		Viewers:        0,
+		AddedBy:        addedBy,
+		Status:         "pending",
 	}
 
 	s.mu.Lock()

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -52,8 +52,8 @@ func TestServiceSubmitValidationAndListing(t *testing.T) {
 			if len(items) != 1 {
 				t.Fatalf("expected one result, got %d", len(items))
 			}
-			if items[0].Username != "best_streamer" {
-				t.Fatalf("unexpected username: %s", items[0].Username)
+			if items[0].TwitchNickname != "best_streamer" {
+				t.Fatalf("unexpected twitch nickname: %s", items[0].TwitchNickname)
 			}
 		})
 	}


### PR DESCRIPTION
### Motivation
- Streamlink requires a stable Twitch channel identifier when starting captures, so onboarding must persist the streamer's Twitch nickname for later resolution. 
- Align the public API and docs with the canonical field used by the media worker while preserving backward compatibility for existing clients.

### Description
- Change streamer model to expose `twitchNickname` and store the canonical Twitch channel identifier in `internal/streamers/model.go` as `TwitchNickname`.
- Update the submit flow in `internal/streamers/service.go` to accept `twitchNickname` (signature `Submit(ctx, twitchNickname, addedBy)`) and to validate/store the lowercased nickname for later `ResolveStreamlinkChannel` use. 
- Update the HTTP handler in `internal/app/router.go` to accept a new `twitchNickname` request field and fall back to legacy `twitchUsername` when `twitchNickname` is not present. 
- Update OpenAPI (`docs/openapi.yaml`) and local setup docs (`docs/local_setup.md`) to document `twitchNickname` as the primary onboarding field, and update internal assignment contract to require `twitchNickname` where applicable. 
- Add and update tests: `internal/app/router_streamers_submit_test.go` (new) verifies both `twitchNickname` usage and fallback to legacy `twitchUsername`, and `internal/streamers/service_test.go` was adjusted to assert `TwitchNickname` storage.

Priority checklist (aligned with `docs/implementation_plan.md` M2.1):
- [x] Persist Twitch nickname during streamer onboarding so Streamlink can resolve channels later.
- [x] Update API contract so clients can send `twitchNickname` explicitly.
- [x] Update OpenAPI and local docs to reflect `twitchNickname` usage.
- [x] Preserve backward compatibility by accepting legacy `twitchUsername` as a fallback.
- [ ] Auto-start Streamlink analysis job after `POST /api/streamers` success (hook behavior unchanged in this PR).
- [ ] Implement periodic chunk capture, LLM routing, persistence of decisions, and live status publishing (out of scope for this change).

### Testing
- Ran unit tests covering the modified packages and they all passed: `go test ./internal/streamers` (ok), `go test ./internal/app` (ok), and `go test ./internal/media` (ok).
- New tests added: `internal/app/router_streamers_submit_test.go` verifies `twitchNickname` handling and legacy fallback, and `internal/streamers/service_test.go` updated assertions to check `TwitchNickname`.
- No other automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bacc30a1b8832cb62390c037ce068b)