### PR TITLE
Fix go.mod dependency classification for otel metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.48.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.26.0
+	go.opentelemetry.io/otel/metric v1.26.0
 	go.opentelemetry.io/otel/sdk v1.26.0
 	go.opentelemetry.io/otel/sdk/metric v1.26.0
 	go.uber.org/zap v1.27.0
@@ -33,7 +34,6 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
-	go.opentelemetry.io/otel/metric v1.26.0 // indirect
 	go.opentelemetry.io/otel/trace v1.26.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect


### PR DESCRIPTION
### Motivation
- The `internal/media/metrics.go` file imports `go.opentelemetry.io/otel/metric` directly but `go.mod` listed it as `// indirect`, which caused module verification failures and needs to be corrected so verification passes.
- Checklist aligned with `docs/implementation_plan.md` M2.1:
  - [x] Unblocked `go.mod` / `go.sum` verification by classifying `go.opentelemetry.io/otel/metric` as a direct dependency.
  - [ ] Automatically connect/start worker job after streamer onboarding.
  - [ ] Download/capture stream chunks every 10 seconds.
  - [ ] Send each chunk to the LLM with the active admin-created prompt.
  - [ ] Persist decisions and publish live status updates.

### Description
- Move `go.opentelemetry.io/otel/metric` from the indirect dependency block into the direct `require` block in `go.mod` so the module metadata matches the actual import in `internal/media/metrics.go`.

### Testing
- Ran `go mod tidy` and it completed successfully.
- Ran `go mod verify` and it reported `all modules verified`.
- Ran `go test ./... -count=1` in this environment which timed out without any failing package output before the timeout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc4d238e7c832c863158e10725620f)