### PR TITLE
Align stream capture scheduler cadence

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -31,7 +31,7 @@ stream analysis immediately after a streamer is added:
 
 ### Priority checklist (must be tracked in status updates)
 - [x] Auto-start Streamlink analysis job after `POST /api/streamers` success.
-- [ ] Fixed 10-second capture cadence with lock/idempotency protections.
+- [x] Fixed 10-second capture cadence with lock/idempotency protections.
 - [ ] Persist the active global game-detection prompt in the database with audit/version history.
 - [ ] Persist active per-game scenarios in the database, including linked steps and expected transitions.
 - [x] Resolve the active global game-detection prompt from admin configuration.

--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -40,6 +40,11 @@
 - **Setup**: 10k simulated connections per node; publish `EVENT_UPDATED` at 2 Hz.
 - **Assertions**: 99% of clients receive updates within 1 s; dropped message rate < 0.5%.
 
+### S7 – Streamlink Capture Cadence & Idempotency
+- **Path**: background `streamlink -> LLM` scheduler for active streamers.
+- **Profile**: 100 active streamers across 15 minutes with a fixed 10-second capture cadence.
+- **Assertions**: no streamer executes more than one capture cycle per 10-second window; duplicate scheduler starts do not increase chunk volume; worker busy skips remain below 1% after warm-up.
+
 ## Metrics Collection
 - Export `http_server_duration_seconds` (histograms) to Prometheus.
 - Custom metrics: `votes_submitted_total`, `ws_clients_connected`, `ws_message_lag_seconds`.
@@ -53,4 +58,3 @@
 ## Test Automation
 - Add GitHub Actions workflow to run nightly k6 smoke (reduced load) against staging.
 - Full test suite executed before major releases.
-

--- a/internal/media/scheduler.go
+++ b/internal/media/scheduler.go
@@ -3,6 +3,7 @@ package media
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -29,6 +30,8 @@ type Scheduler struct {
 	logger    *zap.Logger
 	processor StreamProcessor
 	interval  time.Duration
+	locker    Locker
+	nowFn     func() time.Time
 
 	mu      sync.Mutex
 	jobs    map[string]context.CancelFunc
@@ -44,10 +47,26 @@ func NewScheduler(worker *Worker, interval time.Duration) *Scheduler {
 }
 
 func NewSchedulerWithProcessor(processor StreamProcessor, interval time.Duration) *Scheduler {
+	return NewSchedulerWithProcessorAndLocker(processor, interval, NewInMemoryLocker())
+}
+
+func NewSchedulerWithProcessorAndLocker(processor StreamProcessor, interval time.Duration, locker Locker) *Scheduler {
 	if interval <= 0 {
 		interval = 10 * time.Second
 	}
-	return &Scheduler{logger: zap.NewNop(), processor: processor, interval: interval, jobs: make(map[string]context.CancelFunc)}
+	if locker == nil {
+		locker = NewInMemoryLocker()
+	}
+	return &Scheduler{
+		logger:    zap.NewNop(),
+		processor: processor,
+		interval:  interval,
+		locker:    locker,
+		nowFn: func() time.Time {
+			return time.Now().UTC()
+		},
+		jobs: make(map[string]context.CancelFunc),
+	}
 }
 
 func (s *Scheduler) SetLogger(logger *zap.Logger) {
@@ -114,16 +133,14 @@ func (s *Scheduler) run(ctx context.Context, streamerID string) {
 		logger.Info("scheduler stopped for streamer", zap.String("streamerID", streamerID))
 	}()
 
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-
 	s.runCycle(ctx, streamerID)
 	for {
+		wait := s.waitUntilNextWindow()
 		select {
 		case <-ctx.Done():
 			logger.Info("scheduler context cancelled", zap.String("streamerID", streamerID))
 			return
-		case <-ticker.C:
+		case <-time.After(wait):
 			s.runCycle(ctx, streamerID)
 		}
 	}
@@ -138,12 +155,53 @@ func (s *Scheduler) runCycle(ctx context.Context, streamerID string) {
 		logger.Warn("scheduler skipped cycle because processor is not configured", zap.String("streamerID", streamerID))
 		return
 	}
-	logger.Info("scheduler cycle triggered", zap.String("streamerID", streamerID))
+	windowStart := s.currentWindowStart()
+	windowKey := fmt.Sprintf("stream-schedule:%s:%d", streamerID, windowStart.Unix())
+	windowTTL := time.Until(windowStart.Add(s.interval))
+	if windowTTL <= 0 {
+		windowTTL = s.interval
+	}
+	if s.locker != nil && !s.locker.TryLock(windowKey, windowTTL) {
+		logger.Info("scheduler cycle skipped due to existing window idempotency key", zap.String("streamerID", streamerID), zap.String("windowKey", windowKey), zap.Time("windowStart", windowStart), zap.Duration("windowTTL", windowTTL))
+		return
+	}
+	logger.Info("scheduler cycle triggered", zap.String("streamerID", streamerID), zap.Time("windowStart", windowStart), zap.String("windowKey", windowKey))
 	if err := s.processor.ProcessStreamer(ctx, streamerID); err != nil {
 		logger.Error("scheduler cycle failed", zap.String("streamerID", streamerID), zap.Error(err))
 		return
 	}
 	logger.Info("scheduler cycle completed", zap.String("streamerID", streamerID))
+}
+
+func (s *Scheduler) currentWindowStart() time.Time {
+	now := time.Now().UTC()
+	if s != nil && s.nowFn != nil {
+		now = s.nowFn().UTC()
+	}
+	if s == nil || s.interval <= 0 {
+		return now
+	}
+	return now.Truncate(s.interval)
+}
+
+func (s *Scheduler) waitUntilNextWindow() time.Duration {
+	if s == nil || s.interval <= 0 {
+		return 10 * time.Second
+	}
+	now := s.currentWindowStart()
+	current := time.Now().UTC()
+	if s.nowFn != nil {
+		current = s.nowFn().UTC()
+	}
+	next := now.Add(s.interval)
+	wait := time.Until(next)
+	if s.nowFn != nil {
+		wait = next.Sub(current)
+	}
+	if wait <= 0 {
+		return s.interval
+	}
+	return wait
 }
 
 func (s *Scheduler) Stop(streamerID string) {

--- a/internal/media/scheduler_test.go
+++ b/internal/media/scheduler_test.go
@@ -101,3 +101,43 @@ func TestSchedulerLifecycleHooksTrackStartAndStop(t *testing.T) {
 		t.Fatalf("unexpected stop hook calls: %#v", stopped)
 	}
 }
+
+func TestSchedulerRunCycleIsIdempotentWithinWindow(t *testing.T) {
+	processor := &fakeProcessor{}
+	now := time.Date(2026, 3, 18, 12, 0, 7, 0, time.UTC)
+	scheduler := NewSchedulerWithProcessorAndLocker(processor, 10*time.Second, NewInMemoryLocker())
+	scheduler.nowFn = func() time.Time { return now }
+
+	scheduler.runCycle(context.Background(), "str-1")
+	scheduler.runCycle(context.Background(), "str-1")
+
+	if got := processor.callCount(); got != 1 {
+		t.Fatalf("expected one call in same window, got %d", got)
+	}
+}
+
+func TestSchedulerRunCycleProcessesNextWindow(t *testing.T) {
+	processor := &fakeProcessor{}
+	now := time.Date(2026, 3, 18, 12, 0, 7, 0, time.UTC)
+	scheduler := NewSchedulerWithProcessorAndLocker(processor, 10*time.Second, NewInMemoryLocker())
+	scheduler.nowFn = func() time.Time { return now }
+
+	scheduler.runCycle(context.Background(), "str-1")
+	now = now.Add(10 * time.Second)
+	scheduler.runCycle(context.Background(), "str-1")
+
+	if got := processor.callCount(); got != 2 {
+		t.Fatalf("expected processing in two distinct windows, got %d", got)
+	}
+}
+
+func TestSchedulerWaitUntilNextWindowAlignsToCadence(t *testing.T) {
+	scheduler := NewSchedulerWithProcessorAndLocker(&fakeProcessor{}, 10*time.Second, NewInMemoryLocker())
+	now := time.Date(2026, 3, 18, 12, 0, 7, 500_000_000, time.UTC)
+	scheduler.nowFn = func() time.Time { return now }
+
+	wait := scheduler.waitUntilNextWindow()
+	if wait != 2500*time.Millisecond {
+		t.Fatalf("expected 2.5s wait until next window, got %s", wait)
+	}
+}


### PR DESCRIPTION
### Motivation
- Ensure the Streamlink capture scheduler executes once per fixed 10-second window and that duplicate scheduler starts do not trigger duplicate captures, matching the M2.1 orchestration requirements for reliable, idempotent stream sampling.

### Description
- Replace ticker-driven scheduling with window-aware cadence: compute `currentWindowStart` and `waitUntilNextWindow` and use `time.After(wait)` to align cycles to fixed windows in `internal/media/scheduler.go`.
- Add per-window idempotency using a `Locker` and window key (`stream-schedule:<streamer>:<window_unix>`) so only one cycle runs per streamer per window; introduce `NewSchedulerWithProcessorAndLocker` and injectable `nowFn` for deterministic tests.
- Add three unit tests validating same-window idempotency, next-window execution, and wait alignment in `internal/media/scheduler_test.go`.
- Update docs: mark the M2.1 cadence/idempotency checklist item as completed in `docs/implementation_plan.md` and add a load-test scenario `S7` for Streamlink cadence/idempotency in `docs/load_testing.md`.

### Testing
- Ran `gofmt -w` on the modified files (succeeded).
- Ran `go test ./internal/media` and the media package tests passed (including the new scheduler tests).
- Compile-only / wider test runs for `./cmd/server`, `./internal/app`, and `./internal/streamers` were attempted but did not complete within the session window (compile attempts started; full run not completed).

M2.1 / priority checklist (aligned to `docs/implementation_plan.md`):
- [x] Auto-start Streamlink analysis job after `POST /api/streamers` success.
- [x] Fixed 10-second capture cadence with lock/idempotency protections.
- [ ] Persist the active global game-detection prompt in the database with audit/version history.
- [ ] Persist active per-game scenarios in the database, including linked steps and expected transitions.
- [x] Resolve the active global game-detection prompt from admin configuration.
- [x] Resolve the active per-game scenario and the active prompt for its current step.
- [x] Worker payload includes prompt text + runtime params (model, temperature, token limits) for the resolved step.
- [ ] Persist chunk metadata, LLM request/response refs, normalized stage decision, confidence, and transition outcome.
- [ ] Publish realtime `LLM_STAGE_UPDATED` events and provide REST backfill/history.
- [ ] Add retry/backoff + DLQ behavior for Streamlink and LLM failures.
- [ ] Add observability for chunk lag, stage latency, and per-streamer failure rate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb10d9cf6c832c8115cdbffc9bbba6)