### PR TITLE
Add scenario engine and integrate global detector + per-game scenario execution into worker

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -20,6 +20,11 @@ stream analysis immediately after a streamer is added:
 - Capture stream fragments every **10 seconds** via Streamlink.
 - For each fragment, first call the **active global game-detection prompt**
   managed by admins.
+- Persist prompts/scenarios in the database so agents and services never rely on
+  in-memory-only prompt configuration.
+- Model each game scenario as a **sequence of linked prompts** where every next
+  step is chosen only after the previous LLM response matches an expected
+  normalized outcome/transition rule.
 - When a game is detected, resolve the **active admin-managed scenario** for that
   game and execute its stage prompts/transition rules step-by-step.
 - Persist run/stage outputs and broadcast state updates to clients.
@@ -27,6 +32,8 @@ stream analysis immediately after a streamer is added:
 ### Priority checklist (must be tracked in status updates)
 - [ ] Auto-start Streamlink analysis job after `POST /api/streamers` success.
 - [ ] Fixed 10-second capture cadence with lock/idempotency protections.
+- [ ] Persist the active global game-detection prompt in the database with audit/version history.
+- [ ] Persist active per-game scenarios in the database, including linked steps and expected transitions.
 - [x] Resolve the active global game-detection prompt from admin configuration.
 - [x] Resolve the active per-game scenario and the active prompt for its current step.
 - [x] Worker payload includes prompt text + runtime params (model, temperature, token limits) for the resolved step.
@@ -71,6 +78,9 @@ stream analysis immediately after a streamer is added:
 - [x] Deliver admin panel backend contracts for managing LLM request templates,
   stage transitions, and safety limits (temperature, max tokens, timeout,
   fallback strategy).
+- [ ] Move prompt/scenario storage from in-memory services to database-backed
+  repositories with audit-ready versioning for the global detector and per-game
+  step chains.
 - [ ] Implement stream capture worker pipeline:
   `streamlink -> media chunking -> Gemini request -> normalized stage result`.
 - [x] Implement global game detection prompt execution before game-specific flows.

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -52,6 +52,11 @@ type PromptResolver interface {
 	ListActive(ctx context.Context) []prompts.PromptVersion
 }
 
+type ScenarioResolver interface {
+	GetActiveGlobalDetector(ctx context.Context) (prompts.PromptTemplate, error)
+	GetActiveScenarioByGame(ctx context.Context, gameSlug string) (prompts.ScenarioVersion, error)
+}
+
 type RunStore interface {
 	CreateRun(ctx context.Context, streamerID string) (string, error)
 }
@@ -70,6 +75,7 @@ type Worker struct {
 	capture             StreamCapture
 	classifier          StageClassifier
 	prompts             PromptResolver
+	scenarios           ScenarioResolver
 	runs                RunStore
 	decisions           DecisionStore
 	locker              Locker
@@ -87,7 +93,7 @@ type WorkerConfig struct {
 	CaptureRetryBackoff time.Duration
 }
 
-func NewWorker(capture StreamCapture, classifier StageClassifier, promptResolver PromptResolver, runs RunStore, decisions DecisionStore, locker Locker, cfg WorkerConfig) *Worker {
+func NewWorker(capture StreamCapture, classifier StageClassifier, promptResolver PromptResolver, scenarioResolver ScenarioResolver, runs RunStore, decisions DecisionStore, locker Locker, cfg WorkerConfig) *Worker {
 	if cfg.LockTTL <= 0 {
 		cfg.LockTTL = 30 * time.Second
 	}
@@ -105,6 +111,7 @@ func NewWorker(capture StreamCapture, classifier StageClassifier, promptResolver
 		capture:             capture,
 		classifier:          classifier,
 		prompts:             promptResolver,
+		scenarios:           scenarioResolver,
 		runs:                runs,
 		decisions:           decisions,
 		locker:              locker,
@@ -155,12 +162,6 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 		return streamers.LLMDecision{}, err
 	}
 	logger.Info("analysis run created", zap.String("streamerID", id), zap.String("runID", runID))
-	activePrompts := w.prompts.ListActive(ctx)
-	if len(activePrompts) == 0 {
-		logger.Warn("no active prompts found for streamer processing", zap.String("streamerID", id))
-		return streamers.LLMDecision{}, prompts.ErrNotFound
-	}
-	logger.Info("active prompts loaded for streamer processing", zap.String("streamerID", id), zap.Int("promptCount", len(activePrompts)))
 	chunk, err := w.captureWithRetry(ctx, id)
 	if err != nil {
 		if errors.Is(err, ErrStreamlinkAdBreak) {
@@ -173,19 +174,98 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 	logger.Info("stream chunk captured", zap.String("streamerID", id), zap.String("chunkRef", chunk.Reference))
 	defer cleanupChunkRef(chunk.Reference)
 
-	var lastDecision streamers.LLMDecision
-	for _, activePrompt := range activePrompts {
-		logger.Info("processing prompt stage", zap.String("streamerID", id), zap.String("runID", runID), zap.String("stage", activePrompt.Stage), zap.String("promptVersionID", activePrompt.ID))
-		decision, err := w.processStage(ctx, runID, id, chunk, activePrompt)
-		if err != nil {
-			logger.Error("prompt stage processing failed", zap.String("streamerID", id), zap.String("runID", runID), zap.String("stage", activePrompt.Stage), zap.Error(err))
-			return streamers.LLMDecision{}, err
-		}
-		logger.Info("prompt stage processed", zap.String("streamerID", id), zap.String("runID", runID), zap.String("stage", decision.Stage), zap.String("label", decision.Label), zap.Float64("confidence", decision.Confidence))
-		lastDecision = decision
+	lastDecision, err := w.processExecutionPlan(ctx, runID, id, chunk)
+	if err != nil {
+		return streamers.LLMDecision{}, err
 	}
 	logger.Info("streamer processing cycle completed", zap.String("streamerID", id), zap.String("runID", runID), zap.String("finalStage", lastDecision.Stage), zap.String("finalLabel", lastDecision.Label), zap.Float64("finalConfidence", lastDecision.Confidence))
 	return lastDecision, nil
+}
+
+func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID string, chunk ChunkRef) (streamers.LLMDecision, error) {
+	logger := w.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	if w.scenarios != nil {
+		globalPrompt, err := w.scenarios.GetActiveGlobalDetector(ctx)
+		if err != nil {
+			logger.Warn("no active global detector configured", zap.String("streamerID", streamerID), zap.Error(err))
+			return streamers.LLMDecision{}, err
+		}
+		detectorDecision, err := w.processPromptTemplate(ctx, runID, streamerID, chunk, globalPrompt)
+		if err != nil {
+			logger.Error("global detector stage failed", zap.String("streamerID", streamerID), zap.Error(err))
+			return streamers.LLMDecision{}, err
+		}
+		gameSlug := strings.TrimSpace(detectorDecision.Label)
+		if gameSlug == "" || gameSlug == "uncertain" {
+			return detectorDecision, nil
+		}
+		scenario, err := w.scenarios.GetActiveScenarioByGame(ctx, gameSlug)
+		if err != nil {
+			logger.Info("no active game scenario found after detector step", zap.String("streamerID", streamerID), zap.String("gameSlug", gameSlug), zap.Error(err))
+			return detectorDecision, nil
+		}
+		currentStep, ok := scenario.EntryStep()
+		if !ok {
+			return detectorDecision, nil
+		}
+		lastDecision := detectorDecision
+		for {
+			stepDecision, err := w.processPromptTemplate(ctx, runID, streamerID, chunk, currentStep.Prompt)
+			if err != nil {
+				return streamers.LLMDecision{}, err
+			}
+			lastDecision = stepDecision
+			transition, ok := scenario.ResolveTransition(currentStep.Code, stepDecision.Label)
+			if !ok || transition.Terminal {
+				return lastDecision, nil
+			}
+			nextStep, ok := scenario.FindStep(transition.ToStepCode)
+			if !ok {
+				return lastDecision, nil
+			}
+			currentStep = nextStep
+		}
+	}
+
+	activePrompts := w.prompts.ListActive(ctx)
+	if len(activePrompts) == 0 {
+		logger.Warn("no active prompts found for streamer processing", zap.String("streamerID", streamerID))
+		return streamers.LLMDecision{}, prompts.ErrNotFound
+	}
+	logger.Info("active prompts loaded for streamer processing", zap.String("streamerID", streamerID), zap.Int("promptCount", len(activePrompts)))
+
+	var lastDecision streamers.LLMDecision
+	for _, activePrompt := range activePrompts {
+		logger.Info("processing prompt stage", zap.String("streamerID", streamerID), zap.String("runID", runID), zap.String("stage", activePrompt.Stage), zap.String("promptVersionID", activePrompt.ID))
+		decision, err := w.processStage(ctx, runID, streamerID, chunk, activePrompt)
+		if err != nil {
+			logger.Error("prompt stage processing failed", zap.String("streamerID", streamerID), zap.String("runID", runID), zap.String("stage", activePrompt.Stage), zap.Error(err))
+			return streamers.LLMDecision{}, err
+		}
+		logger.Info("prompt stage processed", zap.String("streamerID", streamerID), zap.String("runID", runID), zap.String("stage", decision.Stage), zap.String("label", decision.Label), zap.Float64("confidence", decision.Confidence))
+		lastDecision = decision
+	}
+	return lastDecision, nil
+}
+
+func (w *Worker) processPromptTemplate(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptTemplate) (streamers.LLMDecision, error) {
+	return w.processStage(ctx, runID, streamerID, chunk, prompts.PromptVersion{
+		ID:            activePrompt.ID,
+		Stage:         activePrompt.Stage,
+		Template:      activePrompt.Template,
+		Model:         activePrompt.Model,
+		Temperature:   activePrompt.Temperature,
+		MaxTokens:     activePrompt.MaxTokens,
+		TimeoutMS:     activePrompt.TimeoutMS,
+		RetryCount:    activePrompt.RetryCount,
+		BackoffMS:     activePrompt.BackoffMS,
+		CooldownMS:    activePrompt.CooldownMS,
+		MinConfidence: activePrompt.MinConfidence,
+	})
 }
 
 func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (ChunkRef, error) {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -41,6 +41,27 @@ func (f fakeClassifier) Classify(_ context.Context, input StageRequest) (StageCl
 
 type fakePromptResolver struct{ prompts []prompts.PromptVersion }
 
+type fakeScenarioResolver struct {
+	global      prompts.PromptTemplate
+	scenario    prompts.ScenarioVersion
+	globalErr   error
+	scenarioErr error
+}
+
+func (f fakeScenarioResolver) GetActiveGlobalDetector(_ context.Context) (prompts.PromptTemplate, error) {
+	if f.globalErr != nil {
+		return prompts.PromptTemplate{}, f.globalErr
+	}
+	return f.global, nil
+}
+
+func (f fakeScenarioResolver) GetActiveScenarioByGame(_ context.Context, _ string) (prompts.ScenarioVersion, error) {
+	if f.scenarioErr != nil {
+		return prompts.ScenarioVersion{}, f.scenarioErr
+	}
+	return f.scenario, nil
+}
+
 func (f fakePromptResolver) ListActive(_ context.Context) []prompts.PromptVersion {
 	out := make([]prompts.PromptVersion, len(f.prompts))
 	copy(out, f.prompts)
@@ -97,7 +118,7 @@ func TestWorkerProcessStreamerRunsAllOrderedStages(t *testing.T) {
 			"result":      {Label: "win", Confidence: 0.93, RawResponse: `{"label":"win"}`, TokensIn: 75, TokensOut: 14, Latency: 140 * time.Millisecond},
 		}},
 		fakePromptResolver{prompts: []prompts.PromptVersion{{ID: "prompt-a", Stage: "detector", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "detect cs", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}, {ID: "prompt-b", Stage: "ranked_mode", Position: 2, IsActive: true, MinConfidence: 0.5, Template: "detect mode", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}, {ID: "prompt-c", Stage: "result", Position: 3, IsActive: true, MinConfidence: 0.5, Template: "detect result", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}}},
-		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
+		nil, &InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
 	)
 	got, err := worker.ProcessStreamer(context.Background(), "str-1")
 	if err != nil {
@@ -112,7 +133,7 @@ func TestWorkerProcessStreamerRunsAllOrderedStages(t *testing.T) {
 }
 
 func TestWorkerProcessStreamerUsesGenericUncertainFallback(t *testing.T) {
-	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, fakeClassifier{results: map[string]StageClassification{"custom": {Label: "whatever", Confidence: 0.1}}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "custom", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, fakeClassifier{results: map[string]StageClassification{"custom": {Label: "whatever", Confidence: 0.1}}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "custom", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}}}, nil, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
 	got, err := worker.ProcessStreamer(context.Background(), "str-1")
 	if err != nil {
 		t.Fatalf("ProcessStreamer() error = %v", err)
@@ -127,7 +148,7 @@ func TestWorkerProcessStreamerBusy(t *testing.T) {
 	if ok := locker.TryLock("stream-capture:str-1", time.Second); !ok {
 		t.Fatal("expected lock")
 	}
-	worker := NewWorker(fakeCapture{}, fakeClassifier{}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, locker, WorkerConfig{})
+	worker := NewWorker(fakeCapture{}, fakeClassifier{}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, nil, &InMemoryRunStore{}, &fakeDecisionStore{}, locker, WorkerConfig{})
 	_, err := worker.ProcessStreamer(context.Background(), "str-1")
 	if !errors.Is(err, ErrStreamerBusy) {
 		t.Fatalf("error = %v, want %v", err, ErrStreamerBusy)
@@ -139,7 +160,7 @@ func TestWorkerProcessStreamerCleansUpChunkFileOnSuccess(t *testing.T) {
 	if err := os.WriteFile(chunkPath, []byte("chunk"), 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
-	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: chunkPath}}, fakeClassifier{results: map[string]StageClassification{"custom": {Label: "ok", Confidence: 0.9}}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: chunkPath}}, fakeClassifier{results: map[string]StageClassification{"custom": {Label: "ok", Confidence: 0.9}}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, nil, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
 	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
 		t.Fatalf("ProcessStreamer() error = %v", err)
 	}
@@ -153,7 +174,7 @@ func TestWorkerProcessStreamerCleansUpChunkFileOnClassifierError(t *testing.T) {
 	if err := os.WriteFile(chunkPath, []byte("chunk"), 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
-	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: chunkPath}}, fakeClassifier{errByStage: map[string]error{"custom": errors.New("llm failed")}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: chunkPath}}, fakeClassifier{errByStage: map[string]error{"custom": errors.New("llm failed")}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, nil, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
 	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err == nil {
 		t.Fatal("expected classifier error")
 	}
@@ -164,7 +185,7 @@ func TestWorkerProcessStreamerCleansUpChunkFileOnClassifierError(t *testing.T) {
 
 func TestWorkerProcessStreamerRetriesCapture(t *testing.T) {
 	capture := &flakyCapture{failures: 1, chunk: ChunkRef{Reference: "chunk-1"}}
-	worker := NewWorker(capture, fakeClassifier{results: map[string]StageClassification{"custom": {Label: "ok", Confidence: 0.9}}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5, CaptureRetryCount: 1})
+	worker := NewWorker(capture, fakeClassifier{results: map[string]StageClassification{"custom": {Label: "ok", Confidence: 0.9}}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, nil, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5, CaptureRetryCount: 1})
 	worker.sleepFn = func(context.Context, time.Duration) error { return nil }
 
 	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
@@ -177,7 +198,7 @@ func TestWorkerProcessStreamerRetriesCapture(t *testing.T) {
 
 func TestWorkerProcessStreamerRetriesStageClassification(t *testing.T) {
 	classifier := &flakyClassifier{failures: 1, result: StageClassification{Label: "ok", Confidence: 0.9}}
-	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, classifier, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1, RetryCount: 1, BackoffMS: 10}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, classifier, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1, RetryCount: 1, BackoffMS: 10}}}, nil, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
 	worker.sleepFn = func(context.Context, time.Duration) error { return nil }
 
 	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
@@ -190,7 +211,7 @@ func TestWorkerProcessStreamerRetriesStageClassification(t *testing.T) {
 
 func TestWorkerProcessStreamerReturnsErrorAfterRetryExhausted(t *testing.T) {
 	classifier := &flakyClassifier{failures: 2, result: StageClassification{Label: "ok", Confidence: 0.9}}
-	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, classifier, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1, RetryCount: 1, BackoffMS: 10}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, classifier, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1, RetryCount: 1, BackoffMS: 10}}}, nil, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
 	worker.sleepFn = func(context.Context, time.Duration) error { return nil }
 
 	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err == nil {
@@ -202,7 +223,7 @@ func TestWorkerProcessStreamerReturnsErrorAfterRetryExhausted(t *testing.T) {
 }
 
 func TestWorkerProcessStreamerSkipsAdBreakWithoutFailingCycle(t *testing.T) {
-	worker := NewWorker(fakeCapture{err: ErrStreamlinkAdBreak}, fakeClassifier{}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+	worker := NewWorker(fakeCapture{err: ErrStreamlinkAdBreak}, fakeClassifier{}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, nil, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
 
 	got, err := worker.ProcessStreamer(context.Background(), "str-ads")
 	if err != nil {
@@ -210,5 +231,46 @@ func TestWorkerProcessStreamerSkipsAdBreakWithoutFailingCycle(t *testing.T) {
 	}
 	if got != (streamers.LLMDecision{}) {
 		t.Fatalf("expected zero decision on ad break, got %#v", got)
+	}
+}
+
+func TestWorkerProcessStreamerRunsGlobalDetectorAndScenarioSteps(t *testing.T) {
+	decisions := &fakeDecisionStore{}
+	scenario := prompts.ScenarioVersion{
+		ID:       "scenario-cs",
+		GameSlug: "counter_strike",
+		IsActive: true,
+		Steps: []prompts.ScenarioStep{
+			{Code: "match_start", Position: 1, Prompt: prompts.PromptTemplate{ID: "step-1", Stage: "match_start", Template: "is new match", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000, MinConfidence: 0.5}},
+			{Code: "match_result", Position: 2, Prompt: prompts.PromptTemplate{ID: "step-2", Stage: "match_result", Template: "result?", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000, MinConfidence: 0.5}},
+		},
+		Transitions: []prompts.ScenarioTransition{
+			{FromStepCode: "match_start", Outcome: "match_started", ToStepCode: "match_result"},
+			{FromStepCode: "match_result", Outcome: "win", Terminal: true},
+		},
+	}
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		fakeClassifier{results: map[string]StageClassification{
+			"global_detector": {Label: "counter_strike", Confidence: 0.98},
+			"match_start":     {Label: "match_started", Confidence: 0.93},
+			"match_result":    {Label: "win", Confidence: 0.95},
+		}},
+		nil,
+		fakeScenarioResolver{global: prompts.PromptTemplate{ID: "det-1", Stage: "global_detector", Template: "detect game", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000, MinConfidence: 0.5}, scenario: scenario},
+		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
+	)
+	got, err := worker.ProcessStreamer(context.Background(), "str-1")
+	if err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got.Stage != "match_result" || got.Label != "win" {
+		t.Fatalf("final decision = %#v", got)
+	}
+	if len(decisions.items) != 3 {
+		t.Fatalf("recorded %d decisions, want 3", len(decisions.items))
+	}
+	if decisions.items[0].Stage != "global_detector" || decisions.items[1].Stage != "match_start" || decisions.items[2].Stage != "match_result" {
+		t.Fatalf("unexpected decision order: %#v", decisions.items)
 	}
 }

--- a/internal/prompts/scenario.go
+++ b/internal/prompts/scenario.go
@@ -1,0 +1,390 @@
+package prompts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	PromptKindGlobalDetector = "global_detector"
+	PromptKindScenarioStep   = "scenario_step"
+)
+
+var (
+	ErrInvalidPromptKind      = errors.New("prompt kind is invalid")
+	ErrInvalidGameSlug        = errors.New("gameSlug must not be empty")
+	ErrInvalidScenarioName    = errors.New("scenario name must not be empty")
+	ErrInvalidScenarioStep    = errors.New("scenario step code must not be empty")
+	ErrInvalidScenarioOutcome = errors.New("scenario transition outcome must not be empty")
+	ErrScenarioNotFound       = errors.New("scenario not found")
+)
+
+type ScenarioStepInput struct {
+	Code           string
+	Title          string
+	PromptTemplate string
+	Model          string
+	Temperature    float64
+	MaxTokens      int
+	TimeoutMS      int
+	RetryCount     int
+	BackoffMS      int
+	CooldownMS     int
+	MinConfidence  float64
+}
+
+type ScenarioTransitionInput struct {
+	FromStepCode string
+	Outcome      string
+	ToStepCode   string
+	Terminal     bool
+}
+
+type CreateScenarioRequest struct {
+	GameSlug    string
+	Name        string
+	Description string
+	ActorID     string
+	Steps       []ScenarioStepInput
+	Transitions []ScenarioTransitionInput
+}
+
+type PromptTemplate struct {
+	ID            string    `json:"id"`
+	Kind          string    `json:"kind"`
+	Stage         string    `json:"stage"`
+	GameSlug      string    `json:"gameSlug,omitempty"`
+	Version       int       `json:"version"`
+	Template      string    `json:"template"`
+	Model         string    `json:"model"`
+	Temperature   float64   `json:"temperature"`
+	MaxTokens     int       `json:"maxTokens"`
+	TimeoutMS     int       `json:"timeoutMs"`
+	RetryCount    int       `json:"retryCount"`
+	BackoffMS     int       `json:"backoffMs"`
+	CooldownMS    int       `json:"cooldownMs"`
+	MinConfidence float64   `json:"minConfidence"`
+	IsActive      bool      `json:"isActive"`
+	CreatedBy     string    `json:"createdBy"`
+	ActivatedBy   string    `json:"activatedBy,omitempty"`
+	CreatedAt     time.Time `json:"createdAt"`
+	ActivatedAt   time.Time `json:"activatedAt,omitempty"`
+}
+
+type ScenarioStep struct {
+	ID       string         `json:"id"`
+	Code     string         `json:"code"`
+	Title    string         `json:"title"`
+	Position int            `json:"position"`
+	Prompt   PromptTemplate `json:"prompt"`
+}
+
+type ScenarioTransition struct {
+	ID           string `json:"id"`
+	FromStepCode string `json:"fromStepCode"`
+	Outcome      string `json:"outcome"`
+	ToStepCode   string `json:"toStepCode,omitempty"`
+	Terminal     bool   `json:"terminal"`
+}
+
+type ScenarioVersion struct {
+	ID          string               `json:"id"`
+	GameSlug    string               `json:"gameSlug"`
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
+	Version     int                  `json:"version"`
+	IsActive    bool                 `json:"isActive"`
+	CreatedBy   string               `json:"createdBy"`
+	ActivatedBy string               `json:"activatedBy,omitempty"`
+	CreatedAt   time.Time            `json:"createdAt"`
+	ActivatedAt time.Time            `json:"activatedAt,omitempty"`
+	Steps       []ScenarioStep       `json:"steps"`
+	Transitions []ScenarioTransition `json:"transitions"`
+}
+
+func ValidateCreateScenarioRequest(req CreateScenarioRequest) error {
+	if strings.TrimSpace(req.GameSlug) == "" {
+		return ErrInvalidGameSlug
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return ErrInvalidScenarioName
+	}
+	if len(req.Steps) == 0 {
+		return ErrInvalidScenarioStep
+	}
+	seen := make(map[string]struct{}, len(req.Steps))
+	for _, step := range req.Steps {
+		code := strings.TrimSpace(step.Code)
+		if code == "" {
+			return ErrInvalidScenarioStep
+		}
+		if _, ok := seen[code]; ok {
+			return fmt.Errorf("duplicate scenario step code: %s", code)
+		}
+		seen[code] = struct{}{}
+		if err := ValidateCreateRequest(CreateRequest{
+			Stage:         code,
+			Template:      step.PromptTemplate,
+			Model:         step.Model,
+			Temperature:   step.Temperature,
+			MaxTokens:     step.MaxTokens,
+			TimeoutMS:     step.TimeoutMS,
+			RetryCount:    step.RetryCount,
+			BackoffMS:     step.BackoffMS,
+			CooldownMS:    step.CooldownMS,
+			MinConfidence: step.MinConfidence,
+		}); err != nil {
+			return err
+		}
+	}
+	for _, transition := range req.Transitions {
+		if strings.TrimSpace(transition.FromStepCode) == "" {
+			return ErrInvalidScenarioStep
+		}
+		if strings.TrimSpace(transition.Outcome) == "" {
+			return ErrInvalidScenarioOutcome
+		}
+		if !transition.Terminal && strings.TrimSpace(transition.ToStepCode) == "" {
+			return ErrInvalidScenarioStep
+		}
+	}
+	return nil
+}
+
+// ScenarioService stores global detector prompts and game scenarios. The current
+// implementation is in-memory, but its API is shaped so it can be backed by DB tables.
+type ScenarioService struct {
+	mu              sync.RWMutex
+	counter         int
+	globalDetectors []PromptTemplate
+	scenariosByGame map[string][]ScenarioVersion
+}
+
+func NewScenarioService() *ScenarioService {
+	return &ScenarioService{scenariosByGame: map[string][]ScenarioVersion{}}
+}
+
+func (s *ScenarioService) CreateGlobalDetector(ctx context.Context, req CreateRequest) (PromptTemplate, error) {
+	return s.createPrompt(ctx, PromptKindGlobalDetector, "", req)
+}
+
+func (s *ScenarioService) createPrompt(_ context.Context, kind string, gameSlug string, req CreateRequest) (PromptTemplate, error) {
+	if kind != PromptKindGlobalDetector && kind != PromptKindScenarioStep {
+		return PromptTemplate{}, ErrInvalidPromptKind
+	}
+	if err := ValidateCreateRequest(req); err != nil {
+		return PromptTemplate{}, err
+	}
+	if kind == PromptKindScenarioStep && strings.TrimSpace(gameSlug) == "" {
+		return PromptTemplate{}, ErrInvalidGameSlug
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.counter++
+	now := time.Now().UTC()
+	item := PromptTemplate{
+		ID:            fmt.Sprintf("prompt-template-%d", s.counter),
+		Kind:          kind,
+		Stage:         strings.TrimSpace(req.Stage),
+		GameSlug:      strings.TrimSpace(gameSlug),
+		Version:       len(s.globalDetectors) + 1,
+		Template:      strings.TrimSpace(req.Template),
+		Model:         strings.TrimSpace(req.Model),
+		Temperature:   req.Temperature,
+		MaxTokens:     req.MaxTokens,
+		TimeoutMS:     req.TimeoutMS,
+		RetryCount:    req.RetryCount,
+		BackoffMS:     req.BackoffMS,
+		CooldownMS:    req.CooldownMS,
+		MinConfidence: req.MinConfidence,
+		CreatedBy:     strings.TrimSpace(req.ActorID),
+		CreatedAt:     now,
+		IsActive:      true,
+		ActivatedBy:   strings.TrimSpace(req.ActorID),
+		ActivatedAt:   now,
+	}
+	for i := range s.globalDetectors {
+		s.globalDetectors[i].IsActive = false
+	}
+	s.globalDetectors = append(s.globalDetectors, item)
+	return item, nil
+}
+
+func (s *ScenarioService) GetActiveGlobalDetector(_ context.Context) (PromptTemplate, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for i := len(s.globalDetectors) - 1; i >= 0; i-- {
+		if s.globalDetectors[i].IsActive {
+			return s.globalDetectors[i], nil
+		}
+	}
+	return PromptTemplate{}, ErrNotFound
+}
+
+func (s *ScenarioService) CreateScenario(_ context.Context, req CreateScenarioRequest) (ScenarioVersion, error) {
+	if err := ValidateCreateScenarioRequest(req); err != nil {
+		return ScenarioVersion{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	gameSlug := strings.ToLower(strings.TrimSpace(req.GameSlug))
+	version := len(s.scenariosByGame[gameSlug]) + 1
+	now := time.Now().UTC()
+	s.counter++
+	scenario := ScenarioVersion{
+		ID:          fmt.Sprintf("scenario-%d", s.counter),
+		GameSlug:    gameSlug,
+		Name:        strings.TrimSpace(req.Name),
+		Description: strings.TrimSpace(req.Description),
+		Version:     version,
+		IsActive:    len(s.scenariosByGame[gameSlug]) == 0,
+		CreatedBy:   strings.TrimSpace(req.ActorID),
+		CreatedAt:   now,
+	}
+	if scenario.IsActive {
+		scenario.ActivatedBy = strings.TrimSpace(req.ActorID)
+		scenario.ActivatedAt = now
+	}
+	for idx, step := range req.Steps {
+		s.counter++
+		prompt := PromptTemplate{
+			ID:            fmt.Sprintf("prompt-template-%d", s.counter),
+			Kind:          PromptKindScenarioStep,
+			Stage:         strings.TrimSpace(step.Code),
+			GameSlug:      gameSlug,
+			Version:       scenario.Version,
+			Template:      strings.TrimSpace(step.PromptTemplate),
+			Model:         strings.TrimSpace(step.Model),
+			Temperature:   step.Temperature,
+			MaxTokens:     step.MaxTokens,
+			TimeoutMS:     step.TimeoutMS,
+			RetryCount:    step.RetryCount,
+			BackoffMS:     step.BackoffMS,
+			CooldownMS:    step.CooldownMS,
+			MinConfidence: step.MinConfidence,
+			CreatedBy:     strings.TrimSpace(req.ActorID),
+			CreatedAt:     now,
+			IsActive:      scenario.IsActive,
+			ActivatedBy:   scenario.ActivatedBy,
+			ActivatedAt:   scenario.ActivatedAt,
+		}
+		scenario.Steps = append(scenario.Steps, ScenarioStep{
+			ID:       fmt.Sprintf("scenario-step-%d", s.counter),
+			Code:     strings.TrimSpace(step.Code),
+			Title:    strings.TrimSpace(step.Title),
+			Position: idx + 1,
+			Prompt:   prompt,
+		})
+	}
+	for _, transition := range req.Transitions {
+		s.counter++
+		scenario.Transitions = append(scenario.Transitions, ScenarioTransition{
+			ID:           fmt.Sprintf("scenario-transition-%d", s.counter),
+			FromStepCode: strings.TrimSpace(transition.FromStepCode),
+			Outcome:      strings.TrimSpace(transition.Outcome),
+			ToStepCode:   strings.TrimSpace(transition.ToStepCode),
+			Terminal:     transition.Terminal,
+		})
+	}
+	s.scenariosByGame[gameSlug] = append(s.scenariosByGame[gameSlug], scenario)
+	return scenario, nil
+}
+
+func (s *ScenarioService) ActivateScenario(_ context.Context, id, actorID string) (ScenarioVersion, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for game, scenarios := range s.scenariosByGame {
+		activeIdx := -1
+		for i := range scenarios {
+			if scenarios[i].ID == strings.TrimSpace(id) {
+				activeIdx = i
+				break
+			}
+		}
+		if activeIdx == -1 {
+			continue
+		}
+		now := time.Now().UTC()
+		for i := range scenarios {
+			scenarios[i].IsActive = i == activeIdx
+			if i == activeIdx {
+				scenarios[i].ActivatedAt = now
+				scenarios[i].ActivatedBy = strings.TrimSpace(actorID)
+			}
+			for j := range scenarios[i].Steps {
+				scenarios[i].Steps[j].Prompt.IsActive = i == activeIdx
+				if i == activeIdx {
+					scenarios[i].Steps[j].Prompt.ActivatedAt = now
+					scenarios[i].Steps[j].Prompt.ActivatedBy = strings.TrimSpace(actorID)
+				}
+			}
+		}
+		s.scenariosByGame[game] = scenarios
+		return scenarios[activeIdx], nil
+	}
+	return ScenarioVersion{}, ErrScenarioNotFound
+}
+
+func (s *ScenarioService) GetActiveScenarioByGame(_ context.Context, gameSlug string) (ScenarioVersion, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, scenario := range s.scenariosByGame[strings.ToLower(strings.TrimSpace(gameSlug))] {
+		if scenario.IsActive {
+			return scenario, nil
+		}
+	}
+	return ScenarioVersion{}, ErrScenarioNotFound
+}
+
+func (s *ScenarioService) ListScenarios(_ context.Context) []ScenarioVersion {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]ScenarioVersion, 0)
+	for _, scenarios := range s.scenariosByGame {
+		items = append(items, scenarios...)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].GameSlug == items[j].GameSlug {
+			return items[i].Version > items[j].Version
+		}
+		return items[i].GameSlug < items[j].GameSlug
+	})
+	return items
+}
+
+func (v ScenarioVersion) EntryStep() (ScenarioStep, bool) {
+	if len(v.Steps) == 0 {
+		return ScenarioStep{}, false
+	}
+	return v.Steps[0], true
+}
+
+func (v ScenarioVersion) ResolveTransition(fromStepCode, outcome string) (ScenarioTransition, bool) {
+	fromStepCode = strings.TrimSpace(fromStepCode)
+	outcome = strings.TrimSpace(outcome)
+	for _, transition := range v.Transitions {
+		if transition.FromStepCode == fromStepCode && strings.EqualFold(transition.Outcome, outcome) {
+			return transition, true
+		}
+	}
+	return ScenarioTransition{}, false
+}
+
+func (v ScenarioVersion) FindStep(code string) (ScenarioStep, bool) {
+	code = strings.TrimSpace(code)
+	for _, step := range v.Steps {
+		if step.Code == code {
+			return step, true
+		}
+	}
+	return ScenarioStep{}, false
+}

--- a/internal/prompts/scenario_test.go
+++ b/internal/prompts/scenario_test.go
@@ -1,0 +1,84 @@
+package prompts
+
+import (
+	"context"
+	"testing"
+)
+
+func TestScenarioServiceCreatesGlobalDetectorAndScenario(t *testing.T) {
+	svc := NewScenarioService()
+	global, err := svc.CreateGlobalDetector(context.Background(), CreateRequest{
+		Stage:         "global_detector",
+		Template:      "detect current game",
+		Model:         "gemini-2.0-flash",
+		Temperature:   0.1,
+		MaxTokens:     256,
+		TimeoutMS:     2000,
+		RetryCount:    1,
+		BackoffMS:     250,
+		CooldownMS:    1000,
+		MinConfidence: 0.7,
+		ActorID:       "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateGlobalDetector() error = %v", err)
+	}
+	if !global.IsActive {
+		t.Fatal("expected active global detector")
+	}
+
+	scenario, err := svc.CreateScenario(context.Background(), CreateScenarioRequest{
+		GameSlug:    "counter_strike",
+		Name:        "CS ranked flow",
+		Description: "Wait for ranked match lifecycle",
+		ActorID:     "admin-1",
+		Steps: []ScenarioStepInput{
+			{Code: "match_start", Title: "Match start", PromptTemplate: "Has a ranked match started?", Model: "gemini-2.0-flash", Temperature: 0.1, MaxTokens: 256, TimeoutMS: 2000, MinConfidence: 0.7},
+			{Code: "match_result", Title: "Match result", PromptTemplate: "Did the streamer win?", Model: "gemini-2.0-flash", Temperature: 0.1, MaxTokens: 256, TimeoutMS: 2000, MinConfidence: 0.7},
+		},
+		Transitions: []ScenarioTransitionInput{
+			{FromStepCode: "match_start", Outcome: "match_started", ToStepCode: "match_result"},
+			{FromStepCode: "match_result", Outcome: "win", Terminal: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateScenario() error = %v", err)
+	}
+	if !scenario.IsActive {
+		t.Fatal("expected first scenario version to become active")
+	}
+	if len(scenario.Steps) != 2 || len(scenario.Transitions) != 2 {
+		t.Fatalf("unexpected scenario payload: %#v", scenario)
+	}
+
+	activeScenario, err := svc.GetActiveScenarioByGame(context.Background(), "counter_strike")
+	if err != nil {
+		t.Fatalf("GetActiveScenarioByGame() error = %v", err)
+	}
+	if activeScenario.ID != scenario.ID {
+		t.Fatalf("active scenario id = %q, want %q", activeScenario.ID, scenario.ID)
+	}
+
+	entry, ok := activeScenario.EntryStep()
+	if !ok || entry.Code != "match_start" {
+		t.Fatalf("EntryStep() = %#v, %v", entry, ok)
+	}
+	transition, ok := activeScenario.ResolveTransition("match_start", "match_started")
+	if !ok || transition.ToStepCode != "match_result" {
+		t.Fatalf("ResolveTransition() = %#v, %v", transition, ok)
+	}
+}
+
+func TestValidateCreateScenarioRequestRejectsBrokenTransition(t *testing.T) {
+	err := ValidateCreateScenarioRequest(CreateScenarioRequest{
+		GameSlug: "counter_strike",
+		Name:     "broken",
+		Steps: []ScenarioStepInput{
+			{Code: "step-1", PromptTemplate: "prompt", Model: "gemini", Temperature: 0.1, MaxTokens: 1, TimeoutMS: 1, MinConfidence: 0.1},
+		},
+		Transitions: []ScenarioTransitionInput{{FromStepCode: "step-1", Outcome: "go"}},
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+}


### PR DESCRIPTION
### Motivation
- Enable persistent, admin-managed global game detection and per-game scenario flows instead of relying on in-memory-only prompts.
- Model game scenarios as ordered, linked prompt steps where transitions are chosen based on normalized LLM outcomes.

### Description
- Introduce a new prompts scenario domain with an in-memory `ScenarioService` and types in `internal/prompts/scenario.go` including `PromptTemplate`, `ScenarioStep`, `ScenarioTransition`, and `ScenarioVersion` plus validation helpers.
- Add a `ScenarioResolver` interface and wire it into the `Worker` by extending `NewWorker` and the `Worker` struct to support `GetActiveGlobalDetector` and `GetActiveScenarioByGame` flows.
- Implement `processExecutionPlan` and `processPromptTemplate` in `internal/media/worker.go` to run the global detector, resolve the active scenario for the detected game, execute steps in order, and follow transition rules until terminal or no next step.
- Update `ProcessStreamer` to delegate to the execution plan and preserve fallback behavior to the legacy active prompt listing when no scenario resolver is present.
- Add `fakeScenarioResolver` and update `internal/media/worker_test.go` to pass `nil` for scenarios where not used and add `TestWorkerProcessStreamerRunsGlobalDetectorAndScenarioSteps` to verify end-to-end scenario execution ordering.
- Update `docs/implementation_plan.md` to note persistence/versioning of prompts and scenarios as part of the priority checklist.

### Testing
- Ran unit tests for the modified packages with `go test ./internal/...` and the suite passed.
- Exercised worker behavior via `TestWorkerProcessStreamerRunsAllOrderedStages`, `TestWorkerProcessStreamerUsesGenericUncertainFallback`, and the new `TestWorkerProcessStreamerRunsGlobalDetectorAndScenarioSteps`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb00472704832c80b0ef792545e0eb)