### PR TITLE
Add streamer_llm_decisions migration (0002) and update migration plan

### DIFF
--- a/docs/migrations_plan.md
+++ b/docs/migrations_plan.md
@@ -1,8 +1,10 @@
 # Migration Plan
 
 ## v1 (Initial Release)
-> Current status: migration scaffolding added in `migrations/0001_users.up.sql`
-> and `migrations/0001_users.down.sql` for the `users` domain.
+> Current status: migration scaffolding added for `users` and streamer LLM
+> decision persistence in `migrations/0001_users.up.sql`,
+> `migrations/0001_users.down.sql`, `migrations/0002_streamer_llm_decisions.up.sql`,
+> and `migrations/0002_streamer_llm_decisions.down.sql`.
 
 1. Create core tables: `users`, `wallet_accounts`, `wallet_ledger`, `payments`, `streamers`, `games`, `events`, `votes`, `media_clips`, `prompts`, `config`, `referrals`, `idempotency`.
 2. Seed configuration values: `minViewers=100`, `starsRate`, `limits.votePerMin`, feature flags (`paymentsEnabled`, `referralsEnabled`, `mediaEnabled`, `adminEnabled`).

--- a/migrations/0002_streamer_llm_decisions.down.sql
+++ b/migrations/0002_streamer_llm_decisions.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_streamer_llm_decisions_streamer_stage_created_at;
+DROP INDEX IF EXISTS idx_streamer_llm_decisions_run_id;
+DROP INDEX IF EXISTS idx_streamer_llm_decisions_streamer_created_at;
+DROP TABLE IF EXISTS streamer_llm_decisions;

--- a/migrations/0002_streamer_llm_decisions.up.sql
+++ b/migrations/0002_streamer_llm_decisions.up.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS streamer_llm_decisions (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    streamer_id TEXT NOT NULL,
+    stage TEXT NOT NULL,
+    label TEXT NOT NULL,
+    confidence DOUBLE PRECISION NOT NULL DEFAULT 0,
+    chunk_captured_at TIMESTAMPTZ,
+    prompt_version_id TEXT,
+    prompt_text TEXT,
+    model TEXT,
+    temperature DOUBLE PRECISION NOT NULL DEFAULT 0,
+    max_tokens INTEGER NOT NULL DEFAULT 0,
+    timeout_ms INTEGER NOT NULL DEFAULT 0,
+    chunk_ref TEXT,
+    request_ref TEXT,
+    response_ref TEXT,
+    raw_response TEXT,
+    tokens_in INTEGER NOT NULL DEFAULT 0,
+    tokens_out INTEGER NOT NULL DEFAULT 0,
+    latency_ms BIGINT NOT NULL DEFAULT 0,
+    transition_outcome TEXT,
+    transition_to_step TEXT,
+    transition_terminal BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL,
+    CHECK (char_length(id) > 0),
+    CHECK (char_length(run_id) > 0),
+    CHECK (char_length(streamer_id) > 0),
+    CHECK (char_length(stage) > 0),
+    CHECK (char_length(label) > 0),
+    CHECK (confidence >= 0 AND confidence <= 1),
+    CHECK (temperature >= 0),
+    CHECK (max_tokens >= 0),
+    CHECK (timeout_ms >= 0),
+    CHECK (tokens_in >= 0),
+    CHECK (tokens_out >= 0),
+    CHECK (latency_ms >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_streamer_llm_decisions_streamer_created_at
+    ON streamer_llm_decisions (streamer_id, created_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_streamer_llm_decisions_run_id
+    ON streamer_llm_decisions (run_id);
+CREATE INDEX IF NOT EXISTS idx_streamer_llm_decisions_streamer_stage_created_at
+    ON streamer_llm_decisions (streamer_id, stage, created_at DESC, id DESC);


### PR DESCRIPTION
### Motivation
- Persist LLM decisions produced for streamers to support auditing, replay, and analytics of model outputs and transitions.
- Provide efficient query paths for streamer-, run-, and stage-scoped lookups via dedicated indexes and enforce basic data integrity with non-null checks and value bounds.

### Description
- Add migration files `migrations/0002_streamer_llm_decisions.up.sql` and `migrations/0002_streamer_llm_decisions.down.sql` to create and drop the `streamer_llm_decisions` table with indexes `idx_streamer_llm_decisions_streamer_created_at`, `idx_streamer_llm_decisions_run_id`, and `idx_streamer_llm_decisions_streamer_stage_created_at`.
- Define a schema capturing run metadata, prompt/model params, tokens/latency, raw responses, transition outcome fields, timestamps, and checks on required text fields and numeric bounds.
- Update `docs/migrations_plan.md` to record that migration scaffolding was added for `users` and streamer LLM decision persistence and to list the new migration files.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd34fa18bc832c8a54ee5a3362144d)