### PR TITLE
Add scheduler lifecycle hooks and track per-streamer analysis state

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -127,6 +127,7 @@ func main() {
 	streamWorker.SetLogger(logger.Named("stream_worker"))
 	streamScheduler := media.NewScheduler(streamWorker, 10*time.Second)
 	streamScheduler.SetLogger(logger.Named("stream_scheduler"))
+	streamScheduler.SetLifecycleHooks(streamersService.MarkAnalysisActive, streamersService.MarkAnalysisInactive)
 	streamersService.SetSubmissionHook(func(_ context.Context, streamerID string) error {
 		return streamScheduler.Start(streamerID)
 	})

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -30,7 +30,7 @@ stream analysis immediately after a streamer is added:
 - Persist run/stage outputs and broadcast state updates to clients.
 
 ### Priority checklist (must be tracked in status updates)
-- [ ] Auto-start Streamlink analysis job after `POST /api/streamers` success.
+- [x] Auto-start Streamlink analysis job after `POST /api/streamers` success.
 - [ ] Fixed 10-second capture cadence with lock/idempotency protections.
 - [ ] Persist the active global game-detection prompt in the database with audit/version history.
 - [ ] Persist active per-game scenarios in the database, including linked steps and expected transitions.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -153,7 +153,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/me` – returns the authenticated user's profile plus `isAdmin` flag when called with the issued JWT.
 - `GET /api/config` – exposes client configuration and feature flags for the authenticated user.
 - `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
-- `POST /api/streamers` – submits a Twitch streamer nickname for moderation/validation and Streamlink usage.
+- `POST /api/streamers` – submits a Twitch streamer nickname for moderation/validation, then immediately starts the per-streamer Streamlink analysis scheduler when background orchestration is configured.
 - `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM detector/scenario status for a streamer.
 - `GET /api/streamers/{streamerId}/llm-decisions?limit=` – returns recent detector/scenario decision history for a streamer.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.

--- a/internal/app/router_streamers_submit_test.go
+++ b/internal/app/router_streamers_submit_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -80,5 +81,48 @@ func TestSubmitStreamerFallsBackToLegacyTwitchUsername(t *testing.T) {
 	}
 	if items[0].TwitchNickname != "legacyname" {
 		t.Fatalf("expected stored twitchNickname legacyname, got %q", items[0].TwitchNickname)
+	}
+}
+
+func TestSubmitStreamerStartsAnalysisStatusWhenHookConfigured(t *testing.T) {
+	streamersService := streamers.NewService()
+	streamersService.SetSubmissionHook(func(_ context.Context, streamerID string) error {
+		if streamerID == "" {
+			t.Fatal("expected streamerID in submission hook")
+		}
+		return nil
+	})
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamersService,
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	body := bytes.NewBufferString(`{"twitchNickname":"HookedStreamer"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/streamers", body)
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+
+	items := streamersService.List(req.Context(), "hookedstreamer", "pending", 1)
+	if len(items) != 1 {
+		t.Fatalf("expected one streamer, got %d", len(items))
+	}
+
+	status := streamersService.GetLLMStatus(req.Context(), items[0].ID)
+	if status.State != "active" {
+		t.Fatalf("expected active status after submission hook, got %q", status.State)
 	}
 }

--- a/internal/media/scheduler.go
+++ b/internal/media/scheduler.go
@@ -30,8 +30,10 @@ type Scheduler struct {
 	processor StreamProcessor
 	interval  time.Duration
 
-	mu   sync.Mutex
-	jobs map[string]context.CancelFunc
+	mu      sync.Mutex
+	jobs    map[string]context.CancelFunc
+	onStart func(string)
+	onStop  func(string)
 }
 
 func NewScheduler(worker *Worker, interval time.Duration) *Scheduler {
@@ -59,6 +61,16 @@ func (s *Scheduler) SetLogger(logger *zap.Logger) {
 	s.logger = logger
 }
 
+func (s *Scheduler) SetLifecycleHooks(onStart, onStop func(string)) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onStart = onStart
+	s.onStop = onStop
+}
+
 func (s *Scheduler) Start(streamerID string) error {
 	logger := s.logger
 	if logger == nil {
@@ -78,9 +90,13 @@ func (s *Scheduler) Start(streamerID string) error {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	s.jobs[id] = cancel
+	onStart := s.onStart
 	s.mu.Unlock()
 
 	logger.Info("scheduler started for streamer", zap.String("streamerID", id), zap.Duration("interval", s.interval))
+	if onStart != nil {
+		onStart(id)
+	}
 	go s.run(ctx, id)
 	return nil
 }
@@ -91,7 +107,10 @@ func (s *Scheduler) run(ctx context.Context, streamerID string) {
 		logger = zap.NewNop()
 	}
 	defer func() {
-		s.remove(streamerID)
+		onStop := s.remove(streamerID)
+		if onStop != nil {
+			onStop(streamerID)
+		}
 		logger.Info("scheduler stopped for streamer", zap.String("streamerID", streamerID))
 	}()
 
@@ -141,8 +160,10 @@ func (s *Scheduler) Stop(streamerID string) {
 	}
 }
 
-func (s *Scheduler) remove(streamerID string) {
+func (s *Scheduler) remove(streamerID string) func(string) {
 	s.mu.Lock()
+	onStop := s.onStop
 	delete(s.jobs, streamerID)
 	s.mu.Unlock()
+	return onStop
 }

--- a/internal/media/scheduler_test.go
+++ b/internal/media/scheduler_test.go
@@ -56,3 +56,48 @@ func TestSchedulerStartIsIdempotentPerStreamer(t *testing.T) {
 		t.Fatalf("second Start() error = %v", err)
 	}
 }
+
+func TestSchedulerLifecycleHooksTrackStartAndStop(t *testing.T) {
+	processor := &fakeProcessor{}
+	scheduler := NewSchedulerWithProcessor(processor, time.Hour)
+
+	var (
+		mu      sync.Mutex
+		started []string
+		stopped []string
+	)
+	scheduler.SetLifecycleHooks(func(streamerID string) {
+		mu.Lock()
+		started = append(started, streamerID)
+		mu.Unlock()
+	}, func(streamerID string) {
+		mu.Lock()
+		stopped = append(stopped, streamerID)
+		mu.Unlock()
+	})
+
+	if err := scheduler.Start("str-42"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	scheduler.Stop("str-42")
+
+	deadline := time.Now().Add(150 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		done := len(started) == 1 && len(stopped) == 1
+		mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(started) != 1 || started[0] != "str-42" {
+		t.Fatalf("unexpected start hook calls: %#v", started)
+	}
+	if len(stopped) != 1 || stopped[0] != "str-42" {
+		t.Fatalf("unexpected stop hook calls: %#v", stopped)
+	}
+}

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -40,11 +40,17 @@ type submissionLimit struct {
 	windowEnds time.Time
 }
 
+type analysisState struct {
+	active    bool
+	updatedAt string
+}
+
 type Service struct {
 	logger         *zap.Logger
 	mu             sync.RWMutex
 	items          []Streamer
 	decisions      map[string][]LLMDecision
+	analysis       map[string]analysisState
 	validator      TwitchValidator
 	rateLimitMu    sync.Mutex
 	rateLimitByKey map[string]submissionLimit
@@ -67,6 +73,7 @@ func NewServiceWithValidator(validator TwitchValidator) *Service {
 		logger:         zap.NewNop(),
 		items:          []Streamer{},
 		decisions:      make(map[string][]LLMDecision),
+		analysis:       make(map[string]analysisState),
 		validator:      validator,
 		rateLimitByKey: make(map[string]submissionLimit),
 		nowFn: func() time.Time {
@@ -210,9 +217,11 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 			if n := len(s.items); n > 0 && s.items[n-1].ID == id {
 				s.items = s.items[:n-1]
 			}
+			delete(s.analysis, id)
 			s.mu.Unlock()
 			return Submission{}, err
 		}
+		s.markAnalysisStateLocked(id, true)
 		logger.Info("streamer submission hook completed", zap.String("streamerID", id))
 	}
 
@@ -269,6 +278,7 @@ func (s *Service) RecordLLMDecision(_ context.Context, req RecordDecisionRequest
 
 	s.mu.Lock()
 	s.decisions[streamerID] = append(s.decisions[streamerID], item)
+	s.markAnalysisStateLocked(streamerID, true)
 	s.mu.Unlock()
 
 	return item, nil
@@ -313,6 +323,10 @@ func (s *Service) GetLLMStatus(_ context.Context, streamerID string) LLMStatus {
 	defer s.mu.RUnlock()
 
 	items := s.decisions[key]
+	if state, ok := s.analysis[key]; ok && state.active {
+		status.State = "active"
+		status.UpdatedAt = state.updatedAt
+	}
 	if len(items) == 0 {
 		return status
 	}
@@ -343,6 +357,33 @@ func (s *Service) GetLLMStatus(_ context.Context, streamerID string) LLMStatus {
 	}
 	status.LatestByStage = ordered
 	return status
+}
+
+func (s *Service) MarkAnalysisActive(streamerID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.markAnalysisStateLocked(streamerID, true)
+}
+
+func (s *Service) MarkAnalysisInactive(streamerID string) {
+	id := strings.TrimSpace(streamerID)
+	if id == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.analysis[id] = analysisState{active: false, updatedAt: s.nowFn().UTC().Format(time.RFC3339Nano)}
+}
+
+func (s *Service) markAnalysisStateLocked(streamerID string, active bool) {
+	id := strings.TrimSpace(streamerID)
+	if id == "" {
+		return
+	}
+	s.analysis[id] = analysisState{
+		active:    active,
+		updatedAt: s.nowFn().UTC().Format(time.RFC3339Nano),
+	}
 }
 
 func inferDetectedGameKey(items []LLMDecision) string {

--- a/internal/streamers/service_hook_test.go
+++ b/internal/streamers/service_hook_test.go
@@ -21,6 +21,13 @@ func TestSubmitCallsSubmissionHook(t *testing.T) {
 	if !called {
 		t.Fatalf("expected submission hook to be called")
 	}
+	status := svc.GetLLMStatus(context.Background(), svc.List(context.Background(), "", "", 1)[0].ID)
+	if status.State != "active" {
+		t.Fatalf("expected active analysis status after successful hook, got %q", status.State)
+	}
+	if status.UpdatedAt == "" {
+		t.Fatal("expected status updated timestamp after successful hook")
+	}
 }
 
 func TestSubmitRollsBackOnHookError(t *testing.T) {
@@ -51,5 +58,20 @@ func TestResolveStreamlinkChannel(t *testing.T) {
 	}
 	if channel != "stream_name" {
 		t.Fatalf("channel = %q, want stream_name", channel)
+	}
+}
+
+func TestMarkAnalysisInactiveResetsIdleStatusWithoutDecisions(t *testing.T) {
+	svc := NewService()
+	result, err := svc.Submit(context.Background(), "stream_name", "user-1")
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+
+	svc.MarkAnalysisInactive(result.ID)
+
+	status := svc.GetLLMStatus(context.Background(), result.ID)
+	if status.State != "idle" {
+		t.Fatalf("expected idle status after deactivation, got %q", status.State)
 	}
 }


### PR DESCRIPTION
### Motivation
- Enable background orchestration to mark a streamer as actively being analyzed when the scheduler starts and mark it inactive when the scheduler stops so status endpoints reflect runtime analysis activity.
- Ensure the submission flow immediately starts scheduler orchestration and persists an "active" analysis state so clients and UI can show live analysis after submission.
- Update local docs and implementation checklist to reflect auto-start behavior and operational details.

### Description
- Added lifecycle hook support to the scheduler with `SetLifecycleHooks(onStart, onStop func(string))` and invoked hooks when a scheduler job starts and stops in `internal/media/scheduler.go`.
- Wired scheduler lifecycle hooks to the streamers service in `cmd/server/main.go` via `streamScheduler.SetLifecycleHooks(streamersService.MarkAnalysisActive, streamersService.MarkAnalysisInactive)`.
- Added per-streamer analysis state tracking to `internal/streamers/service.go` using an `analysis` map and functions `MarkAnalysisActive`, `MarkAnalysisInactive`, and `markAnalysisStateLocked`, and updated `Submit` and `RecordLLMDecision` to set the analysis state on successful submission/decisions and to rollback on hook error.
- Adjusted scheduler stop/remove semantics to surface the `onStop` callback and return it from `remove` so it can be executed after cleanup.
- Updated documentation: `docs/implementation_plan.md` checklist item for auto-start and `docs/local_setup.md` description for `POST /api/streamers` to note immediate scheduler start when background orchestration is configured.
- Added unit tests: `internal/media/scheduler_test.go` test `TestSchedulerLifecycleHooksTrackStartAndStop`, `internal/streamers/service_hook_test.go` additions to verify analysis becomes active after hook and resets to idle on deactivation, and `internal/app/router_streamers_submit_test.go` test `TestSubmitStreamerStartsAnalysisStatusWhenHookConfigured` to verify handler behavior.

### Testing
- Ran the new and affected unit tests locally; `go test ./...` completed successfully in the working tree.
- Confirmed `TestSchedulerLifecycleHooksTrackStartAndStop` passed and verifies callbacks are invoked on start/stop of a scheduler job.
- Confirmed streamer-related tests passed, including `TestSubmitCallsSubmissionHook`, `TestSubmitStreamerStartsAnalysisStatusWhenHookConfigured`, and `TestMarkAnalysisInactiveResetsIdleStatusWithoutDecisions`, which validate analysis state transitions after submission, hook errors, and explicit deactivation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb04c83e70832ca26bfb4774fb823c)