### PR TITLE
Add ScenarioService and admin HTTP endpoints for scenarios and global detectors

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -190,6 +190,7 @@ func main() {
 		streamersService,
 		gamesService,
 		promptsService,
+		scenariosService,
 		eventsService,
 		app.ConfigResponseFromConfig(cfg),
 	)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -375,6 +375,234 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PromptVersion'
+  /api/admin/global-detectors:
+    get:
+      summary: List global detector prompts (admin)
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Global detector prompts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PromptTemplate'
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create global detector prompt (admin)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PromptCreateRequest'
+      responses:
+        '201':
+          description: Created global detector prompt
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptTemplate'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/global-detectors/{detectorId}:
+    get:
+      summary: Get global detector prompt (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: detectorId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Global detector prompt
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptTemplate'
+        default:
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update global detector prompt (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: detectorId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PromptCreateRequest'
+      responses:
+        '200':
+          description: Updated global detector prompt
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptTemplate'
+        default:
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Delete global detector prompt (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: detectorId
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Global detector deleted
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/global-detectors/{detectorId}/activate:
+    post:
+      summary: Activate global detector prompt (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: detectorId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activated global detector prompt
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptTemplate'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/scenarios:
+    get:
+      summary: List scenarios (admin)
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Scenario versions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScenarioVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create scenario (admin)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScenarioCreateRequest'
+      responses:
+        '201':
+          description: Created scenario
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioVersion'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/scenarios/{scenarioId}:
+    get:
+      summary: Get scenario (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: scenarioId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Scenario version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update scenario (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: scenarioId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScenarioCreateRequest'
+      responses:
+        '200':
+          description: Updated scenario
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Delete scenario (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: scenarioId
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Scenario deleted
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/scenarios/{scenarioId}/activate:
+    post:
+      summary: Activate scenario (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: scenarioId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activated scenario
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioVersion'
         default:
           $ref: '#/components/responses/Error'
   /api/events/live:
@@ -1112,6 +1340,147 @@ components:
               type: string
               format: date-time
               nullable: true
+    PromptTemplate:
+      allOf:
+        - $ref: '#/components/schemas/PromptCreateRequest'
+        - type: object
+          properties:
+            id:
+              type: string
+            kind:
+              type: string
+            gameSlug:
+              type: string
+              nullable: true
+            version:
+              type: integer
+            isActive:
+              type: boolean
+            createdBy:
+              type: string
+            activatedBy:
+              type: string
+              nullable: true
+            createdAt:
+              type: string
+              format: date-time
+            activatedAt:
+              type: string
+              format: date-time
+              nullable: true
+    ScenarioStepRequest:
+      type: object
+      required: [code, title, promptTemplate, model, temperature, maxTokens, timeoutMs, retryCount, backoffMs, cooldownMs, minConfidence]
+      properties:
+        code:
+          type: string
+        title:
+          type: string
+        promptTemplate:
+          type: string
+        model:
+          type: string
+        temperature:
+          type: number
+        maxTokens:
+          type: integer
+        timeoutMs:
+          type: integer
+        retryCount:
+          type: integer
+        backoffMs:
+          type: integer
+        cooldownMs:
+          type: integer
+        minConfidence:
+          type: number
+    ScenarioTransitionRequest:
+      type: object
+      required: [fromStepCode, outcome]
+      properties:
+        fromStepCode:
+          type: string
+        outcome:
+          type: string
+        toStepCode:
+          type: string
+        terminal:
+          type: boolean
+    ScenarioCreateRequest:
+      type: object
+      required: [gameSlug, name, steps, transitions]
+      properties:
+        gameSlug:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScenarioStepRequest'
+        transitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScenarioTransitionRequest'
+    ScenarioStep:
+      type: object
+      properties:
+        id:
+          type: string
+        code:
+          type: string
+        title:
+          type: string
+        position:
+          type: integer
+        prompt:
+          $ref: '#/components/schemas/PromptTemplate'
+    ScenarioTransition:
+      type: object
+      properties:
+        id:
+          type: string
+        fromStepCode:
+          type: string
+        outcome:
+          type: string
+        toStepCode:
+          type: string
+        terminal:
+          type: boolean
+    ScenarioVersion:
+      allOf:
+        - $ref: '#/components/schemas/ScenarioCreateRequest'
+        - type: object
+          properties:
+            id:
+              type: string
+            version:
+              type: integer
+            isActive:
+              type: boolean
+            createdBy:
+              type: string
+            activatedBy:
+              type: string
+              nullable: true
+            createdAt:
+              type: string
+              format: date-time
+            activatedAt:
+              type: string
+              format: date-time
+              nullable: true
+            steps:
+              type: array
+              items:
+                $ref: '#/components/schemas/ScenarioStep'
+            transitions:
+              type: array
+              items:
+                $ref: '#/components/schemas/ScenarioTransition'
     LiveEvent:
       type: object
       properties:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -55,6 +55,42 @@ func ConfigResponseFromConfig(cfg config.Config) ClientConfigResponse {
 	}
 }
 
+func scenarioRequestToCreateRequest(req scenarioCreateRequest, actorID string) prompts.CreateScenarioRequest {
+	steps := make([]prompts.ScenarioStepInput, 0, len(req.Steps))
+	for _, step := range req.Steps {
+		steps = append(steps, prompts.ScenarioStepInput{
+			Code:           step.Code,
+			Title:          step.Title,
+			PromptTemplate: step.PromptTemplate,
+			Model:          step.Model,
+			Temperature:    step.Temperature,
+			MaxTokens:      step.MaxTokens,
+			TimeoutMS:      step.TimeoutMS,
+			RetryCount:     step.RetryCount,
+			BackoffMS:      step.BackoffMS,
+			CooldownMS:     step.CooldownMS,
+			MinConfidence:  step.MinConfidence,
+		})
+	}
+	transitions := make([]prompts.ScenarioTransitionInput, 0, len(req.Transitions))
+	for _, transition := range req.Transitions {
+		transitions = append(transitions, prompts.ScenarioTransitionInput{
+			FromStepCode: transition.FromStepCode,
+			Outcome:      transition.Outcome,
+			ToStepCode:   transition.ToStepCode,
+			Terminal:     transition.Terminal,
+		})
+	}
+	return prompts.CreateScenarioRequest{
+		GameSlug:    req.GameSlug,
+		Name:        req.Name,
+		Description: req.Description,
+		ActorID:     actorID,
+		Steps:       steps,
+		Transitions: transitions,
+	}
+}
+
 type configLimits struct {
 	VotePerMin int `json:"votePerMin"`
 }
@@ -84,6 +120,35 @@ type promptCreateRequest struct {
 	BackoffMS     int     `json:"backoffMs"`
 	CooldownMS    int     `json:"cooldownMs"`
 	MinConfidence float64 `json:"minConfidence"`
+}
+
+type scenarioStepRequest struct {
+	Code           string  `json:"code"`
+	Title          string  `json:"title"`
+	PromptTemplate string  `json:"promptTemplate"`
+	Model          string  `json:"model"`
+	Temperature    float64 `json:"temperature"`
+	MaxTokens      int     `json:"maxTokens"`
+	TimeoutMS      int     `json:"timeoutMs"`
+	RetryCount     int     `json:"retryCount"`
+	BackoffMS      int     `json:"backoffMs"`
+	CooldownMS     int     `json:"cooldownMs"`
+	MinConfidence  float64 `json:"minConfidence"`
+}
+
+type scenarioTransitionRequest struct {
+	FromStepCode string `json:"fromStepCode"`
+	Outcome      string `json:"outcome"`
+	ToStepCode   string `json:"toStepCode"`
+	Terminal     bool   `json:"terminal"`
+}
+
+type scenarioCreateRequest struct {
+	GameSlug    string                      `json:"gameSlug"`
+	Name        string                      `json:"name"`
+	Description string                      `json:"description"`
+	Steps       []scenarioStepRequest       `json:"steps"`
+	Transitions []scenarioTransitionRequest `json:"transitions"`
 }
 
 type llmDecisionRecordRequest struct {
@@ -126,6 +191,7 @@ func NewHandler(
 	streamersService *streamers.Service,
 	gamesService *games.Service,
 	promptsService *prompts.Service,
+	scenariosService *prompts.ScenarioService,
 	eventsService *events.Service,
 	clientConfig ClientConfigResponse,
 ) http.Handler {
@@ -709,6 +775,273 @@ func NewHandler(
 				}
 
 				writeJSON(w, http.StatusOK, updated)
+			})))
+		}
+
+		if scenariosService != nil {
+			mux.Handle("/api/admin/global-detectors", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, scenariosService.ListGlobalDetectors(r.Context()))
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req promptCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					created, err := scenariosService.CreateGlobalDetector(r.Context(), prompts.CreateRequest{
+						Stage:         req.Stage,
+						Template:      req.Template,
+						Model:         req.Model,
+						Temperature:   req.Temperature,
+						MaxTokens:     req.MaxTokens,
+						TimeoutMS:     req.TimeoutMS,
+						RetryCount:    req.RetryCount,
+						BackoffMS:     req.BackoffMS,
+						CooldownMS:    req.CooldownMS,
+						MinConfidence: req.MinConfidence,
+						ActorID:       claims.Subject,
+					})
+					if err != nil {
+						writeError(w, http.StatusBadRequest, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusCreated, created)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/global-detectors/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				path := strings.TrimPrefix(r.URL.Path, "/api/admin/global-detectors/")
+				path = strings.Trim(path, "/")
+				if path == "" {
+					writeError(w, http.StatusBadRequest, "detector id is required")
+					return
+				}
+				if strings.HasSuffix(path, "/activate") {
+					detectorID := strings.TrimSuffix(path, "/activate")
+					detectorID = strings.Trim(detectorID, "/")
+					if r.Method != http.MethodPost {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					item, err := scenariosService.ActivateGlobalDetector(r.Context(), detectorID, claims.Subject)
+					if err != nil {
+						status := http.StatusInternalServerError
+						if errors.Is(err, prompts.ErrDetectorNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+					return
+				}
+
+				switch r.Method {
+				case http.MethodGet:
+					item, err := scenariosService.GetGlobalDetector(r.Context(), path)
+					if err != nil {
+						status := http.StatusInternalServerError
+						if errors.Is(err, prompts.ErrDetectorNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req promptCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					item, err := scenariosService.UpdateGlobalDetector(r.Context(), path, prompts.CreateRequest{
+						Stage:         req.Stage,
+						Template:      req.Template,
+						Model:         req.Model,
+						Temperature:   req.Temperature,
+						MaxTokens:     req.MaxTokens,
+						TimeoutMS:     req.TimeoutMS,
+						RetryCount:    req.RetryCount,
+						BackoffMS:     req.BackoffMS,
+						CooldownMS:    req.CooldownMS,
+						MinConfidence: req.MinConfidence,
+						ActorID:       claims.Subject,
+					})
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrDetectorNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodDelete:
+					if err := scenariosService.DeleteGlobalDetector(r.Context(), path); err != nil {
+						status := http.StatusInternalServerError
+						if errors.Is(err, prompts.ErrDetectorNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/scenarios", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, scenariosService.ListScenarios(r.Context()))
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req scenarioCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					created, err := scenariosService.CreateScenario(r.Context(), scenarioRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusCreated, created)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/scenarios/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				path := strings.TrimPrefix(r.URL.Path, "/api/admin/scenarios/")
+				path = strings.Trim(path, "/")
+				if path == "" {
+					writeError(w, http.StatusBadRequest, "scenario id is required")
+					return
+				}
+				if strings.HasSuffix(path, "/activate") {
+					scenarioID := strings.TrimSuffix(path, "/activate")
+					scenarioID = strings.Trim(scenarioID, "/")
+					if r.Method != http.MethodPost {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					item, err := scenariosService.ActivateScenario(r.Context(), scenarioID, claims.Subject)
+					if err != nil {
+						status := http.StatusInternalServerError
+						if errors.Is(err, prompts.ErrScenarioNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					item, err := scenariosService.GetScenario(r.Context(), path)
+					if err != nil {
+						status := http.StatusInternalServerError
+						if errors.Is(err, prompts.ErrScenarioNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req scenarioCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					item, err := scenariosService.UpdateScenario(r.Context(), path, scenarioRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrScenarioNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodDelete:
+					if err := scenariosService.DeleteScenario(r.Context(), path); err != nil {
+						status := http.StatusInternalServerError
+						if errors.Is(err, prompts.ErrScenarioNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
 			})))
 		}
 

--- a/internal/app/router_admin_test.go
+++ b/internal/app/router_admin_test.go
@@ -20,7 +20,7 @@ func TestMeReturnsIsAdminTrueForAdmin(t *testing.T) {
 		t.Fatalf("userService.SyncTelegramProfile() error = %v", err)
 	}
 
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), userService, nil, nil, nil, nil, ClientConfigResponse{})
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), userService, nil, nil, nil, nil, nil, ClientConfigResponse{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 	req.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
@@ -50,7 +50,7 @@ func TestMeReturnsIsAdminFalseForNonAdmin(t *testing.T) {
 		t.Fatalf("userService.SyncTelegramProfile() error = %v", err)
 	}
 
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), userService, nil, nil, nil, nil, ClientConfigResponse{})
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), userService, nil, nil, nil, nil, nil, ClientConfigResponse{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
@@ -74,7 +74,7 @@ func TestMeReturnsIsAdminFalseForNonAdmin(t *testing.T) {
 }
 
 func TestAdminMeEndpointRemovedFallsBackToRoot(t *testing.T) {
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, nil, nil, nil, ClientConfigResponse{})
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, nil, nil, nil, nil, ClientConfigResponse{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/admin/me", nil)
 	req.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))

--- a/internal/app/router_auth_refresh_test.go
+++ b/internal/app/router_auth_refresh_test.go
@@ -33,7 +33,7 @@ func TestAuthRefreshEndpointRotatesTokens(t *testing.T) {
 		t.Fatalf("store.Create() error = %v", err)
 	}
 
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, authService, nil, nil, nil, nil, nil, nil, ClientConfigResponse{})
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, authService, nil, nil, nil, nil, nil, nil, nil, ClientConfigResponse{})
 	body, _ := json.Marshal(map[string]string{"refreshToken": refreshToken})
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", bytes.NewReader(body))
 	res := httptest.NewRecorder()
@@ -72,7 +72,7 @@ func TestAuthLogoutAllEndpoint(t *testing.T) {
 		t.Fatalf("store.Create() error = %v", err)
 	}
 
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, authService, nil, nil, nil, nil, nil, nil, ClientConfigResponse{})
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, authService, nil, nil, nil, nil, nil, nil, nil, ClientConfigResponse{})
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout-all", nil)
 	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
 	res := httptest.NewRecorder()

--- a/internal/app/router_games_test.go
+++ b/internal/app/router_games_test.go
@@ -50,7 +50,7 @@ func buildToken(t *testing.T, userID string) string {
 }
 
 func TestAdminGamesForbiddenForNonAdmin(t *testing.T) {
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, games.NewService(), nil, nil, ClientConfigResponse{})
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, games.NewService(), nil, nil, nil, ClientConfigResponse{})
 	req := httptest.NewRequest(http.MethodGet, "/api/admin/games", nil)
 	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
 	res := httptest.NewRecorder()
@@ -62,7 +62,7 @@ func TestAdminGamesForbiddenForNonAdmin(t *testing.T) {
 }
 
 func TestAdminGamesCreateAndList(t *testing.T) {
-	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, games.NewService(), nil, nil, ClientConfigResponse{})
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, nil, games.NewService(), nil, nil, nil, ClientConfigResponse{})
 	token := buildToken(t, "admin-1")
 
 	body, _ := json.Marshal(map[string]any{"slug": "cs2", "title": "Counter-Strike 2", "status": "draft"})

--- a/internal/app/router_prompts_test.go
+++ b/internal/app/router_prompts_test.go
@@ -25,6 +25,7 @@ func TestAdminPromptsCreateListAndActivate(t *testing.T) {
 		nil,
 		prompts.NewService(),
 		nil,
+		nil,
 		ClientConfigResponse{},
 	)
 	token := buildToken(t, "admin-1")
@@ -93,6 +94,7 @@ func TestAdminPromptsForbiddenForNonAdmin(t *testing.T) {
 		nil,
 		nil,
 		prompts.NewService(),
+		nil,
 		nil,
 		ClientConfigResponse{},
 	)

--- a/internal/app/router_scenarios_test.go
+++ b/internal/app/router_scenarios_test.go
@@ -1,0 +1,252 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/funpot/funpot-go-core/internal/admin"
+	"github.com/funpot/funpot-go-core/internal/prompts"
+)
+
+func TestAdminGlobalDetectorsCRUD(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		nil,
+		nil,
+		nil,
+		prompts.NewScenarioService(),
+		nil,
+		ClientConfigResponse{},
+	)
+	token := buildToken(t, "admin-1")
+
+	createBody, _ := json.Marshal(map[string]any{
+		"stage":         "global_detector",
+		"template":      "detect current game",
+		"model":         "gemini-2.0-flash",
+		"temperature":   0.1,
+		"maxTokens":     256,
+		"timeoutMs":     2000,
+		"retryCount":    1,
+		"backoffMs":     250,
+		"cooldownMs":    1000,
+		"minConfidence": 0.7,
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/global-detectors", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createRes := httptest.NewRecorder()
+	handler.ServeHTTP(createRes, createReq)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", createRes.Code, createRes.Body.String())
+	}
+
+	var created map[string]any
+	if err := json.Unmarshal(createRes.Body.Bytes(), &created); err != nil {
+		t.Fatalf("json.Unmarshal(create) error = %v", err)
+	}
+	id, _ := created["id"].(string)
+	if id == "" {
+		t.Fatal("expected created detector id")
+	}
+
+	updateBody, _ := json.Marshal(map[string]any{
+		"stage":         "global_detector_v2",
+		"template":      "detect cs2 exactly",
+		"model":         "gemini-2.0-flash",
+		"temperature":   0.2,
+		"maxTokens":     300,
+		"timeoutMs":     2500,
+		"retryCount":    2,
+		"backoffMs":     500,
+		"cooldownMs":    2000,
+		"minConfidence": 0.8,
+	})
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/admin/global-detectors/"+id, bytes.NewReader(updateBody))
+	updateReq.Header.Set("Authorization", "Bearer "+token)
+	updateRes := httptest.NewRecorder()
+	handler.ServeHTTP(updateRes, updateReq)
+	if updateRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", updateRes.Code, updateRes.Body.String())
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/global-detectors", nil)
+	listReq.Header.Set("Authorization", "Bearer "+token)
+	listRes := httptest.NewRecorder()
+	handler.ServeHTTP(listRes, listReq)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listRes.Code)
+	}
+
+	activateReq := httptest.NewRequest(http.MethodPost, "/api/admin/global-detectors/"+id+"/activate", nil)
+	activateReq.Header.Set("Authorization", "Bearer "+token)
+	activateRes := httptest.NewRecorder()
+	handler.ServeHTTP(activateRes, activateReq)
+	if activateRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", activateRes.Code, activateRes.Body.String())
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/admin/global-detectors/"+id, nil)
+	deleteReq.Header.Set("Authorization", "Bearer "+token)
+	deleteRes := httptest.NewRecorder()
+	handler.ServeHTTP(deleteRes, deleteReq)
+	if deleteRes.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", deleteRes.Code, deleteRes.Body.String())
+	}
+}
+
+func TestAdminScenariosCRUD(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		nil,
+		nil,
+		nil,
+		prompts.NewScenarioService(),
+		nil,
+		ClientConfigResponse{},
+	)
+	token := buildToken(t, "admin-1")
+
+	createBody, _ := json.Marshal(map[string]any{
+		"gameSlug":    "counter_strike",
+		"name":        "CS ranked flow",
+		"description": "desc",
+		"steps": []map[string]any{
+			{
+				"code":           "match_start",
+				"title":          "Match start",
+				"promptTemplate": "Has a ranked match started?",
+				"model":          "gemini-2.0-flash",
+				"temperature":    0.1,
+				"maxTokens":      256,
+				"timeoutMs":      2000,
+				"retryCount":     1,
+				"backoffMs":      250,
+				"cooldownMs":     1000,
+				"minConfidence":  0.7,
+			},
+		},
+		"transitions": []map[string]any{
+			{
+				"fromStepCode": "match_start",
+				"outcome":      "match_started",
+				"terminal":     true,
+			},
+		},
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/scenarios", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createRes := httptest.NewRecorder()
+	handler.ServeHTTP(createRes, createReq)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", createRes.Code, createRes.Body.String())
+	}
+
+	var created map[string]any
+	if err := json.Unmarshal(createRes.Body.Bytes(), &created); err != nil {
+		t.Fatalf("json.Unmarshal(create) error = %v", err)
+	}
+	id, _ := created["id"].(string)
+	if id == "" {
+		t.Fatal("expected created scenario id")
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/admin/scenarios/"+id, nil)
+	getReq.Header.Set("Authorization", "Bearer "+token)
+	getRes := httptest.NewRecorder()
+	handler.ServeHTTP(getRes, getReq)
+	if getRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", getRes.Code)
+	}
+
+	updateBody, _ := json.Marshal(map[string]any{
+		"gameSlug":    "counter_strike",
+		"name":        "CS ranked flow updated",
+		"description": "updated",
+		"steps": []map[string]any{
+			{
+				"code":           "match_start",
+				"title":          "Match start",
+				"promptTemplate": "Has a ranked match started?",
+				"model":          "gemini-2.0-flash",
+				"temperature":    0.2,
+				"maxTokens":      128,
+				"timeoutMs":      1500,
+				"retryCount":     1,
+				"backoffMs":      250,
+				"cooldownMs":     1000,
+				"minConfidence":  0.7,
+			},
+			{
+				"code":           "match_result",
+				"title":          "Match result",
+				"promptTemplate": "Did the streamer win?",
+				"model":          "gemini-2.0-flash",
+				"temperature":    0.2,
+				"maxTokens":      128,
+				"timeoutMs":      1500,
+				"retryCount":     1,
+				"backoffMs":      250,
+				"cooldownMs":     1000,
+				"minConfidence":  0.7,
+			},
+		},
+		"transitions": []map[string]any{
+			{
+				"fromStepCode": "match_start",
+				"outcome":      "match_started",
+				"toStepCode":   "match_result",
+			},
+			{
+				"fromStepCode": "match_result",
+				"outcome":      "win",
+				"terminal":     true,
+			},
+		},
+	})
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/admin/scenarios/"+id, bytes.NewReader(updateBody))
+	updateReq.Header.Set("Authorization", "Bearer "+token)
+	updateRes := httptest.NewRecorder()
+	handler.ServeHTTP(updateRes, updateReq)
+	if updateRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", updateRes.Code, updateRes.Body.String())
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/scenarios", nil)
+	listReq.Header.Set("Authorization", "Bearer "+token)
+	listRes := httptest.NewRecorder()
+	handler.ServeHTTP(listRes, listReq)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listRes.Code)
+	}
+
+	activateReq := httptest.NewRequest(http.MethodPost, "/api/admin/scenarios/"+id+"/activate", nil)
+	activateReq.Header.Set("Authorization", "Bearer "+token)
+	activateRes := httptest.NewRecorder()
+	handler.ServeHTTP(activateRes, activateReq)
+	if activateRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", activateRes.Code, activateRes.Body.String())
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/admin/scenarios/"+id, nil)
+	deleteReq.Header.Set("Authorization", "Bearer "+token)
+	deleteRes := httptest.NewRecorder()
+	handler.ServeHTTP(deleteRes, deleteReq)
+	if deleteRes.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", deleteRes.Code, deleteRes.Body.String())
+	}
+}

--- a/internal/app/router_streamers_llm_test.go
+++ b/internal/app/router_streamers_llm_test.go
@@ -25,6 +25,7 @@ func TestStreamerLLMDecisionsCreateAndList(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		ClientConfigResponse{},
 	)
 
@@ -92,6 +93,7 @@ func TestStreamerLLMDecisionCreateForbiddenForNonAdmin(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		ClientConfigResponse{},
 	)
 
@@ -119,6 +121,7 @@ func TestStreamerLLMDecisionCreateRejectsInvalidChunkTimestamp(t *testing.T) {
 		admin.NewService([]string{"admin-1"}),
 		nil,
 		streamers.NewService(),
+		nil,
 		nil,
 		nil,
 		nil,

--- a/internal/app/router_streamers_status_test.go
+++ b/internal/app/router_streamers_status_test.go
@@ -26,6 +26,7 @@ func TestStreamerStatusReturnsAggregatedLLMState(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		ClientConfigResponse{},
 	)
 
@@ -92,6 +93,7 @@ func TestStreamerStatusReturnsIdleWhenNoDecisionsYet(t *testing.T) {
 		admin.NewService([]string{"admin-1"}),
 		nil,
 		streamers.NewService(),
+		nil,
 		nil,
 		nil,
 		nil,

--- a/internal/app/router_streamers_submit_test.go
+++ b/internal/app/router_streamers_submit_test.go
@@ -27,6 +27,7 @@ func TestSubmitStreamerUsesTwitchNickname(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		ClientConfigResponse{},
 	)
 
@@ -59,6 +60,7 @@ func TestSubmitStreamerFallsBackToLegacyTwitchUsername(t *testing.T) {
 		admin.NewService([]string{"admin-1"}),
 		nil,
 		streamersService,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -100,6 +102,7 @@ func TestSubmitStreamerStartsAnalysisStatusWhenHookConfigured(t *testing.T) {
 		admin.NewService([]string{"admin-1"}),
 		nil,
 		streamersService,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/internal/prompts/scenario.go
+++ b/internal/prompts/scenario.go
@@ -21,6 +21,7 @@ var (
 	ErrInvalidScenarioName    = errors.New("scenario name must not be empty")
 	ErrInvalidScenarioStep    = errors.New("scenario step code must not be empty")
 	ErrInvalidScenarioOutcome = errors.New("scenario transition outcome must not be empty")
+	ErrDetectorNotFound       = errors.New("global detector not found")
 	ErrScenarioNotFound       = errors.New("scenario not found")
 )
 
@@ -173,6 +174,18 @@ func (s *ScenarioService) CreateGlobalDetector(ctx context.Context, req CreateRe
 	return s.createPrompt(ctx, PromptKindGlobalDetector, "", req)
 }
 
+func (s *ScenarioService) ListGlobalDetectors(_ context.Context) []PromptTemplate {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := make([]PromptTemplate, len(s.globalDetectors))
+	copy(items, s.globalDetectors)
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Version > items[j].Version
+	})
+	return items
+}
+
 func (s *ScenarioService) createPrompt(_ context.Context, kind string, gameSlug string, req CreateRequest) (PromptTemplate, error) {
 	if kind != PromptKindGlobalDetector && kind != PromptKindScenarioStep {
 		return PromptTemplate{}, ErrInvalidPromptKind
@@ -226,6 +239,96 @@ func (s *ScenarioService) GetActiveGlobalDetector(_ context.Context) (PromptTemp
 		}
 	}
 	return PromptTemplate{}, ErrNotFound
+}
+
+func (s *ScenarioService) GetGlobalDetector(_ context.Context, id string) (PromptTemplate, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, detector := range s.globalDetectors {
+		if detector.ID == strings.TrimSpace(id) {
+			return detector, nil
+		}
+	}
+	return PromptTemplate{}, ErrDetectorNotFound
+}
+
+func (s *ScenarioService) UpdateGlobalDetector(_ context.Context, id string, req CreateRequest) (PromptTemplate, error) {
+	if err := ValidateCreateRequest(req); err != nil {
+		return PromptTemplate{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	targetID := strings.TrimSpace(id)
+	for i := range s.globalDetectors {
+		if s.globalDetectors[i].ID != targetID {
+			continue
+		}
+		item := s.globalDetectors[i]
+		item.Stage = strings.TrimSpace(req.Stage)
+		item.Template = strings.TrimSpace(req.Template)
+		item.Model = strings.TrimSpace(req.Model)
+		item.Temperature = req.Temperature
+		item.MaxTokens = req.MaxTokens
+		item.TimeoutMS = req.TimeoutMS
+		item.RetryCount = req.RetryCount
+		item.BackoffMS = req.BackoffMS
+		item.CooldownMS = req.CooldownMS
+		item.MinConfidence = req.MinConfidence
+		s.globalDetectors[i] = item
+		return item, nil
+	}
+	return PromptTemplate{}, ErrDetectorNotFound
+}
+
+func (s *ScenarioService) ActivateGlobalDetector(_ context.Context, id, actorID string) (PromptTemplate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	targetID := strings.TrimSpace(id)
+	activeIdx := -1
+	for i := range s.globalDetectors {
+		if s.globalDetectors[i].ID == targetID {
+			activeIdx = i
+			break
+		}
+	}
+	if activeIdx == -1 {
+		return PromptTemplate{}, ErrDetectorNotFound
+	}
+
+	now := time.Now().UTC()
+	for i := range s.globalDetectors {
+		s.globalDetectors[i].IsActive = i == activeIdx
+		if i == activeIdx {
+			s.globalDetectors[i].ActivatedAt = now
+			s.globalDetectors[i].ActivatedBy = strings.TrimSpace(actorID)
+		}
+	}
+	return s.globalDetectors[activeIdx], nil
+}
+
+func (s *ScenarioService) DeleteGlobalDetector(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	targetID := strings.TrimSpace(id)
+	for i := range s.globalDetectors {
+		if s.globalDetectors[i].ID != targetID {
+			continue
+		}
+		wasActive := s.globalDetectors[i].IsActive
+		s.globalDetectors = append(s.globalDetectors[:i], s.globalDetectors[i+1:]...)
+		if wasActive && len(s.globalDetectors) > 0 {
+			last := len(s.globalDetectors) - 1
+			s.globalDetectors[last].IsActive = true
+			s.globalDetectors[last].ActivatedAt = time.Now().UTC()
+		}
+		return nil
+	}
+	return ErrDetectorNotFound
 }
 
 func (s *ScenarioService) CreateScenario(_ context.Context, req CreateScenarioRequest) (ScenarioVersion, error) {
@@ -299,6 +402,105 @@ func (s *ScenarioService) CreateScenario(_ context.Context, req CreateScenarioRe
 	return scenario, nil
 }
 
+func (s *ScenarioService) GetScenario(_ context.Context, id string) (ScenarioVersion, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	targetID := strings.TrimSpace(id)
+	for _, scenarios := range s.scenariosByGame {
+		for _, scenario := range scenarios {
+			if scenario.ID == targetID {
+				return scenario, nil
+			}
+		}
+	}
+	return ScenarioVersion{}, ErrScenarioNotFound
+}
+
+func (s *ScenarioService) UpdateScenario(_ context.Context, id string, req CreateScenarioRequest) (ScenarioVersion, error) {
+	if err := ValidateCreateScenarioRequest(req); err != nil {
+		return ScenarioVersion{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	targetID := strings.TrimSpace(id)
+	targetGame := strings.ToLower(strings.TrimSpace(req.GameSlug))
+	for game, scenarios := range s.scenariosByGame {
+		for idx := range scenarios {
+			if scenarios[idx].ID != targetID {
+				continue
+			}
+			current := scenarios[idx]
+			now := time.Now().UTC()
+			updated := ScenarioVersion{
+				ID:          current.ID,
+				GameSlug:    targetGame,
+				Name:        strings.TrimSpace(req.Name),
+				Description: strings.TrimSpace(req.Description),
+				Version:     current.Version,
+				IsActive:    current.IsActive,
+				CreatedBy:   current.CreatedBy,
+				ActivatedBy: current.ActivatedBy,
+				CreatedAt:   current.CreatedAt,
+				ActivatedAt: current.ActivatedAt,
+			}
+			for stepIdx, step := range req.Steps {
+				s.counter++
+				prompt := PromptTemplate{
+					ID:            fmt.Sprintf("prompt-template-%d", s.counter),
+					Kind:          PromptKindScenarioStep,
+					Stage:         strings.TrimSpace(step.Code),
+					GameSlug:      targetGame,
+					Version:       updated.Version,
+					Template:      strings.TrimSpace(step.PromptTemplate),
+					Model:         strings.TrimSpace(step.Model),
+					Temperature:   step.Temperature,
+					MaxTokens:     step.MaxTokens,
+					TimeoutMS:     step.TimeoutMS,
+					RetryCount:    step.RetryCount,
+					BackoffMS:     step.BackoffMS,
+					CooldownMS:    step.CooldownMS,
+					MinConfidence: step.MinConfidence,
+					CreatedBy:     strings.TrimSpace(req.ActorID),
+					CreatedAt:     now,
+					IsActive:      updated.IsActive,
+					ActivatedBy:   updated.ActivatedBy,
+					ActivatedAt:   updated.ActivatedAt,
+				}
+				updated.Steps = append(updated.Steps, ScenarioStep{
+					ID:       fmt.Sprintf("scenario-step-%d", s.counter),
+					Code:     strings.TrimSpace(step.Code),
+					Title:    strings.TrimSpace(step.Title),
+					Position: stepIdx + 1,
+					Prompt:   prompt,
+				})
+			}
+			for _, transition := range req.Transitions {
+				s.counter++
+				updated.Transitions = append(updated.Transitions, ScenarioTransition{
+					ID:           fmt.Sprintf("scenario-transition-%d", s.counter),
+					FromStepCode: strings.TrimSpace(transition.FromStepCode),
+					Outcome:      strings.TrimSpace(transition.Outcome),
+					ToStepCode:   strings.TrimSpace(transition.ToStepCode),
+					Terminal:     transition.Terminal,
+				})
+			}
+
+			if game == targetGame {
+				scenarios[idx] = updated
+				s.scenariosByGame[game] = scenarios
+			} else {
+				s.scenariosByGame[game] = append(scenarios[:idx], scenarios[idx+1:]...)
+				s.scenariosByGame[targetGame] = append(s.scenariosByGame[targetGame], updated)
+			}
+			return updated, nil
+		}
+	}
+	return ScenarioVersion{}, ErrScenarioNotFound
+}
+
 func (s *ScenarioService) ActivateScenario(_ context.Context, id, actorID string) (ScenarioVersion, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -332,6 +534,33 @@ func (s *ScenarioService) ActivateScenario(_ context.Context, id, actorID string
 		return scenarios[activeIdx], nil
 	}
 	return ScenarioVersion{}, ErrScenarioNotFound
+}
+
+func (s *ScenarioService) DeleteScenario(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	targetID := strings.TrimSpace(id)
+	for game, scenarios := range s.scenariosByGame {
+		for idx := range scenarios {
+			if scenarios[idx].ID != targetID {
+				continue
+			}
+			wasActive := scenarios[idx].IsActive
+			scenarios = append(scenarios[:idx], scenarios[idx+1:]...)
+			if len(scenarios) == 0 {
+				delete(s.scenariosByGame, game)
+				return nil
+			}
+			if wasActive {
+				scenarios[0].IsActive = true
+				scenarios[0].ActivatedAt = time.Now().UTC()
+			}
+			s.scenariosByGame[game] = scenarios
+			return nil
+		}
+	}
+	return ErrScenarioNotFound
 }
 
 func (s *ScenarioService) GetActiveScenarioByGame(_ context.Context, gameSlug string) (ScenarioVersion, error) {

--- a/internal/prompts/scenario_test.go
+++ b/internal/prompts/scenario_test.go
@@ -82,3 +82,139 @@ func TestValidateCreateScenarioRequestRejectsBrokenTransition(t *testing.T) {
 		t.Fatal("expected validation error")
 	}
 }
+
+func TestScenarioServiceSupportsFullDetectorAndScenarioCRUD(t *testing.T) {
+	svc := NewScenarioService()
+
+	detector, err := svc.CreateGlobalDetector(context.Background(), CreateRequest{
+		Stage:         "global_detector",
+		Template:      "detect current game",
+		Model:         "gemini-2.0-flash",
+		Temperature:   0.1,
+		MaxTokens:     256,
+		TimeoutMS:     2000,
+		RetryCount:    1,
+		BackoffMS:     250,
+		CooldownMS:    1000,
+		MinConfidence: 0.7,
+		ActorID:       "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateGlobalDetector() error = %v", err)
+	}
+
+	updatedDetector, err := svc.UpdateGlobalDetector(context.Background(), detector.ID, CreateRequest{
+		Stage:         "global_detector_v2",
+		Template:      "detect game precisely",
+		Model:         "gemini-2.0-flash",
+		Temperature:   0.2,
+		MaxTokens:     300,
+		TimeoutMS:     2500,
+		RetryCount:    2,
+		BackoffMS:     500,
+		CooldownMS:    1500,
+		MinConfidence: 0.8,
+		ActorID:       "admin-2",
+	})
+	if err != nil {
+		t.Fatalf("UpdateGlobalDetector() error = %v", err)
+	}
+	if updatedDetector.Stage != "global_detector_v2" {
+		t.Fatalf("expected updated detector stage, got %q", updatedDetector.Stage)
+	}
+
+	secondDetector, err := svc.CreateGlobalDetector(context.Background(), CreateRequest{
+		Stage:         "global_detector_v3",
+		Template:      "detect cs2 or dota",
+		Model:         "gemini-2.0-flash",
+		Temperature:   0.2,
+		MaxTokens:     512,
+		TimeoutMS:     2500,
+		RetryCount:    2,
+		BackoffMS:     500,
+		CooldownMS:    1500,
+		MinConfidence: 0.8,
+		ActorID:       "admin-2",
+	})
+	if err != nil {
+		t.Fatalf("CreateGlobalDetector() second error = %v", err)
+	}
+	if _, err := svc.ActivateGlobalDetector(context.Background(), detector.ID, "admin-3"); err != nil {
+		t.Fatalf("ActivateGlobalDetector() error = %v", err)
+	}
+	activeDetector, err := svc.GetActiveGlobalDetector(context.Background())
+	if err != nil {
+		t.Fatalf("GetActiveGlobalDetector() error = %v", err)
+	}
+	if activeDetector.ID != detector.ID {
+		t.Fatalf("active detector id = %q, want %q", activeDetector.ID, detector.ID)
+	}
+	if err := svc.DeleteGlobalDetector(context.Background(), secondDetector.ID); err != nil {
+		t.Fatalf("DeleteGlobalDetector() error = %v", err)
+	}
+
+	scenario, err := svc.CreateScenario(context.Background(), CreateScenarioRequest{
+		GameSlug:    "counter_strike",
+		Name:        "CS ranked flow",
+		Description: "Wait for ranked match lifecycle",
+		ActorID:     "admin-1",
+		Steps: []ScenarioStepInput{
+			{Code: "match_start", Title: "Match start", PromptTemplate: "Has a ranked match started?", Model: "gemini-2.0-flash", Temperature: 0.1, MaxTokens: 256, TimeoutMS: 2000, MinConfidence: 0.7},
+		},
+		Transitions: []ScenarioTransitionInput{
+			{FromStepCode: "match_start", Outcome: "match_started", Terminal: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateScenario() error = %v", err)
+	}
+	updatedScenario, err := svc.UpdateScenario(context.Background(), scenario.ID, CreateScenarioRequest{
+		GameSlug:    "counter_strike",
+		Name:        "CS ranked flow updated",
+		Description: "Updated description",
+		ActorID:     "admin-2",
+		Steps: []ScenarioStepInput{
+			{Code: "match_start", Title: "Match start", PromptTemplate: "Has a ranked match started?", Model: "gemini-2.0-flash", Temperature: 0.2, MaxTokens: 128, TimeoutMS: 1500, MinConfidence: 0.6},
+			{Code: "match_result", Title: "Match result", PromptTemplate: "Did the streamer win?", Model: "gemini-2.0-flash", Temperature: 0.2, MaxTokens: 128, TimeoutMS: 1500, MinConfidence: 0.6},
+		},
+		Transitions: []ScenarioTransitionInput{
+			{FromStepCode: "match_start", Outcome: "match_started", ToStepCode: "match_result"},
+			{FromStepCode: "match_result", Outcome: "win", Terminal: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateScenario() error = %v", err)
+	}
+	if updatedScenario.Name != "CS ranked flow updated" || len(updatedScenario.Steps) != 2 {
+		t.Fatalf("unexpected updated scenario: %#v", updatedScenario)
+	}
+
+	secondScenario, err := svc.CreateScenario(context.Background(), CreateScenarioRequest{
+		GameSlug:    "counter_strike",
+		Name:        "CS alt flow",
+		Description: "alt",
+		ActorID:     "admin-3",
+		Steps: []ScenarioStepInput{
+			{Code: "alt_step", Title: "Alt", PromptTemplate: "alt?", Model: "gemini-2.0-flash", Temperature: 0.1, MaxTokens: 128, TimeoutMS: 1000, MinConfidence: 0.6},
+		},
+		Transitions: []ScenarioTransitionInput{
+			{FromStepCode: "alt_step", Outcome: "done", Terminal: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateScenario() second error = %v", err)
+	}
+	if _, err := svc.ActivateScenario(context.Background(), secondScenario.ID, "admin-4"); err != nil {
+		t.Fatalf("ActivateScenario() error = %v", err)
+	}
+	gotScenario, err := svc.GetScenario(context.Background(), secondScenario.ID)
+	if err != nil {
+		t.Fatalf("GetScenario() error = %v", err)
+	}
+	if !gotScenario.IsActive {
+		t.Fatalf("expected active scenario after activation: %#v", gotScenario)
+	}
+	if err := svc.DeleteScenario(context.Background(), scenario.ID); err != nil {
+		t.Fatalf("DeleteScenario() error = %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide first-class support for game scenarios and global detector prompts so admins can manage detector templates and multi-step scenarios via HTTP API and use them from runtime components.
- Expand the OpenAPI spec and router to expose CRUD and activation endpoints for both global detectors and scenarios.

### Description

- Implemented `prompts.ScenarioService` with in-memory CRUD APIs for global detectors and scenarios including `Create`, `List`, `Get`, `Update`, `Activate`, and `Delete` operations and related errors like `ErrDetectorNotFound` and `ErrScenarioNotFound`.
- Wired the service into the HTTP layer: added router handlers under `/api/admin/global-detectors` and `/api/admin/scenarios` with JSON request parsing, admin checks, and conversion helpers like `scenarioRequestToCreateRequest`.
- Extended OpenAPI (`docs/openapi.yaml`) with the new endpoints and added schema definitions for `PromptTemplate`, `Scenario*` request/response types, and related components.
- Updated `cmd/server/main.go` to pass the `scenariosService` into `app.NewHandler`, and adjusted many tests and handler signatures to account for the new parameter.

### Testing

- Ran unit tests including `internal/prompts/scenario_test.go` and new router tests `internal/app/router_scenarios_test.go` exercising full detector and scenario CRUD flows, and these tests passed.
- Ran the full test suite via `go test ./...` to validate router wiring and existing endpoints, and the test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd361e6274832c85c962c180c2c666)