### PR TITLE
Bootstrap missing `streamer_llm_decisions` schema, add tests and docs

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -155,7 +155,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
 - `POST /api/streamers` – submits a Twitch streamer nickname for moderation/validation, then immediately starts the per-streamer Streamlink analysis scheduler when background orchestration is configured.
 - `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM detector/scenario status for a streamer.
-- When PostgreSQL is enabled, detailed LLM decision history (`chunkRef`, prompt/runtime params, request/response refs, transition outcome) is persisted in `streamer_llm_decisions` so `/api/streamers/{streamerId}/llm-decisions` and `/status` survive service restarts.
+- When PostgreSQL is enabled, detailed LLM decision history (`chunkRef`, prompt/runtime params, request/response refs, transition outcome) is persisted in `streamer_llm_decisions` so `/api/streamers/{streamerId}/llm-decisions` and `/status` survive service restarts. The API now bootstraps this table/index set on first access if migrations were missed, but versioned migrations remain the canonical deployment path.
 - `GET /api/streamers/{streamerId}/llm-decisions?limit=` – returns recent detector/scenario decision history for a streamer.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
 - `GET /api/admin/games` – admin-only endpoint listing all configured games.

--- a/internal/streamers/postgres_decisions.go
+++ b/internal/streamers/postgres_decisions.go
@@ -5,19 +5,91 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 )
+
+const streamerLLMDecisionsDDL = `
+CREATE TABLE IF NOT EXISTS streamer_llm_decisions (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    streamer_id TEXT NOT NULL,
+    stage TEXT NOT NULL,
+    label TEXT NOT NULL,
+    confidence DOUBLE PRECISION NOT NULL DEFAULT 0,
+    chunk_captured_at TIMESTAMPTZ,
+    prompt_version_id TEXT,
+    prompt_text TEXT,
+    model TEXT,
+    temperature DOUBLE PRECISION NOT NULL DEFAULT 0,
+    max_tokens INTEGER NOT NULL DEFAULT 0,
+    timeout_ms INTEGER NOT NULL DEFAULT 0,
+    chunk_ref TEXT,
+    request_ref TEXT,
+    response_ref TEXT,
+    raw_response TEXT,
+    tokens_in INTEGER NOT NULL DEFAULT 0,
+    tokens_out INTEGER NOT NULL DEFAULT 0,
+    latency_ms BIGINT NOT NULL DEFAULT 0,
+    transition_outcome TEXT,
+    transition_to_step TEXT,
+    transition_terminal BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL,
+    CHECK (char_length(id) > 0),
+    CHECK (char_length(run_id) > 0),
+    CHECK (char_length(streamer_id) > 0),
+    CHECK (char_length(stage) > 0),
+    CHECK (char_length(label) > 0),
+    CHECK (confidence >= 0 AND confidence <= 1),
+    CHECK (temperature >= 0),
+    CHECK (max_tokens >= 0),
+    CHECK (timeout_ms >= 0),
+    CHECK (tokens_in >= 0),
+    CHECK (tokens_out >= 0),
+    CHECK (latency_ms >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_streamer_llm_decisions_streamer_created_at
+    ON streamer_llm_decisions (streamer_id, created_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_streamer_llm_decisions_run_id
+    ON streamer_llm_decisions (run_id);
+CREATE INDEX IF NOT EXISTS idx_streamer_llm_decisions_streamer_stage_created_at
+    ON streamer_llm_decisions (streamer_id, stage, created_at DESC, id DESC);
+`
 
 // PostgresDecisionRepository persists LLM decisions in PostgreSQL for audit/history APIs.
 type PostgresDecisionRepository struct {
 	db *sql.DB
+
+	schemaMu        sync.Mutex
+	schemaEnsured   bool
+	schemaEnsureErr error
 }
 
 func NewPostgresDecisionRepository(db *sql.DB) *PostgresDecisionRepository {
 	return &PostgresDecisionRepository{db: db}
 }
 
+func (r *PostgresDecisionRepository) ensureSchema(ctx context.Context) error {
+	r.schemaMu.Lock()
+	defer r.schemaMu.Unlock()
+
+	if r.schemaEnsured {
+		return nil
+	}
+	if _, err := r.db.ExecContext(ctx, streamerLLMDecisionsDDL); err != nil {
+		r.schemaEnsureErr = fmt.Errorf("ensure streamer llm decisions schema: %w", err)
+		return r.schemaEnsureErr
+	}
+	r.schemaEnsured = true
+	r.schemaEnsureErr = nil
+	return nil
+}
+
 func (r *PostgresDecisionRepository) RecordLLMDecision(ctx context.Context, item LLMDecision) error {
+	if err := r.ensureSchema(ctx); err != nil {
+		return err
+	}
 	const query = `
 INSERT INTO streamer_llm_decisions (
 	id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
@@ -63,6 +135,9 @@ INSERT INTO streamer_llm_decisions (
 }
 
 func (r *PostgresDecisionRepository) ListLLMDecisions(ctx context.Context, streamerID string, limit int) ([]LLMDecision, error) {
+	if err := r.ensureSchema(ctx); err != nil {
+		return nil, err
+	}
 	if limit <= 0 {
 		limit = 20
 	}
@@ -79,6 +154,9 @@ LIMIT $2`
 }
 
 func (r *PostgresDecisionRepository) ListAllLLMDecisions(ctx context.Context, streamerID string) ([]LLMDecision, error) {
+	if err := r.ensureSchema(ctx); err != nil {
+		return nil, err
+	}
 	const query = `
 SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
        prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,

--- a/internal/streamers/postgres_decisions_test.go
+++ b/internal/streamers/postgres_decisions_test.go
@@ -18,6 +18,7 @@ func TestPostgresDecisionRepositoryRecordLLMDecision(t *testing.T) {
 	defer db.Close()
 
 	repo := NewPostgresDecisionRepository(db)
+	mock.ExpectExec(regexp.QuoteMeta(streamerLLMDecisionsDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
 	createdAt := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
 	capturedAt := createdAt.Add(-10 * time.Second)
 	item := LLMDecision{
@@ -103,6 +104,7 @@ func TestPostgresDecisionRepositoryListLLMDecisions(t *testing.T) {
 	defer db.Close()
 
 	repo := NewPostgresDecisionRepository(db)
+	mock.ExpectExec(regexp.QuoteMeta(streamerLLMDecisionsDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
 	createdAt := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
 	capturedAt := createdAt.Add(-10 * time.Second)
 	rows := sqlmock.NewRows([]string{
@@ -158,4 +160,53 @@ func (s stringValuer) Value() (driver.Value, error) {
 		return nil, nil
 	}
 	return string(s), nil
+}
+
+func TestPostgresDecisionRepositoryEnsuresSchemaOnce(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresDecisionRepository(db)
+	mock.ExpectExec(regexp.QuoteMeta(streamerLLMDecisionsDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	rows := sqlmock.NewRows([]string{
+		"id", "run_id", "streamer_id", "stage", "label", "confidence", "chunk_captured_at",
+		"prompt_version_id", "prompt_text", "model", "temperature", "max_tokens", "timeout_ms",
+		"chunk_ref", "request_ref", "response_ref", "raw_response", "tokens_in", "tokens_out",
+		"latency_ms", "transition_outcome", "transition_to_step", "transition_terminal", "created_at",
+	})
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
+       prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
+       chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
+       latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+FROM streamer_llm_decisions
+WHERE streamer_id = $1
+ORDER BY created_at DESC, id DESC
+LIMIT $2`)).
+		WithArgs("str_1", 1).
+		WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
+       prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
+       chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
+       latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+FROM streamer_llm_decisions
+WHERE streamer_id = $1
+ORDER BY created_at ASC, id ASC`)).
+		WithArgs("str_1").
+		WillReturnRows(rows)
+
+	if _, err := repo.ListLLMDecisions(context.Background(), "str_1", 1); err != nil {
+		t.Fatalf("ListLLMDecisions() error = %v", err)
+	}
+	if _, err := repo.ListAllLLMDecisions(context.Background(), "str_1"); err != nil {
+		t.Fatalf("ListAllLLMDecisions() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
 }


### PR DESCRIPTION
### Motivation
- API endpoints reading/writing LLM decisions (`/api/streamers/{streamerId}/llm-decisions` and `/status`) fail with `relation "streamer_llm_decisions" does not exist` when the PostgreSQL migration was not applied, causing runtime errors. 
- The change makes the service resilient in local/dev environments by ensuring the required table and indexes exist on first access while keeping versioned migrations as the canonical production path.

### Description
- Add in-repo DDL and a thread-safe `ensureSchema(ctx)` helper in `internal/streamers.PostgresDecisionRepository` that executes the `CREATE TABLE IF NOT EXISTS ...` and index statements before reads/writes. 
- Call `ensureSchema` from `RecordLLMDecision`, `ListLLMDecisions`, and `ListAllLLMDecisions` so the repository bootstraps the schema on first access. 
- Add repository tests to cover the bootstrap path and a new `TestPostgresDecisionRepositoryEnsuresSchemaOnce` to assert the DDL is executed and only once per repository instance, and update `internal/streamers/postgres_decisions_test.go` accordingly. 
- Update local docs in `docs/local_setup.md` to note the API will bootstrap the `streamer_llm_decisions` table/index set when migrations were missed while recommending versioned migrations for deployments.

Checklist (aligned with M2.1 / priority plan):
- [x] Persist LLM decisions so history survives restarts (schema bootstrap implemented). 
- [x] Live status and history APIs recover when the decision table is missing at runtime. 
- [ ] Streamlink-driven chunk capture and LLM worker orchestration remain to be implemented or verified in follow-ups. 
- [ ] Full migration automation in CI/deploy is still a follow-up task.

### Testing
- Ran unit tests for the streamers package with `go test ./internal/streamers -run 'Test(PostgresDecisionRepository|RecordAndListLLMDecisions|GetLLMStatusAggregatesLatestStageSnapshots)' -count=1` and they passed. 
- Ran handler/package tests with `go test ./internal/app -count=1` and they passed. 
- Added and exercised `TestPostgresDecisionRepositoryEnsuresSchemaOnce` which validates the DDL execution path with `sqlmock` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd4dc67e4c832caa9cc46429969e92)