### PR TITLE
Persist streamer LLM decision history

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -106,6 +106,9 @@ func main() {
 	adminService := admin.NewService(cfg.Admin.UserIDs)
 	streamersService := streamers.NewService()
 	streamersService.SetLogger(logger.Named("streamers"))
+	if db != nil {
+		streamersService.SetDecisionRepository(streamers.NewPostgresDecisionRepository(db))
+	}
 	gamesService := games.NewService()
 	promptsService := prompts.NewService()
 	scenariosService := prompts.NewScenarioService()

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -37,7 +37,7 @@ stream analysis immediately after a streamer is added:
 - [x] Resolve the active global game-detection prompt from admin configuration.
 - [x] Resolve the active per-game scenario and the active prompt for its current step.
 - [x] Worker payload includes prompt text + runtime params (model, temperature, token limits) for the resolved step.
-- [ ] Persist chunk metadata, LLM request/response refs, normalized stage decision, confidence, and transition outcome.
+- [x] Persist chunk metadata, LLM request/response refs, normalized stage decision, confidence, and transition outcome.
 - [ ] Publish realtime `LLM_STAGE_UPDATED` events and provide REST backfill/history.
 - [ ] Add retry/backoff + DLQ behavior for Streamlink and LLM failures.
 - [ ] Add observability for chunk lag, stage latency, and per-streamer failure rate.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -155,6 +155,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
 - `POST /api/streamers` – submits a Twitch streamer nickname for moderation/validation, then immediately starts the per-streamer Streamlink analysis scheduler when background orchestration is configured.
 - `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM detector/scenario status for a streamer.
+- When PostgreSQL is enabled, detailed LLM decision history (`chunkRef`, prompt/runtime params, request/response refs, transition outcome) is persisted in `streamer_llm_decisions` so `/api/streamers/{streamerId}/llm-decisions` and `/status` survive service restarts.
 - `GET /api/streamers/{streamerId}/llm-decisions?limit=` – returns recent detector/scenario decision history for a streamer.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
 - `GET /api/admin/games` – admin-only endpoint listing all configured games.

--- a/internal/streamers/memory_repository.go
+++ b/internal/streamers/memory_repository.go
@@ -1,0 +1,66 @@
+package streamers
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+// InMemoryDecisionRepository stores LLM decisions in process memory.
+type InMemoryDecisionRepository struct {
+	mu    sync.RWMutex
+	items map[string][]LLMDecision
+}
+
+func NewInMemoryDecisionRepository() *InMemoryDecisionRepository {
+	return &InMemoryDecisionRepository{items: make(map[string][]LLMDecision)}
+}
+
+func (r *InMemoryDecisionRepository) RecordLLMDecision(_ context.Context, item LLMDecision) error {
+	key := strings.TrimSpace(item.StreamerID)
+	if key == "" {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.items[key] = append(r.items[key], item)
+	return nil
+}
+
+func (r *InMemoryDecisionRepository) ListLLMDecisions(_ context.Context, streamerID string, limit int) ([]LLMDecision, error) {
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return []LLMDecision{}, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	items := r.items[key]
+	if len(items) == 0 {
+		return []LLMDecision{}, nil
+	}
+	if limit > len(items) {
+		limit = len(items)
+	}
+	start := len(items) - limit
+	out := make([]LLMDecision, 0, limit)
+	for i := len(items) - 1; i >= start; i-- {
+		out = append(out, items[i])
+	}
+	return out, nil
+}
+
+func (r *InMemoryDecisionRepository) ListAllLLMDecisions(_ context.Context, streamerID string) ([]LLMDecision, error) {
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return []LLMDecision{}, nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	items := r.items[key]
+	out := make([]LLMDecision, len(items))
+	copy(out, items)
+	return out, nil
+}

--- a/internal/streamers/postgres_decisions.go
+++ b/internal/streamers/postgres_decisions.go
@@ -1,0 +1,209 @@
+package streamers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PostgresDecisionRepository persists LLM decisions in PostgreSQL for audit/history APIs.
+type PostgresDecisionRepository struct {
+	db *sql.DB
+}
+
+func NewPostgresDecisionRepository(db *sql.DB) *PostgresDecisionRepository {
+	return &PostgresDecisionRepository{db: db}
+}
+
+func (r *PostgresDecisionRepository) RecordLLMDecision(ctx context.Context, item LLMDecision) error {
+	const query = `
+INSERT INTO streamer_llm_decisions (
+	id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
+	prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
+	chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
+	latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+) VALUES (
+	$1, $2, $3, $4, $5, $6, $7,
+	$8, $9, $10, $11, $12, $13,
+	$14, $15, $16, $17, $18, $19,
+	$20, $21, $22, $23, $24
+)`
+	_, err := r.db.ExecContext(ctx, query,
+		item.ID,
+		item.RunID,
+		item.StreamerID,
+		item.Stage,
+		item.Label,
+		item.Confidence,
+		parseRFC3339Null(item.ChunkCapturedAt),
+		nullString(item.PromptVersionID),
+		nullString(item.PromptText),
+		nullString(item.Model),
+		item.Temperature,
+		item.MaxTokens,
+		item.TimeoutMS,
+		nullString(item.ChunkRef),
+		nullString(item.RequestRef),
+		nullString(item.ResponseRef),
+		nullString(item.RawResponse),
+		item.TokensIn,
+		item.TokensOut,
+		item.LatencyMS,
+		nullString(item.TransitionOutcome),
+		nullString(item.TransitionToStep),
+		item.TransitionTerminal,
+		parseRFC3339Time(item.CreatedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("insert streamer llm decision: %w", err)
+	}
+	return nil
+}
+
+func (r *PostgresDecisionRepository) ListLLMDecisions(ctx context.Context, streamerID string, limit int) ([]LLMDecision, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	const query = `
+SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
+       prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
+       chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
+       latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+FROM streamer_llm_decisions
+WHERE streamer_id = $1
+ORDER BY created_at DESC, id DESC
+LIMIT $2`
+	return r.queryDecisions(ctx, query, streamerID, limit)
+}
+
+func (r *PostgresDecisionRepository) ListAllLLMDecisions(ctx context.Context, streamerID string) ([]LLMDecision, error) {
+	const query = `
+SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
+       prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
+       chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
+       latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+FROM streamer_llm_decisions
+WHERE streamer_id = $1
+ORDER BY created_at ASC, id ASC`
+	return r.queryDecisions(ctx, query, streamerID)
+}
+
+func (r *PostgresDecisionRepository) queryDecisions(ctx context.Context, query string, args ...any) ([]LLMDecision, error) {
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query streamer llm decisions: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	items := make([]LLMDecision, 0)
+	for rows.Next() {
+		item, err := scanDecision(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate streamer llm decisions: %w", err)
+	}
+	return items, nil
+}
+
+type decisionScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanDecision(row decisionScanner) (LLMDecision, error) {
+	var (
+		item              LLMDecision
+		chunkCapturedAt   sql.NullTime
+		promptVersionID   sql.NullString
+		promptText        sql.NullString
+		model             sql.NullString
+		chunkRef          sql.NullString
+		requestRef        sql.NullString
+		responseRef       sql.NullString
+		rawResponse       sql.NullString
+		transitionOutcome sql.NullString
+		transitionToStep  sql.NullString
+		createdAt         time.Time
+	)
+	if err := row.Scan(
+		&item.ID,
+		&item.RunID,
+		&item.StreamerID,
+		&item.Stage,
+		&item.Label,
+		&item.Confidence,
+		&chunkCapturedAt,
+		&promptVersionID,
+		&promptText,
+		&model,
+		&item.Temperature,
+		&item.MaxTokens,
+		&item.TimeoutMS,
+		&chunkRef,
+		&requestRef,
+		&responseRef,
+		&rawResponse,
+		&item.TokensIn,
+		&item.TokensOut,
+		&item.LatencyMS,
+		&transitionOutcome,
+		&transitionToStep,
+		&item.TransitionTerminal,
+		&createdAt,
+	); err != nil {
+		return LLMDecision{}, fmt.Errorf("scan streamer llm decision: %w", err)
+	}
+	item.ChunkCapturedAt = formatNullTime(chunkCapturedAt)
+	item.PromptVersionID = promptVersionID.String
+	item.PromptText = promptText.String
+	item.Model = model.String
+	item.ChunkRef = chunkRef.String
+	item.RequestRef = requestRef.String
+	item.ResponseRef = responseRef.String
+	item.RawResponse = rawResponse.String
+	item.TransitionOutcome = transitionOutcome.String
+	item.TransitionToStep = transitionToStep.String
+	item.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
+	return item, nil
+}
+
+func nullString(value string) sql.NullString {
+	trimmed := strings.TrimSpace(value)
+	return sql.NullString{String: trimmed, Valid: trimmed != ""}
+}
+
+func parseRFC3339Null(value string) sql.NullTime {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return sql.NullTime{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, trimmed)
+	if err != nil {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: parsed.UTC(), Valid: true}
+}
+
+func parseRFC3339Time(value string) time.Time {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, trimmed)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
+}
+
+func formatNullTime(value sql.NullTime) string {
+	if !value.Valid {
+		return ""
+	}
+	return value.Time.UTC().Format(time.RFC3339Nano)
+}

--- a/internal/streamers/postgres_decisions_test.go
+++ b/internal/streamers/postgres_decisions_test.go
@@ -1,0 +1,161 @@
+package streamers
+
+import (
+	"context"
+	"database/sql/driver"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPostgresDecisionRepositoryRecordLLMDecision(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresDecisionRepository(db)
+	createdAt := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	capturedAt := createdAt.Add(-10 * time.Second)
+	item := LLMDecision{
+		ID:                 "llm_1",
+		RunID:              "run_1",
+		StreamerID:         "str_1",
+		Stage:              "detector",
+		Label:              "cs_detected",
+		Confidence:         0.91,
+		ChunkCapturedAt:    capturedAt.Format(time.RFC3339Nano),
+		PromptVersionID:    "prompt_1",
+		PromptText:         "detect the game",
+		Model:              "gemini-2.0-flash",
+		Temperature:        0.2,
+		MaxTokens:          256,
+		TimeoutMS:          2000,
+		ChunkRef:           "streamlink://chunk-1",
+		RequestRef:         "req-1",
+		ResponseRef:        "resp-1",
+		RawResponse:        "raw",
+		TokensIn:           123,
+		TokensOut:          45,
+		LatencyMS:          890,
+		TransitionOutcome:  "cs_detected",
+		TransitionToStep:   "match_start",
+		TransitionTerminal: false,
+		CreatedAt:          createdAt.Format(time.RFC3339Nano),
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+INSERT INTO streamer_llm_decisions (
+	id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
+	prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
+	chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
+	latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+) VALUES (
+	$1, $2, $3, $4, $5, $6, $7,
+	$8, $9, $10, $11, $12, $13,
+	$14, $15, $16, $17, $18, $19,
+	$20, $21, $22, $23, $24
+)`)).
+		WithArgs(
+			item.ID,
+			item.RunID,
+			item.StreamerID,
+			item.Stage,
+			item.Label,
+			item.Confidence,
+			sqlmock.AnyArg(),
+			nullDriverString(item.PromptVersionID),
+			nullDriverString(item.PromptText),
+			nullDriverString(item.Model),
+			item.Temperature,
+			item.MaxTokens,
+			item.TimeoutMS,
+			nullDriverString(item.ChunkRef),
+			nullDriverString(item.RequestRef),
+			nullDriverString(item.ResponseRef),
+			nullDriverString(item.RawResponse),
+			item.TokensIn,
+			item.TokensOut,
+			item.LatencyMS,
+			nullDriverString(item.TransitionOutcome),
+			nullDriverString(item.TransitionToStep),
+			item.TransitionTerminal,
+			createdAt,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := repo.RecordLLMDecision(context.Background(), item); err != nil {
+		t.Fatalf("RecordLLMDecision() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresDecisionRepositoryListLLMDecisions(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresDecisionRepository(db)
+	createdAt := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	capturedAt := createdAt.Add(-10 * time.Second)
+	rows := sqlmock.NewRows([]string{
+		"id", "run_id", "streamer_id", "stage", "label", "confidence", "chunk_captured_at",
+		"prompt_version_id", "prompt_text", "model", "temperature", "max_tokens", "timeout_ms",
+		"chunk_ref", "request_ref", "response_ref", "raw_response", "tokens_in", "tokens_out",
+		"latency_ms", "transition_outcome", "transition_to_step", "transition_terminal", "created_at",
+	}).AddRow(
+		"llm_1", "run_1", "str_1", "detector", "cs_detected", 0.91, capturedAt,
+		"prompt_1", "detect the game", "gemini-2.0-flash", 0.2, 256, 2000,
+		"streamlink://chunk-1", "req-1", "resp-1", "raw", 123, 45,
+		890, "cs_detected", "match_start", false, createdAt,
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
+       prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
+       chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
+       latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+FROM streamer_llm_decisions
+WHERE streamer_id = $1
+ORDER BY created_at DESC, id DESC
+LIMIT $2`)).
+		WithArgs("str_1", 5).
+		WillReturnRows(rows)
+
+	items, err := repo.ListLLMDecisions(context.Background(), "str_1", 5)
+	if err != nil {
+		t.Fatalf("ListLLMDecisions() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
+	}
+	if items[0].ChunkCapturedAt != capturedAt.Format(time.RFC3339Nano) || items[0].CreatedAt != createdAt.Format(time.RFC3339Nano) {
+		t.Fatalf("unexpected timestamps: %+v", items[0])
+	}
+	if items[0].TransitionToStep != "match_start" || items[0].RequestRef != "req-1" {
+		t.Fatalf("unexpected decision payload: %+v", items[0])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func nullDriverString(value string) driver.Valuer {
+	return stringValuer(value)
+}
+
+type stringValuer string
+
+func (s stringValuer) Value() (driver.Value, error) {
+	if s == "" {
+		return nil, nil
+	}
+	return string(s), nil
+}

--- a/internal/streamers/repository.go
+++ b/internal/streamers/repository.go
@@ -1,0 +1,10 @@
+package streamers
+
+import "context"
+
+// DecisionRepository persists detailed LLM stage decisions for streamer analysis runs.
+type DecisionRepository interface {
+	RecordLLMDecision(ctx context.Context, item LLMDecision) error
+	ListLLMDecisions(ctx context.Context, streamerID string, limit int) ([]LLMDecision, error)
+	ListAllLLMDecisions(ctx context.Context, streamerID string) ([]LLMDecision, error)
+}

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -49,7 +49,7 @@ type Service struct {
 	logger         *zap.Logger
 	mu             sync.RWMutex
 	items          []Streamer
-	decisions      map[string][]LLMDecision
+	decisionRepo   DecisionRepository
 	analysis       map[string]analysisState
 	validator      TwitchValidator
 	rateLimitMu    sync.Mutex
@@ -72,7 +72,7 @@ func NewServiceWithValidator(validator TwitchValidator) *Service {
 	return &Service{
 		logger:         zap.NewNop(),
 		items:          []Streamer{},
-		decisions:      make(map[string][]LLMDecision),
+		decisionRepo:   NewInMemoryDecisionRepository(),
 		analysis:       make(map[string]analysisState),
 		validator:      validator,
 		rateLimitByKey: make(map[string]submissionLimit),
@@ -91,6 +91,15 @@ func (s *Service) SetLogger(logger *zap.Logger) {
 		return
 	}
 	s.logger = logger
+}
+
+func (s *Service) SetDecisionRepository(repo DecisionRepository) {
+	if s == nil || repo == nil {
+		return
+	}
+	s.mu.Lock()
+	s.decisionRepo = repo
+	s.mu.Unlock()
 }
 
 func (s *Service) SetSubmissionHook(hook func(context.Context, string) error) {
@@ -221,7 +230,9 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 			s.mu.Unlock()
 			return Submission{}, err
 		}
+		s.mu.Lock()
 		s.markAnalysisStateLocked(id, true)
+		s.mu.Unlock()
 		logger.Info("streamer submission hook completed", zap.String("streamerID", id))
 	}
 
@@ -229,7 +240,7 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 	return Submission{ID: id, Status: "pending", Reason: nil}, nil
 }
 
-func (s *Service) RecordLLMDecision(_ context.Context, req RecordDecisionRequest) (LLMDecision, error) {
+func (s *Service) RecordLLMDecision(ctx context.Context, req RecordDecisionRequest) (LLMDecision, error) {
 	streamerID := strings.TrimSpace(req.StreamerID)
 	if streamerID == "" {
 		return LLMDecision{}, errors.New("streamerId is required")
@@ -282,8 +293,18 @@ func (s *Service) RecordLLMDecision(_ context.Context, req RecordDecisionRequest
 		CreatedAt:          s.nowFn().UTC().Format(time.RFC3339Nano),
 	}
 
+	s.mu.RLock()
+	repo := s.decisionRepo
+	s.mu.RUnlock()
+	if repo == nil {
+		repo = NewInMemoryDecisionRepository()
+		s.SetDecisionRepository(repo)
+	}
+	if err := repo.RecordLLMDecision(ctx, item); err != nil {
+		return LLMDecision{}, err
+	}
+
 	s.mu.Lock()
-	s.decisions[streamerID] = append(s.decisions[streamerID], item)
 	s.markAnalysisStateLocked(streamerID, true)
 	s.mu.Unlock()
 
@@ -297,7 +318,7 @@ func formatOptionalTime(value time.Time) string {
 	return value.UTC().Format(time.RFC3339Nano)
 }
 
-func (s *Service) ListLLMDecisions(_ context.Context, streamerID string, limit int) []LLMDecision {
+func (s *Service) ListLLMDecisions(ctx context.Context, streamerID string, limit int) []LLMDecision {
 	key := strings.TrimSpace(streamerID)
 	if key == "" {
 		return []LLMDecision{}
@@ -307,25 +328,23 @@ func (s *Service) ListLLMDecisions(_ context.Context, streamerID string, limit i
 	}
 
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	items := s.decisions[key]
-	if len(items) == 0 {
+	repo := s.decisionRepo
+	s.mu.RUnlock()
+	if repo == nil {
 		return []LLMDecision{}
 	}
-	if limit > len(items) {
-		limit = len(items)
-	}
 
-	start := len(items) - limit
-	out := make([]LLMDecision, 0, limit)
-	for i := len(items) - 1; i >= start; i-- {
-		out = append(out, items[i])
+	items, err := repo.ListLLMDecisions(ctx, key, limit)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("failed to list llm decisions", zap.String("streamerID", key), zap.Error(err))
+		}
+		return []LLMDecision{}
 	}
-	return out
+	return items
 }
 
-func (s *Service) GetLLMStatus(_ context.Context, streamerID string) LLMStatus {
+func (s *Service) GetLLMStatus(ctx context.Context, streamerID string) LLMStatus {
 	key := strings.TrimSpace(streamerID)
 	status := LLMStatus{StreamerID: key, State: "idle", LatestByStage: []LLMDecision{}}
 	if key == "" {
@@ -333,10 +352,22 @@ func (s *Service) GetLLMStatus(_ context.Context, streamerID string) LLMStatus {
 	}
 
 	s.mu.RLock()
-	defer s.mu.RUnlock()
+	repo := s.decisionRepo
+	state, ok := s.analysis[key]
+	s.mu.RUnlock()
 
-	items := s.decisions[key]
-	if state, ok := s.analysis[key]; ok && state.active {
+	items := []LLMDecision{}
+	if repo != nil {
+		loaded, err := repo.ListAllLLMDecisions(ctx, key)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Error("failed to load llm status history", zap.String("streamerID", key), zap.Error(err))
+			}
+		} else {
+			items = loaded
+		}
+	}
+	if ok && state.active {
 		status.State = "active"
 		status.UpdatedAt = state.updatedAt
 	}


### PR DESCRIPTION
### Motivation
- Make LLM stage decisions durable so streamer status and history survive process restarts and can be queried/audited when PostgreSQL is available.
- Replace the ad-hoc in-memory decisions map with a repository abstraction to allow DB-backed storage and future migrations without changing service logic.

### Description
- Add `DecisionRepository` interface and an in-process `InMemoryDecisionRepository` implementation to centralize recording and listing of LLM decisions. 
- Implement `PostgresDecisionRepository` that persists detailed fields (chunk metadata, prompt/runtime params, request/response refs, tokens/latency, transitions) into `streamer_llm_decisions` and rehydrates status/history queries.
- Wire the streamer service to use the repository: `RecordLLMDecision`, `ListLLMDecisions` and `GetLLMStatus` now read/write via the repository, defaulting to the in-memory repo when DB is not configured.
- Auto-select the PostgreSQL repository in the app bootstrap when a DB connection exists and update docs and the implementation-plan checklist to reflect the completed persistence item.
- Priority checklist (aligned with M2.1):
  - [x] Auto-start Streamlink analysis job after `POST /api/streamers` success.
  - [x] Fixed 10-second capture cadence with lock/idempotency protections.
  - [ ] Persist the active global game-detection prompt in the database with audit/version history.
  - [ ] Persist active per-game scenarios in the database, including linked steps and expected transitions.
  - [x] Resolve the active global game-detection prompt from admin configuration.
  - [x] Resolve the active per-game scenario and the active prompt for its current step.
  - [x] Worker payload includes prompt text + runtime params (model, temperature, token limits) for the resolved step.
  - [x] Persist chunk metadata, LLM request/response refs, normalized stage decision, confidence, and transition outcome.
  - [ ] Publish realtime `LLM_STAGE_UPDATED` events and provide REST backfill/history.
  - [ ] Add retry/backoff + DLQ behavior for Streamlink and LLM failures.

### Testing
- Ran unit tests for affected packages: `go test ./internal/streamers` succeeded (including `TestPostgresDecisionRepository*`).
- Ran broader package tests: `go test ./internal/media` and `go test ./internal/app` succeeded.
- Verified server package tests: `go test ./cmd/server` succeeded.
- All executed automated tests completed successfully (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb155cb73c832c8bb2169af9a8d5ab)