### PR TITLE
Add stream worker observability metrics

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -183,6 +183,10 @@ local smoke tests.
 ## Observability Notes
 - Disable Prometheus scraping locally by setting `FUNPOT_TELEMETRY_METRICS_ENABLED=false`.
 - Adjust the log level (`debug`, `info`, `warn`, `error`) via `FUNPOT_LOG_LEVEL`.
+- Stream-analysis metrics now expose worker health signals on `/metrics`, including
+  `funpot_stream_chunk_lag_seconds`, `funpot_stream_stage_latency_ms`,
+  `funpot_stream_stage_results_total`, `funpot_stream_stage_tokens_total`, and
+  `funpot_stream_streamer_failures_total` for M2.1 orchestration monitoring.
 - When Sentry is enabled, the shutdown process flushes pending events with a
   2-second timeout.
 - Telegram authentication requires a bot token; for local development you can

--- a/internal/media/metrics.go
+++ b/internal/media/metrics.go
@@ -1,0 +1,111 @@
+package media
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type workerMetrics struct {
+	cycleTotal        metric.Int64Counter
+	streamerFailures  metric.Int64Counter
+	stageResultsTotal metric.Int64Counter
+	stageLatencyMS    metric.Float64Histogram
+	stageTokensTotal  metric.Int64Counter
+	chunkLagSeconds   metric.Float64Histogram
+}
+
+func newWorkerMetrics() *workerMetrics {
+	meter := otel.Meter("github.com/funpot/funpot-go-core/internal/media")
+
+	cycleTotal, _ := meter.Int64Counter(
+		"funpot_stream_processing_cycles_total",
+		metric.WithDescription("Total number of streamer processing cycles by result."),
+	)
+	streamerFailures, _ := meter.Int64Counter(
+		"funpot_stream_streamer_failures_total",
+		metric.WithDescription("Total number of streamer processing failures grouped by streamer and operation."),
+	)
+	stageResultsTotal, _ := meter.Int64Counter(
+		"funpot_stream_stage_results_total",
+		metric.WithDescription("Total number of processed LLM stage results by stage and normalized outcome."),
+	)
+	stageLatencyMS, _ := meter.Float64Histogram(
+		"funpot_stream_stage_latency_ms",
+		metric.WithDescription("Observed latency for LLM stage classification in milliseconds."),
+	)
+	stageTokensTotal, _ := meter.Int64Counter(
+		"funpot_stream_stage_tokens_total",
+		metric.WithDescription("Total token usage emitted by LLM stage processing."),
+	)
+	chunkLagSeconds, _ := meter.Float64Histogram(
+		"funpot_stream_chunk_lag_seconds",
+		metric.WithDescription("Delay between chunk capture time and decision persistence in seconds."),
+	)
+
+	return &workerMetrics{
+		cycleTotal:        cycleTotal,
+		streamerFailures:  streamerFailures,
+		stageResultsTotal: stageResultsTotal,
+		stageLatencyMS:    stageLatencyMS,
+		stageTokensTotal:  stageTokensTotal,
+		chunkLagSeconds:   chunkLagSeconds,
+	}
+}
+
+func (m *workerMetrics) recordCycle(ctx context.Context, streamerID, result string) {
+	if m == nil {
+		return
+	}
+	m.cycleTotal.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("streamer_id", streamerID),
+		attribute.String("result", result),
+	))
+}
+
+func (m *workerMetrics) recordFailure(ctx context.Context, streamerID, operation string) {
+	if m == nil {
+		return
+	}
+	m.streamerFailures.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("streamer_id", streamerID),
+		attribute.String("operation", operation),
+	))
+}
+
+func (m *workerMetrics) recordStageResult(ctx context.Context, stage, label string, latency time.Duration, tokensIn, tokensOut int) {
+	if m == nil {
+		return
+	}
+	m.stageResultsTotal.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("stage", stage),
+		attribute.String("label", label),
+	))
+	m.stageLatencyMS.Record(ctx, float64(latency.Milliseconds()), metric.WithAttributes(
+		attribute.String("stage", stage),
+	))
+	m.stageTokensTotal.Add(ctx, int64(tokensIn), metric.WithAttributes(
+		attribute.String("stage", stage),
+		attribute.String("direction", "in"),
+	))
+	m.stageTokensTotal.Add(ctx, int64(tokensOut), metric.WithAttributes(
+		attribute.String("stage", stage),
+		attribute.String("direction", "out"),
+	))
+}
+
+func (m *workerMetrics) recordChunkLag(ctx context.Context, stage string, capturedAt time.Time, now time.Time) {
+	if m == nil || capturedAt.IsZero() {
+		return
+	}
+	lag := now.Sub(capturedAt)
+	if lag < 0 {
+		lag = 0
+	}
+	m.chunkLagSeconds.Record(ctx, lag.Seconds(), metric.WithAttributes(
+		attribute.String("stage", stage),
+	))
+}

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -76,6 +76,7 @@ type Locker interface {
 
 type Worker struct {
 	logger              *zap.Logger
+	metrics             *workerMetrics
 	capture             StreamCapture
 	classifier          StageClassifier
 	prompts             PromptResolver
@@ -112,6 +113,7 @@ func NewWorker(capture StreamCapture, classifier StageClassifier, promptResolver
 	}
 	return &Worker{
 		logger:              zap.NewNop(),
+		metrics:             newWorkerMetrics(),
 		capture:             capture,
 		classifier:          classifier,
 		prompts:             promptResolver,
@@ -146,12 +148,14 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 	id := strings.TrimSpace(streamerID)
 	if id == "" {
 		logger.Warn("worker rejected empty streamer id")
+		w.metrics.recordCycle(ctx, id, "invalid")
 		return streamers.LLMDecision{}, ErrStreamerIDRequired
 	}
 	logger.Info("streamer processing cycle started", zap.String("streamerID", id))
 	lockKey := fmt.Sprintf("stream-capture:%s", id)
 	if !w.locker.TryLock(lockKey, w.lockTTL) {
 		logger.Info("streamer processing skipped because worker is busy", zap.String("streamerID", id), zap.String("lockKey", lockKey))
+		w.metrics.recordCycle(ctx, id, "busy")
 		return streamers.LLMDecision{}, ErrStreamerBusy
 	}
 	logger.Info("streamer processing lock acquired", zap.String("streamerID", id), zap.String("lockKey", lockKey), zap.Duration("lockTTL", w.lockTTL))
@@ -163,6 +167,8 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 	runID, err := w.runs.CreateRun(ctx, id)
 	if err != nil {
 		logger.Error("failed to create analysis run", zap.String("streamerID", id), zap.Error(err))
+		w.metrics.recordFailure(ctx, id, "create_run")
+		w.metrics.recordCycle(ctx, id, "failed")
 		return streamers.LLMDecision{}, err
 	}
 	logger.Info("analysis run created", zap.String("streamerID", id), zap.String("runID", runID))
@@ -170,9 +176,12 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 	if err != nil {
 		if errors.Is(err, ErrStreamlinkAdBreak) {
 			logger.Info("stream chunk capture skipped because stream is on ad break", zap.String("streamerID", id), zap.Error(err))
+			w.metrics.recordCycle(ctx, id, "ad_break")
 			return streamers.LLMDecision{}, nil
 		}
 		logger.Error("stream chunk capture failed", zap.String("streamerID", id), zap.Error(err))
+		w.metrics.recordFailure(ctx, id, "capture")
+		w.metrics.recordCycle(ctx, id, "failed")
 		return streamers.LLMDecision{}, err
 	}
 	logger.Info("stream chunk captured", zap.String("streamerID", id), zap.String("chunkRef", chunk.Reference))
@@ -180,8 +189,11 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 
 	lastDecision, err := w.processExecutionPlan(ctx, runID, id, chunk)
 	if err != nil {
+		w.metrics.recordFailure(ctx, id, "execution_plan")
+		w.metrics.recordCycle(ctx, id, "failed")
 		return streamers.LLMDecision{}, err
 	}
+	w.metrics.recordCycle(ctx, id, "completed")
 	logger.Info("streamer processing cycle completed", zap.String("streamerID", id), zap.String("runID", runID), zap.String("finalStage", lastDecision.Stage), zap.String("finalLabel", lastDecision.Label), zap.Float64("finalConfidence", lastDecision.Confidence))
 	return lastDecision, nil
 }
@@ -268,6 +280,7 @@ func (w *Worker) processScenarioStep(ctx context.Context, runID, streamerID stri
 		Prompt:     activePrompt,
 	}, activePrompt)
 	if err != nil {
+		w.metrics.recordFailure(ctx, streamerID, activePrompt.Stage)
 		return streamers.LLMDecision{}, prompts.ScenarioTransition{}, false, err
 	}
 	label := strings.TrimSpace(result.Label)
@@ -326,6 +339,7 @@ func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (Chunk
 func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptVersion, transition *prompts.ScenarioTransition) (streamers.LLMDecision, error) {
 	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt}, activePrompt)
 	if err != nil {
+		w.metrics.recordFailure(ctx, streamerID, activePrompt.Stage)
 		return streamers.LLMDecision{}, err
 	}
 	return w.processStageResult(ctx, activePrompt, result, chunk, runID, streamerID, transition)
@@ -336,6 +350,8 @@ func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.Pr
 	if label == "" || result.Confidence < effectiveConfidenceThreshold(w.minConfidence, activePrompt.MinConfidence) {
 		label = "uncertain"
 	}
+	w.metrics.recordStageResult(ctx, activePrompt.Stage, label, result.Latency, result.TokensIn, result.TokensOut)
+	w.metrics.recordChunkLag(ctx, activePrompt.Stage, chunk.CapturedAt, time.Now().UTC())
 	transitionOutcome := strings.TrimSpace(result.NormalizedOutcome)
 	if transitionOutcome == "" {
 		transitionOutcome = label
@@ -366,7 +382,12 @@ func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.Pr
 		recordReq.TransitionToStep = transition.ToStepCode
 		recordReq.TransitionTerminal = transition.Terminal
 	}
-	return w.decisions.RecordLLMDecision(ctx, recordReq)
+	decision, err := w.decisions.RecordLLMDecision(ctx, recordReq)
+	if err != nil {
+		w.metrics.recordFailure(ctx, streamerID, "record_decision")
+		return streamers.LLMDecision{}, err
+	}
+	return decision, nil
 }
 
 func (w *Worker) classifyWithRetry(ctx context.Context, input StageRequest, activePrompt prompts.PromptVersion) (StageClassification, error) {


### PR DESCRIPTION
### Motivation
- Improve M2.1 observability for the stream analysis worker by exporting metrics that surface failures, per-stage latency, token usage, and chunk lag to OpenTelemetry/Prometheus so monitoring and alerting can be added in follow-ups.

### Description
- Add `internal/media/metrics.go` implementing OpenTelemetry metrics for processing cycles, per-streamer failures, stage result counts, stage latency, token usage, and chunk lag; expose helper methods to record these signals.
- Instrument the media `Worker` to record cycle outcomes (invalid/busy/ad_break/failed/completed), capture/classification/persistence failures, per-stage latency/tokens, and chunk lag before persisting decisions (`internal/media/worker.go`).
- Update `docs/local_setup.md` to document the new metric names for local verification and monitoring.
- M2.1 priority checklist (aligned to `docs/implementation_plan.md`):
  - [x] Auto-start Streamlink analysis job after `POST /api/streamers` success.
  - [x] Fixed 10-second capture cadence with lock/idempotency protections.
  - [ ] Persist the active global game-detection prompt in the database with audit/version history.
  - [ ] Persist active per-game scenarios in the database, including linked steps and expected transitions.
  - [x] Resolve the active global game-detection prompt from admin configuration.
  - [x] Resolve the active per-game scenario and the active prompt for its current step.
  - [x] Worker payload includes prompt text + runtime params (model, temperature, token limits) for the resolved step.
  - [x] Persist chunk metadata, LLM request/response refs, normalized stage decision, confidence, and transition outcome.
  - [ ] Publish realtime `LLM_STAGE_UPDATED` events and provide REST backfill/history.
  - [ ] Add retry/backoff + DLQ behavior for Streamlink and LLM failures.
  - [x] Add observability for chunk lag, stage latency, and per-streamer failure rate (this PR).
  - [ ] Add observability for success ratio, token usage rollups, and drift alerts for prompt regressions.

### Testing
- Run package tests: `go test ./internal/media -run 'TestWorker|TestStreamlink|TestPrompted|TestGemini' -count=1` (package tests executed successfully).
- Run service tests: `go test ./internal/streamers ./internal/app -count=1` (succeeded).
- Full test suite: `go test ./...` (completed successfully across the repository).
- All automated tests referenced above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb182a37a4832c840d52eb4ba9e318)