### PR TITLE
Add richer LLM decision history metadata

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -920,6 +920,9 @@ components:
           type: number
           minimum: 0
           maximum: 1
+        chunkCapturedAt:
+          type: string
+          format: date-time
         promptVersionId:
           type: string
         promptText:
@@ -934,6 +937,10 @@ components:
           type: integer
         chunkRef:
           type: string
+        requestRef:
+          type: string
+        responseRef:
+          type: string
         rawResponse:
           type: string
         tokensIn:
@@ -942,6 +949,12 @@ components:
           type: integer
         latencyMs:
           type: integer
+        transitionOutcome:
+          type: string
+        transitionToStep:
+          type: string
+        transitionTerminal:
+          type: boolean
     LLMDecision:
       type: object
       properties:
@@ -958,6 +971,9 @@ components:
           type: string
         confidence:
           type: number
+        chunkCapturedAt:
+          type: string
+          format: date-time
         promptVersionId:
           type: string
         promptText:
@@ -972,6 +988,10 @@ components:
           type: integer
         chunkRef:
           type: string
+        requestRef:
+          type: string
+        responseRef:
+          type: string
         rawResponse:
           type: string
         tokensIn:
@@ -980,6 +1000,12 @@ components:
           type: integer
         latencyMs:
           type: integer
+        transitionOutcome:
+          type: string
+        transitionToStep:
+          type: string
+        transitionTerminal:
+          type: boolean
         createdAt:
           type: string
           format: date-time

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -87,21 +87,27 @@ type promptCreateRequest struct {
 }
 
 type llmDecisionRecordRequest struct {
-	RunID           string  `json:"runId"`
-	Stage           string  `json:"stage"`
-	Label           string  `json:"label"`
-	Confidence      float64 `json:"confidence"`
-	PromptVersionID string  `json:"promptVersionId"`
-	PromptText      string  `json:"promptText"`
-	Model           string  `json:"model"`
-	Temperature     float64 `json:"temperature"`
-	MaxTokens       int     `json:"maxTokens"`
-	TimeoutMS       int     `json:"timeoutMs"`
-	ChunkRef        string  `json:"chunkRef"`
-	RawResponse     string  `json:"rawResponse"`
-	TokensIn        int     `json:"tokensIn"`
-	TokensOut       int     `json:"tokensOut"`
-	LatencyMS       int64   `json:"latencyMs"`
+	RunID              string  `json:"runId"`
+	Stage              string  `json:"stage"`
+	Label              string  `json:"label"`
+	Confidence         float64 `json:"confidence"`
+	ChunkCapturedAt    string  `json:"chunkCapturedAt"`
+	PromptVersionID    string  `json:"promptVersionId"`
+	PromptText         string  `json:"promptText"`
+	Model              string  `json:"model"`
+	Temperature        float64 `json:"temperature"`
+	MaxTokens          int     `json:"maxTokens"`
+	TimeoutMS          int     `json:"timeoutMs"`
+	ChunkRef           string  `json:"chunkRef"`
+	RequestRef         string  `json:"requestRef"`
+	ResponseRef        string  `json:"responseRef"`
+	RawResponse        string  `json:"rawResponse"`
+	TokensIn           int     `json:"tokensIn"`
+	TokensOut          int     `json:"tokensOut"`
+	LatencyMS          int64   `json:"latencyMs"`
+	TransitionOutcome  string  `json:"transitionOutcome"`
+	TransitionToStep   string  `json:"transitionToStep"`
+	TransitionTerminal bool    `json:"transitionTerminal"`
 }
 
 type meResponse struct {
@@ -439,23 +445,38 @@ func NewHandler(
 							writeError(w, http.StatusBadRequest, "invalid request body")
 							return
 						}
+						var chunkCapturedAt time.Time
+						if strings.TrimSpace(req.ChunkCapturedAt) != "" {
+							parsed, err := time.Parse(time.RFC3339Nano, req.ChunkCapturedAt)
+							if err != nil {
+								writeError(w, http.StatusBadRequest, "chunkCapturedAt must be RFC3339 timestamp")
+								return
+							}
+							chunkCapturedAt = parsed
+						}
 						item, err := streamersService.RecordLLMDecision(r.Context(), streamers.RecordDecisionRequest{
-							RunID:           req.RunID,
-							StreamerID:      streamerID,
-							Stage:           req.Stage,
-							Label:           req.Label,
-							Confidence:      req.Confidence,
-							PromptVersionID: req.PromptVersionID,
-							PromptText:      req.PromptText,
-							Model:           req.Model,
-							Temperature:     req.Temperature,
-							MaxTokens:       req.MaxTokens,
-							TimeoutMS:       req.TimeoutMS,
-							ChunkRef:        req.ChunkRef,
-							RawResponse:     req.RawResponse,
-							TokensIn:        req.TokensIn,
-							TokensOut:       req.TokensOut,
-							LatencyMS:       req.LatencyMS,
+							RunID:              req.RunID,
+							StreamerID:         streamerID,
+							Stage:              req.Stage,
+							Label:              req.Label,
+							Confidence:         req.Confidence,
+							ChunkCapturedAt:    chunkCapturedAt,
+							PromptVersionID:    req.PromptVersionID,
+							PromptText:         req.PromptText,
+							Model:              req.Model,
+							Temperature:        req.Temperature,
+							MaxTokens:          req.MaxTokens,
+							TimeoutMS:          req.TimeoutMS,
+							ChunkRef:           req.ChunkRef,
+							RequestRef:         req.RequestRef,
+							ResponseRef:        req.ResponseRef,
+							RawResponse:        req.RawResponse,
+							TokensIn:           req.TokensIn,
+							TokensOut:          req.TokensOut,
+							LatencyMS:          req.LatencyMS,
+							TransitionOutcome:  req.TransitionOutcome,
+							TransitionToStep:   req.TransitionToStep,
+							TransitionTerminal: req.TransitionTerminal,
 						})
 						if err != nil {
 							writeError(w, http.StatusBadRequest, err.Error())

--- a/internal/app/router_streamers_llm_test.go
+++ b/internal/app/router_streamers_llm_test.go
@@ -30,21 +30,26 @@ func TestStreamerLLMDecisionsCreateAndList(t *testing.T) {
 
 	adminToken := buildToken(t, "admin-1")
 	body, _ := json.Marshal(map[string]any{
-		"runId":           "run-1",
-		"stage":           "detector",
-		"label":           "cs_detected",
-		"confidence":      0.93,
-		"promptVersionId": "prompt-1",
-		"promptText":      "detect stage",
-		"model":           "gemini-2.0-flash",
-		"temperature":     0.2,
-		"maxTokens":       512,
-		"timeoutMs":       3500,
-		"chunkRef":        "streamlink://str-1/100",
-		"rawResponse":     "{}",
-		"tokensIn":        123,
-		"tokensOut":       19,
-		"latencyMs":       120,
+		"runId":              "run-1",
+		"stage":              "detector",
+		"label":              "cs_detected",
+		"confidence":         0.93,
+		"chunkCapturedAt":    "2025-01-01T12:00:00Z",
+		"promptVersionId":    "prompt-1",
+		"promptText":         "detect stage",
+		"model":              "gemini-2.0-flash",
+		"temperature":        0.2,
+		"maxTokens":          512,
+		"timeoutMs":          3500,
+		"chunkRef":           "streamlink://str-1/100",
+		"requestRef":         "gemini-request-1",
+		"responseRef":        "gemini-response-1",
+		"rawResponse":        "{}",
+		"tokensIn":           123,
+		"tokensOut":          19,
+		"latencyMs":          120,
+		"transitionOutcome":  "cs_detected",
+		"transitionTerminal": true,
 	})
 	createReq := httptest.NewRequest(http.MethodPost, "/api/streamers/str-1/llm-decisions", bytes.NewReader(body))
 	createReq.Header.Set("Authorization", "Bearer "+adminToken)
@@ -70,7 +75,7 @@ func TestStreamerLLMDecisionsCreateAndList(t *testing.T) {
 	if len(items) != 1 {
 		t.Fatalf("expected one item, got %d", len(items))
 	}
-	if items[0]["promptVersionId"] != "prompt-1" {
+	if items[0]["promptVersionId"] != "prompt-1" || items[0]["requestRef"] != "gemini-request-1" || items[0]["transitionOutcome"] != "cs_detected" {
 		t.Fatalf("expected metadata to be returned, got %#v", items[0])
 	}
 }
@@ -102,5 +107,36 @@ func TestStreamerLLMDecisionCreateForbiddenForNonAdmin(t *testing.T) {
 	handler.ServeHTTP(res, req)
 	if res.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", res.Code)
+	}
+}
+
+func TestStreamerLLMDecisionCreateRejectsInvalidChunkTimestamp(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamers.NewService(),
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	body, _ := json.Marshal(map[string]any{
+		"runId":           "run-1",
+		"stage":           "detector",
+		"label":           "cs_detected",
+		"confidence":      0.93,
+		"chunkCapturedAt": "not-a-time",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/streamers/str-1/llm-decisions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", res.Code)
 	}
 }

--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -174,7 +174,7 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 	}
 
 	logger.Info("stream capture completed", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.Int64("bytes", stat.Size()))
-	return ChunkRef{Reference: chunkPath}, nil
+	return ChunkRef{Reference: chunkPath, CapturedAt: a.nowFn().UTC()}, nil
 }
 
 func sanitizeToken(value string) string {

--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -204,12 +204,15 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 	}
 
 	return StageClassification{
-		Label:       strings.TrimSpace(parsed.Label),
-		Confidence:  parsed.Confidence,
-		RawResponse: strings.TrimSpace(rawText),
-		TokensIn:    payload.UsageMetadata.PromptTokenCount,
-		TokensOut:   payload.UsageMetadata.CandidatesTokenCount,
-		Latency:     time.Since(started),
+		Label:             strings.TrimSpace(parsed.Label),
+		Confidence:        parsed.Confidence,
+		RawResponse:       strings.TrimSpace(rawText),
+		RequestRef:        endpoint,
+		ResponseRef:       strconv.Itoa(resp.StatusCode),
+		TokensIn:          payload.UsageMetadata.PromptTokenCount,
+		TokensOut:         payload.UsageMetadata.CandidatesTokenCount,
+		Latency:           time.Since(started),
+		NormalizedOutcome: strings.TrimSpace(parsed.Label),
 	}, nil
 }
 

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -21,7 +21,8 @@ var (
 )
 
 type ChunkRef struct {
-	Reference string
+	Reference  string
+	CapturedAt time.Time
 }
 
 type StageRequest struct {
@@ -32,12 +33,15 @@ type StageRequest struct {
 }
 
 type StageClassification struct {
-	Label       string
-	Confidence  float64
-	RawResponse string
-	TokensIn    int
-	TokensOut   int
-	Latency     time.Duration
+	Label             string
+	Confidence        float64
+	RawResponse       string
+	RequestRef        string
+	ResponseRef       string
+	TokensIn          int
+	TokensOut         int
+	Latency           time.Duration
+	NormalizedOutcome string
 }
 
 type StreamCapture interface {
@@ -194,7 +198,7 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 			logger.Warn("no active global detector configured", zap.String("streamerID", streamerID), zap.Error(err))
 			return streamers.LLMDecision{}, err
 		}
-		detectorDecision, err := w.processPromptTemplate(ctx, runID, streamerID, chunk, globalPrompt)
+		detectorDecision, err := w.processPromptTemplate(ctx, runID, streamerID, chunk, globalPrompt, nil)
 		if err != nil {
 			logger.Error("global detector stage failed", zap.String("streamerID", streamerID), zap.Error(err))
 			return streamers.LLMDecision{}, err
@@ -214,12 +218,11 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 		}
 		lastDecision := detectorDecision
 		for {
-			stepDecision, err := w.processPromptTemplate(ctx, runID, streamerID, chunk, currentStep.Prompt)
+			stepDecision, transition, ok, err := w.processScenarioStep(ctx, runID, streamerID, chunk, currentStep, scenario)
 			if err != nil {
 				return streamers.LLMDecision{}, err
 			}
 			lastDecision = stepDecision
-			transition, ok := scenario.ResolveTransition(currentStep.Code, stepDecision.Label)
 			if !ok || transition.Terminal {
 				return lastDecision, nil
 			}
@@ -241,7 +244,7 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 	var lastDecision streamers.LLMDecision
 	for _, activePrompt := range activePrompts {
 		logger.Info("processing prompt stage", zap.String("streamerID", streamerID), zap.String("runID", runID), zap.String("stage", activePrompt.Stage), zap.String("promptVersionID", activePrompt.ID))
-		decision, err := w.processStage(ctx, runID, streamerID, chunk, activePrompt)
+		decision, err := w.processStage(ctx, runID, streamerID, chunk, activePrompt, nil)
 		if err != nil {
 			logger.Error("prompt stage processing failed", zap.String("streamerID", streamerID), zap.String("runID", runID), zap.String("stage", activePrompt.Stage), zap.Error(err))
 			return streamers.LLMDecision{}, err
@@ -252,8 +255,37 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 	return lastDecision, nil
 }
 
-func (w *Worker) processPromptTemplate(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptTemplate) (streamers.LLMDecision, error) {
-	return w.processStage(ctx, runID, streamerID, chunk, prompts.PromptVersion{
+func (w *Worker) processPromptTemplate(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptTemplate, transition *prompts.ScenarioTransition) (streamers.LLMDecision, error) {
+	return w.processStage(ctx, runID, streamerID, chunk, promptVersionFromTemplate(activePrompt), transition)
+}
+
+func (w *Worker) processScenarioStep(ctx context.Context, runID, streamerID string, chunk ChunkRef, step prompts.ScenarioStep, scenario prompts.ScenarioVersion) (streamers.LLMDecision, prompts.ScenarioTransition, bool, error) {
+	activePrompt := promptVersionFromTemplate(step.Prompt)
+	result, err := w.classifyWithRetry(ctx, StageRequest{
+		StreamerID: streamerID,
+		Stage:      activePrompt.Stage,
+		Chunk:      chunk,
+		Prompt:     activePrompt,
+	}, activePrompt)
+	if err != nil {
+		return streamers.LLMDecision{}, prompts.ScenarioTransition{}, false, err
+	}
+	label := strings.TrimSpace(result.Label)
+	if label == "" || result.Confidence < effectiveConfidenceThreshold(w.minConfidence, activePrompt.MinConfidence) {
+		label = "uncertain"
+	}
+	transition, ok := scenario.ResolveTransition(step.Code, label)
+	decision, err := w.processStageResult(ctx, activePrompt, result, chunk, runID, streamerID, func() *prompts.ScenarioTransition {
+		if !ok {
+			return nil
+		}
+		return &transition
+	}())
+	return decision, transition, ok, err
+}
+
+func promptVersionFromTemplate(activePrompt prompts.PromptTemplate) prompts.PromptVersion {
+	return prompts.PromptVersion{
 		ID:            activePrompt.ID,
 		Stage:         activePrompt.Stage,
 		Template:      activePrompt.Template,
@@ -265,7 +297,7 @@ func (w *Worker) processPromptTemplate(ctx context.Context, runID, streamerID st
 		BackoffMS:     activePrompt.BackoffMS,
 		CooldownMS:    activePrompt.CooldownMS,
 		MinConfidence: activePrompt.MinConfidence,
-	})
+	}
 }
 
 func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (ChunkRef, error) {
@@ -291,33 +323,50 @@ func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (Chunk
 	return ChunkRef{}, lastErr
 }
 
-func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptVersion) (streamers.LLMDecision, error) {
+func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptVersion, transition *prompts.ScenarioTransition) (streamers.LLMDecision, error) {
 	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt}, activePrompt)
 	if err != nil {
 		return streamers.LLMDecision{}, err
 	}
+	return w.processStageResult(ctx, activePrompt, result, chunk, runID, streamerID, transition)
+}
+
+func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.PromptVersion, result StageClassification, chunk ChunkRef, runID, streamerID string, transition *prompts.ScenarioTransition) (streamers.LLMDecision, error) {
 	label := strings.TrimSpace(result.Label)
 	if label == "" || result.Confidence < effectiveConfidenceThreshold(w.minConfidence, activePrompt.MinConfidence) {
 		label = "uncertain"
 	}
-	return w.decisions.RecordLLMDecision(ctx, streamers.RecordDecisionRequest{
-		RunID:           runID,
-		StreamerID:      streamerID,
-		Stage:           activePrompt.Stage,
-		Label:           label,
-		Confidence:      result.Confidence,
-		PromptVersionID: activePrompt.ID,
-		PromptText:      activePrompt.Template,
-		Model:           activePrompt.Model,
-		Temperature:     activePrompt.Temperature,
-		MaxTokens:       activePrompt.MaxTokens,
-		TimeoutMS:       activePrompt.TimeoutMS,
-		ChunkRef:        chunk.Reference,
-		RawResponse:     result.RawResponse,
-		TokensIn:        result.TokensIn,
-		TokensOut:       result.TokensOut,
-		LatencyMS:       result.Latency.Milliseconds(),
-	})
+	transitionOutcome := strings.TrimSpace(result.NormalizedOutcome)
+	if transitionOutcome == "" {
+		transitionOutcome = label
+	}
+	recordReq := streamers.RecordDecisionRequest{
+		RunID:             runID,
+		StreamerID:        streamerID,
+		Stage:             activePrompt.Stage,
+		Label:             label,
+		Confidence:        result.Confidence,
+		ChunkCapturedAt:   chunk.CapturedAt,
+		PromptVersionID:   activePrompt.ID,
+		PromptText:        activePrompt.Template,
+		Model:             activePrompt.Model,
+		Temperature:       activePrompt.Temperature,
+		MaxTokens:         activePrompt.MaxTokens,
+		TimeoutMS:         activePrompt.TimeoutMS,
+		ChunkRef:          chunk.Reference,
+		RequestRef:        result.RequestRef,
+		ResponseRef:       result.ResponseRef,
+		RawResponse:       result.RawResponse,
+		TokensIn:          result.TokensIn,
+		TokensOut:         result.TokensOut,
+		LatencyMS:         result.Latency.Milliseconds(),
+		TransitionOutcome: transitionOutcome,
+	}
+	if transition != nil {
+		recordReq.TransitionToStep = transition.ToStepCode
+		recordReq.TransitionTerminal = transition.Terminal
+	}
+	return w.decisions.RecordLLMDecision(ctx, recordReq)
 }
 
 func (w *Worker) classifyWithRetry(ctx context.Context, input StageRequest, activePrompt prompts.PromptVersion) (StageClassification, error) {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -111,11 +111,11 @@ func (s *fakeDecisionStore) RecordLLMDecision(_ context.Context, req streamers.R
 func TestWorkerProcessStreamerRunsAllOrderedStages(t *testing.T) {
 	decisions := &fakeDecisionStore{}
 	worker := NewWorker(
-		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)}},
 		fakeClassifier{results: map[string]StageClassification{
-			"detector":    {Label: "cs_detected", Confidence: 0.91, RawResponse: `{"label":"cs_detected"}`, TokensIn: 128, TokensOut: 32, Latency: 230 * time.Millisecond},
-			"ranked_mode": {Label: "competitive", Confidence: 0.89, RawResponse: `{"label":"competitive"}`, TokensIn: 96, TokensOut: 18, Latency: 180 * time.Millisecond},
-			"result":      {Label: "win", Confidence: 0.93, RawResponse: `{"label":"win"}`, TokensIn: 75, TokensOut: 14, Latency: 140 * time.Millisecond},
+			"detector":    {Label: "cs_detected", Confidence: 0.91, RawResponse: `{"label":"cs_detected"}`, RequestRef: "req-1", ResponseRef: "res-1", TokensIn: 128, TokensOut: 32, Latency: 230 * time.Millisecond},
+			"ranked_mode": {Label: "competitive", Confidence: 0.89, RawResponse: `{"label":"competitive"}`, RequestRef: "req-2", ResponseRef: "res-2", TokensIn: 96, TokensOut: 18, Latency: 180 * time.Millisecond},
+			"result":      {Label: "win", Confidence: 0.93, RawResponse: `{"label":"win"}`, RequestRef: "req-3", ResponseRef: "res-3", TokensIn: 75, TokensOut: 14, Latency: 140 * time.Millisecond},
 		}},
 		fakePromptResolver{prompts: []prompts.PromptVersion{{ID: "prompt-a", Stage: "detector", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "detect cs", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}, {ID: "prompt-b", Stage: "ranked_mode", Position: 2, IsActive: true, MinConfidence: 0.5, Template: "detect mode", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}, {ID: "prompt-c", Stage: "result", Position: 3, IsActive: true, MinConfidence: 0.5, Template: "detect result", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}}},
 		nil, &InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
@@ -129,6 +129,9 @@ func TestWorkerProcessStreamerRunsAllOrderedStages(t *testing.T) {
 	}
 	if len(decisions.items) != 3 {
 		t.Fatalf("recorded %d decisions, want 3", len(decisions.items))
+	}
+	if decisions.items[0].RequestRef == "" || decisions.items[0].ResponseRef == "" || decisions.items[0].ChunkCapturedAt.IsZero() {
+		t.Fatalf("expected request/response/chunk metadata, got %#v", decisions.items[0])
 	}
 }
 
@@ -252,9 +255,9 @@ func TestWorkerProcessStreamerRunsGlobalDetectorAndScenarioSteps(t *testing.T) {
 	worker := NewWorker(
 		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
 		fakeClassifier{results: map[string]StageClassification{
-			"global_detector": {Label: "counter_strike", Confidence: 0.98},
-			"match_start":     {Label: "match_started", Confidence: 0.93},
-			"match_result":    {Label: "win", Confidence: 0.95},
+			"global_detector": {Label: "counter_strike", Confidence: 0.98, NormalizedOutcome: "counter_strike"},
+			"match_start":     {Label: "match_started", Confidence: 0.93, NormalizedOutcome: "match_started"},
+			"match_result":    {Label: "win", Confidence: 0.95, NormalizedOutcome: "win"},
 		}},
 		nil,
 		fakeScenarioResolver{global: prompts.PromptTemplate{ID: "det-1", Stage: "global_detector", Template: "detect game", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000, MinConfidence: 0.5}, scenario: scenario},
@@ -272,5 +275,11 @@ func TestWorkerProcessStreamerRunsGlobalDetectorAndScenarioSteps(t *testing.T) {
 	}
 	if decisions.items[0].Stage != "global_detector" || decisions.items[1].Stage != "match_start" || decisions.items[2].Stage != "match_result" {
 		t.Fatalf("unexpected decision order: %#v", decisions.items)
+	}
+	if decisions.items[1].TransitionOutcome != "match_started" || decisions.items[1].TransitionToStep != "match_result" {
+		t.Fatalf("expected next-step transition metadata, got %#v", decisions.items[1])
+	}
+	if !decisions.items[2].TransitionTerminal || decisions.items[2].TransitionOutcome != "win" {
+		t.Fatalf("expected terminal transition metadata, got %#v", decisions.items[2])
 	}
 }

--- a/internal/streamers/model.go
+++ b/internal/streamers/model.go
@@ -1,5 +1,7 @@
 package streamers
 
+import "time"
+
 type Streamer struct {
 	ID             string `json:"id"`
 	Platform       string `json:"platform"`
@@ -18,24 +20,30 @@ type Submission struct {
 }
 
 type LLMDecision struct {
-	ID              string  `json:"id"`
-	RunID           string  `json:"runId"`
-	StreamerID      string  `json:"streamerId"`
-	Stage           string  `json:"stage"`
-	Label           string  `json:"label"`
-	Confidence      float64 `json:"confidence"`
-	PromptVersionID string  `json:"promptVersionId,omitempty"`
-	PromptText      string  `json:"promptText,omitempty"`
-	Model           string  `json:"model,omitempty"`
-	Temperature     float64 `json:"temperature,omitempty"`
-	MaxTokens       int     `json:"maxTokens,omitempty"`
-	TimeoutMS       int     `json:"timeoutMs,omitempty"`
-	ChunkRef        string  `json:"chunkRef,omitempty"`
-	RawResponse     string  `json:"rawResponse,omitempty"`
-	TokensIn        int     `json:"tokensIn,omitempty"`
-	TokensOut       int     `json:"tokensOut,omitempty"`
-	LatencyMS       int64   `json:"latencyMs,omitempty"`
-	CreatedAt       string  `json:"createdAt"`
+	ID                 string  `json:"id"`
+	RunID              string  `json:"runId"`
+	StreamerID         string  `json:"streamerId"`
+	Stage              string  `json:"stage"`
+	Label              string  `json:"label"`
+	Confidence         float64 `json:"confidence"`
+	ChunkCapturedAt    string  `json:"chunkCapturedAt,omitempty"`
+	PromptVersionID    string  `json:"promptVersionId,omitempty"`
+	PromptText         string  `json:"promptText,omitempty"`
+	Model              string  `json:"model,omitempty"`
+	Temperature        float64 `json:"temperature,omitempty"`
+	MaxTokens          int     `json:"maxTokens,omitempty"`
+	TimeoutMS          int     `json:"timeoutMs,omitempty"`
+	ChunkRef           string  `json:"chunkRef,omitempty"`
+	RequestRef         string  `json:"requestRef,omitempty"`
+	ResponseRef        string  `json:"responseRef,omitempty"`
+	RawResponse        string  `json:"rawResponse,omitempty"`
+	TokensIn           int     `json:"tokensIn,omitempty"`
+	TokensOut          int     `json:"tokensOut,omitempty"`
+	LatencyMS          int64   `json:"latencyMs,omitempty"`
+	TransitionOutcome  string  `json:"transitionOutcome,omitempty"`
+	TransitionToStep   string  `json:"transitionToStep,omitempty"`
+	TransitionTerminal bool    `json:"transitionTerminal,omitempty"`
+	CreatedAt          string  `json:"createdAt"`
 }
 
 type LLMStatus struct {
@@ -51,20 +59,26 @@ type LLMStatus struct {
 }
 
 type RecordDecisionRequest struct {
-	RunID           string
-	StreamerID      string
-	Stage           string
-	Label           string
-	Confidence      float64
-	PromptVersionID string
-	PromptText      string
-	Model           string
-	Temperature     float64
-	MaxTokens       int
-	TimeoutMS       int
-	ChunkRef        string
-	RawResponse     string
-	TokensIn        int
-	TokensOut       int
-	LatencyMS       int64
+	RunID              string
+	StreamerID         string
+	Stage              string
+	Label              string
+	Confidence         float64
+	PromptVersionID    string
+	PromptText         string
+	Model              string
+	Temperature        float64
+	MaxTokens          int
+	TimeoutMS          int
+	ChunkRef           string
+	ChunkCapturedAt    time.Time
+	RequestRef         string
+	ResponseRef        string
+	RawResponse        string
+	TokensIn           int
+	TokensOut          int
+	LatencyMS          int64
+	TransitionOutcome  string
+	TransitionToStep   string
+	TransitionTerminal bool
 }

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -256,24 +256,30 @@ func (s *Service) RecordLLMDecision(_ context.Context, req RecordDecisionRequest
 	s.counterMu.Unlock()
 
 	item := LLMDecision{
-		ID:              id,
-		RunID:           runID,
-		StreamerID:      streamerID,
-		Stage:           stage,
-		Label:           label,
-		Confidence:      req.Confidence,
-		PromptVersionID: strings.TrimSpace(req.PromptVersionID),
-		PromptText:      strings.TrimSpace(req.PromptText),
-		Model:           strings.TrimSpace(req.Model),
-		Temperature:     req.Temperature,
-		MaxTokens:       req.MaxTokens,
-		TimeoutMS:       req.TimeoutMS,
-		ChunkRef:        strings.TrimSpace(req.ChunkRef),
-		RawResponse:     strings.TrimSpace(req.RawResponse),
-		TokensIn:        req.TokensIn,
-		TokensOut:       req.TokensOut,
-		LatencyMS:       req.LatencyMS,
-		CreatedAt:       s.nowFn().UTC().Format(time.RFC3339Nano),
+		ID:                 id,
+		RunID:              runID,
+		StreamerID:         streamerID,
+		Stage:              stage,
+		Label:              label,
+		Confidence:         req.Confidence,
+		ChunkCapturedAt:    formatOptionalTime(req.ChunkCapturedAt),
+		PromptVersionID:    strings.TrimSpace(req.PromptVersionID),
+		PromptText:         strings.TrimSpace(req.PromptText),
+		Model:              strings.TrimSpace(req.Model),
+		Temperature:        req.Temperature,
+		MaxTokens:          req.MaxTokens,
+		TimeoutMS:          req.TimeoutMS,
+		ChunkRef:           strings.TrimSpace(req.ChunkRef),
+		RequestRef:         strings.TrimSpace(req.RequestRef),
+		ResponseRef:        strings.TrimSpace(req.ResponseRef),
+		RawResponse:        strings.TrimSpace(req.RawResponse),
+		TokensIn:           req.TokensIn,
+		TokensOut:          req.TokensOut,
+		LatencyMS:          req.LatencyMS,
+		TransitionOutcome:  strings.TrimSpace(req.TransitionOutcome),
+		TransitionToStep:   strings.TrimSpace(req.TransitionToStep),
+		TransitionTerminal: req.TransitionTerminal,
+		CreatedAt:          s.nowFn().UTC().Format(time.RFC3339Nano),
 	}
 
 	s.mu.Lock()
@@ -282,6 +288,13 @@ func (s *Service) RecordLLMDecision(_ context.Context, req RecordDecisionRequest
 	s.mu.Unlock()
 
 	return item, nil
+}
+
+func formatOptionalTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
 }
 
 func (s *Service) ListLLMDecisions(_ context.Context, streamerID string, limit int) []LLMDecision {

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -91,22 +91,28 @@ func TestRecordAndListLLMDecisions(t *testing.T) {
 	}
 	now = now.Add(time.Second)
 	second, err := svc.RecordLLMDecision(context.Background(), RecordDecisionRequest{
-		RunID:           "run-1",
-		StreamerID:      "str-1",
-		Stage:           "ranked_mode",
-		Label:           "competitive",
-		Confidence:      0.8,
-		PromptVersionID: "prompt-2",
-		PromptText:      "classify match type",
-		Model:           "gemini-2.0-flash",
-		Temperature:     0.1,
-		MaxTokens:       500,
-		TimeoutMS:       2500,
-		ChunkRef:        "streamlink://str-1/123",
-		RawResponse:     "{\"label\":\"competitive\"}",
-		TokensIn:        144,
-		TokensOut:       27,
-		LatencyMS:       180,
+		RunID:              "run-1",
+		StreamerID:         "str-1",
+		Stage:              "ranked_mode",
+		Label:              "competitive",
+		Confidence:         0.8,
+		ChunkCapturedAt:    now,
+		PromptVersionID:    "prompt-2",
+		PromptText:         "classify match type",
+		Model:              "gemini-2.0-flash",
+		Temperature:        0.1,
+		MaxTokens:          500,
+		TimeoutMS:          2500,
+		ChunkRef:           "streamlink://str-1/123",
+		RequestRef:         "gemini-request-1",
+		ResponseRef:        "gemini-response-1",
+		RawResponse:        "{\"label\":\"competitive\"}",
+		TokensIn:           144,
+		TokensOut:          27,
+		LatencyMS:          180,
+		TransitionOutcome:  "competitive",
+		TransitionToStep:   "wait_for_result",
+		TransitionTerminal: false,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -119,7 +125,7 @@ func TestRecordAndListLLMDecisions(t *testing.T) {
 	if items[0].ID != second.ID {
 		t.Fatalf("expected latest decision first, got %s", items[0].ID)
 	}
-	if items[0].PromptVersionID != "prompt-2" || items[0].ChunkRef == "" || items[0].LatencyMS != 180 {
+	if items[0].PromptVersionID != "prompt-2" || items[0].ChunkRef == "" || items[0].LatencyMS != 180 || items[0].RequestRef == "" || items[0].TransitionToStep != "wait_for_result" {
 		t.Fatalf("expected metadata to be persisted, got %#v", items[0])
 	}
 }


### PR DESCRIPTION
### Motivation
- Provide richer persisted context for stream analysis runs so consumers (admin UI, backfill, realtime) can inspect chunk timestamps, LLM request/response references and scenario transition outcomes required by the M2.1 orchestration flow.

### Description
- Persist and expose additional LLM decision fields: `chunkCapturedAt`, `requestRef`, `responseRef`, `transitionOutcome`, `transitionToStep`, and `transitionTerminal` in `internal/streamers` models and API responses, and update OpenAPI (`docs/openapi.yaml`) accordingly.
- Thread capture timestamps and transition metadata through the media pipeline by returning `ChunkRef.CapturedAt` from streamlink adapter, populating `StageClassification.RequestRef/ResponseRef/NormalizedOutcome` in Gemini adapter, and recording those values in the worker when calling `RecordLLMDecision`.
- Extend worker orchestration to emit and persist normalized transition outcomes and next-step/terminal metadata for scenario steps while preserving existing retry/lock behavior; refactor prompt/template -> promptVersion plumbing to centralize conversion.
- API surface and validation: accept `chunkCapturedAt` in admin POST `/api/streamers/{streamerId}/llm-decisions`, validate RFC3339 timestamp, and return the enriched decision payload on GET; tests updated to cover happy path and invalid timestamp validation.
- M2.1 checklist status (aligned to `docs/implementation_plan.md`): [x] Auto-start Streamlink analysis job after `POST /api/streamers`; [ ] Fixed 10-second capture cadence with lock/idempotency protections; [ ] Persist global detector prompts to DB; [ ] Persist per-game scenarios to DB; [x] Resolve active global detector; [x] Resolve active per-game scenario and step; [x] Worker payload includes prompt runtime params; [x] Persist chunk/LLM/request-response/transition metadata; [ ] Publish realtime `LLM_STAGE_UPDATED` events and backfill/history; [ ] Add DLQ/retries and observability.

### Testing
- Ran unit tests: `go test ./internal/streamers ./internal/media ./internal/app`, and the test suites completed successfully.
- Added/updated tests for worker orchestration and persistence (`internal/media/worker_test.go`), streamers decision persistence (`internal/streamers/service_test.go`), and HTTP validation/roundtrip (`internal/app/router_streamers_llm_test.go`), all of which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb0d78bf74832c92bab28ce2241805)