### PR TITLE
Detect and handle Streamlink ad breaks during capture

### DIFF
--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -18,9 +18,17 @@ import (
 var (
 	ErrStreamlinkNoData         = errors.New("streamlink capture produced no data")
 	ErrStreamlinkChannelResolve = errors.New("failed to resolve streamlink channel")
+	ErrStreamlinkAdBreak        = errors.New("streamlink capture paused by ad break")
 )
 
 var streamlinkSafeTokenPattern = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+
+var streamlinkAdBreakMarkers = []string{
+	"waiting for pre-roll ads to finish",
+	"detected advertisement break",
+	"filtering out segments and pausing stream output",
+	"will skip ad segments",
+}
 
 type StreamlinkChannelResolver interface {
 	ResolveStreamlinkChannel(ctx context.Context, streamerID string) (string, error)
@@ -145,11 +153,19 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 		return ChunkRef{}, err
 	}
 	if stat.Size() <= 0 {
-		logger.Warn("stream capture produced empty chunk", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.String("stderr", strings.TrimSpace(stderr.String())), zap.Error(runErr))
-		if runErr != nil {
-			return ChunkRef{}, fmt.Errorf("%w: %v (stderr=%s)", ErrStreamlinkNoData, runErr, strings.TrimSpace(stderr.String()))
+		trimmedStderr := strings.TrimSpace(stderr.String())
+		if isStreamlinkAdBreak(trimmedStderr) {
+			logger.Info("stream capture paused by ad break", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.String("stderr", trimmedStderr), zap.Error(runErr))
+			if runErr != nil {
+				return ChunkRef{}, fmt.Errorf("%w: %v (stderr=%s)", ErrStreamlinkAdBreak, runErr, trimmedStderr)
+			}
+			return ChunkRef{}, fmt.Errorf("%w (stderr=%s)", ErrStreamlinkAdBreak, trimmedStderr)
 		}
-		return ChunkRef{}, fmt.Errorf("%w (stderr=%s)", ErrStreamlinkNoData, strings.TrimSpace(stderr.String()))
+		logger.Warn("stream capture produced empty chunk", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.String("stderr", trimmedStderr), zap.Error(runErr))
+		if runErr != nil {
+			return ChunkRef{}, fmt.Errorf("%w: %v (stderr=%s)", ErrStreamlinkNoData, runErr, trimmedStderr)
+		}
+		return ChunkRef{}, fmt.Errorf("%w (stderr=%s)", ErrStreamlinkNoData, trimmedStderr)
 	}
 
 	if runErr != nil && !errors.Is(captureCtx.Err(), context.DeadlineExceeded) && !errors.Is(runErr, context.DeadlineExceeded) {
@@ -182,4 +198,17 @@ func (c PromptedStageClassifier) Classify(_ context.Context, input StageRequest)
 		return StageClassification{Label: "uncertain", Confidence: 0.1}, nil
 	}
 	return StageClassification{Label: "ok", Confidence: 0.75}, nil
+}
+
+func isStreamlinkAdBreak(stderr string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(stderr))
+	if normalized == "" {
+		return false
+	}
+	for _, marker := range streamlinkAdBreakMarkers {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -24,17 +24,21 @@ func (f fakeChannelResolver) ResolveStreamlinkChannel(_ context.Context, _ strin
 }
 
 type fakeCommandRunner struct {
-	err       error
-	writeData []byte
-	lastName  string
-	lastArgs  []string
+	err          error
+	writeData    []byte
+	stderrOutput string
+	lastName     string
+	lastArgs     []string
 }
 
-func (f *fakeCommandRunner) Run(_ context.Context, stdout io.Writer, _ io.Writer, name string, args ...string) error {
+func (f *fakeCommandRunner) Run(_ context.Context, stdout io.Writer, stderr io.Writer, name string, args ...string) error {
 	f.lastName = name
 	f.lastArgs = append([]string(nil), args...)
 	if len(f.writeData) > 0 {
 		_, _ = stdout.Write(f.writeData)
+	}
+	if f.stderrOutput != "" {
+		_, _ = io.WriteString(stderr, f.stderrOutput)
 	}
 	return f.err
 }
@@ -93,5 +97,23 @@ func TestStreamlinkCaptureAdapterFailsWithoutBytes(t *testing.T) {
 	_, err := adapter.Capture(context.Background(), "str_3")
 	if !errors.Is(err, ErrStreamlinkNoData) {
 		t.Fatalf("expected ErrStreamlinkNoData, got %v", err)
+	}
+}
+
+func TestStreamlinkCaptureAdapterReturnsAdBreakErrorWhenAdsPauseOutput(t *testing.T) {
+	runner := &fakeCommandRunner{
+		err: errors.New("signal: killed"),
+		stderrOutput: strings.Join([]string{
+			"[plugins.twitch][info] Will skip ad segments",
+			"[plugins.twitch][info] Waiting for pre-roll ads to finish, be patient",
+			"[plugins.twitch][info] Detected advertisement break of 15 seconds",
+			"[stream.hls][info] Filtering out segments and pausing stream output",
+		}, "\n"),
+	}
+	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{OutputDir: t.TempDir()}, nil, runner)
+
+	_, err := adapter.Capture(context.Background(), "str_ads")
+	if !errors.Is(err, ErrStreamlinkAdBreak) {
+		t.Fatalf("expected ErrStreamlinkAdBreak, got %v", err)
 	}
 }

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -163,6 +163,10 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 	logger.Info("active prompts loaded for streamer processing", zap.String("streamerID", id), zap.Int("promptCount", len(activePrompts)))
 	chunk, err := w.captureWithRetry(ctx, id)
 	if err != nil {
+		if errors.Is(err, ErrStreamlinkAdBreak) {
+			logger.Info("stream chunk capture skipped because stream is on ad break", zap.String("streamerID", id), zap.Error(err))
+			return streamers.LLMDecision{}, nil
+		}
 		logger.Error("stream chunk capture failed", zap.String("streamerID", id), zap.Error(err))
 		return streamers.LLMDecision{}, err
 	}

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -200,3 +200,15 @@ func TestWorkerProcessStreamerReturnsErrorAfterRetryExhausted(t *testing.T) {
 		t.Fatalf("classifier calls = %d, want 2", got)
 	}
 }
+
+func TestWorkerProcessStreamerSkipsAdBreakWithoutFailingCycle(t *testing.T) {
+	worker := NewWorker(fakeCapture{err: ErrStreamlinkAdBreak}, fakeClassifier{}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+
+	got, err := worker.ProcessStreamer(context.Background(), "str-ads")
+	if err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got != (streamers.LLMDecision{}) {
+		t.Fatalf("expected zero decision on ad break, got %#v", got)
+	}
+}


### PR DESCRIPTION
### Motivation
- Treat Streamlink pauses caused by ad breaks differently from genuine no-data failures so worker cycles do not fail during ads.
- Provide clearer logging and a distinct error type to make ad-break handling observable and testable.

### Description
- Add `ErrStreamlinkAdBreak`, a list of `streamlinkAdBreakMarkers`, and `isStreamlinkAdBreak` to detect ad-break messages in Streamlink stderr.
- Update `StreamlinkCaptureAdapter.Capture` to trim stderr, detect ad-break markers, log ad-break events, and return `ErrStreamlinkAdBreak` (including stderr) instead of `ErrStreamlinkNoData` when appropriate.
- Adjust test fake runner to emit stderr via a new `stderrOutput` field and add `TestStreamlinkCaptureAdapterReturnsAdBreakErrorWhenAdsPauseOutput` to validate ad-break detection.
- Change `Worker.ProcessStreamer` to treat `ErrStreamlinkAdBreak` as non-fatal by logging and returning a zero `LLMDecision`, and add `TestWorkerProcessStreamerSkipsAdBreakWithoutFailingCycle` to assert this behavior.

### Testing
- Ran the package unit tests with `go test ./internal/media -v` and the new tests including `TestStreamlinkCaptureAdapterReturnsAdBreakErrorWhenAdsPauseOutput` passed.
- Ran the full test suite with `go test ./...` and no test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bafb1893e0832ca442a5b7b4f84a15)