### PR TITLE
Treat Streamlink "no playable streams" as a graceful skip (stream ended/unavailable)

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -154,6 +154,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/config` – exposes client configuration and feature flags for the authenticated user.
 - `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
 - `POST /api/streamers` – submits a Twitch streamer nickname for moderation/validation, then immediately starts the per-streamer Streamlink analysis scheduler when background orchestration is configured.
+- When Streamlink reports that a Twitch URL has no playable streams (for example, the stream ended or is offline), the scheduler treats that cycle as a graceful skip instead of a hard worker failure and retries on the next 10-second window.
 - `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM detector/scenario status for a streamer.
 - When PostgreSQL is enabled, detailed LLM decision history (`chunkRef`, prompt/runtime params, request/response refs, transition outcome) is persisted in `streamer_llm_decisions` so `/api/streamers/{streamerId}/llm-decisions` and `/status` survive service restarts. The API now bootstraps this table/index set on first access if migrations were missed, but versioned migrations remain the canonical deployment path.
 - `GET /api/streamers/{streamerId}/llm-decisions?limit=` – returns recent detector/scenario decision history for a streamer.

--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -19,6 +19,7 @@ var (
 	ErrStreamlinkNoData         = errors.New("streamlink capture produced no data")
 	ErrStreamlinkChannelResolve = errors.New("failed to resolve streamlink channel")
 	ErrStreamlinkAdBreak        = errors.New("streamlink capture paused by ad break")
+	ErrStreamlinkStreamEnded    = errors.New("streamlink capture ended because stream is unavailable")
 )
 
 var streamlinkSafeTokenPattern = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
@@ -29,6 +30,12 @@ var streamlinkAdBreakMarkers = []string{
 	"detected advertisement break",
 	"filtering out segments and pausing stream output",
 	"will skip ad segments",
+}
+
+var streamlinkEndedMarkers = []string{
+	"no playable streams found on this url",
+	"this stream is unavailable",
+	"could not open stream",
 }
 
 const defaultPreferredStreamQuality = "720p60,720p,936p60,936p,648p60,648p,480p,1080p60,1080p,best"
@@ -163,6 +170,13 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 			}
 			return ChunkRef{}, fmt.Errorf("%w (stderr=%s)", ErrStreamlinkAdBreak, trimmedStderr)
 		}
+		if isStreamlinkEnded(trimmedStderr) {
+			logger.Info("stream capture skipped because stream is unavailable", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.String("stderr", trimmedStderr), zap.Error(runErr))
+			if runErr != nil {
+				return ChunkRef{}, fmt.Errorf("%w: %v (stderr=%s)", ErrStreamlinkStreamEnded, runErr, trimmedStderr)
+			}
+			return ChunkRef{}, fmt.Errorf("%w (stderr=%s)", ErrStreamlinkStreamEnded, trimmedStderr)
+		}
 		logger.Warn("stream capture produced empty chunk", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.String("stderr", trimmedStderr), zap.Error(runErr))
 		if runErr != nil {
 			return ChunkRef{}, fmt.Errorf("%w: %v (stderr=%s)", ErrStreamlinkNoData, runErr, trimmedStderr)
@@ -216,6 +230,19 @@ func isStreamlinkAdBreak(stderr string) bool {
 		return false
 	}
 	for _, marker := range streamlinkAdBreakMarkers {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func isStreamlinkEnded(stderr string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(stderr))
+	if normalized == "" {
+		return false
+	}
+	for _, marker := range streamlinkEndedMarkers {
 		if strings.Contains(normalized, marker) {
 			return true
 		}

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -129,6 +129,30 @@ func TestStreamlinkCaptureAdapterReturnsAdBreakErrorWhenAdsPauseOutput(t *testin
 	}
 }
 
+func TestStreamlinkCaptureAdapterReturnsStreamEndedErrorWhenNoPlayableStreamsRemain(t *testing.T) {
+	outDir := t.TempDir()
+	runner := &fakeCommandRunner{
+		err: errors.New("exit status 1"),
+		stderrOutput: strings.Join([]string{
+			"[cli][info] Found matching plugin twitch for URL https://twitch.tv/donacs",
+			"error: No playable streams found on this URL: https://twitch.tv/donacs",
+		}, "\n"),
+	}
+	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{OutputDir: outDir}, nil, runner)
+
+	_, err := adapter.Capture(context.Background(), "str_offline")
+	if !errors.Is(err, ErrStreamlinkStreamEnded) {
+		t.Fatalf("expected ErrStreamlinkStreamEnded, got %v", err)
+	}
+	files, readErr := os.ReadDir(filepath.Join(outDir, "str_offline"))
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatalf("ReadDir() error = %v", readErr)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected offline empty chunk to be removed, found %d files", len(files))
+	}
+}
+
 func TestNormalizeStreamlinkQualityPrefersNear720p(t *testing.T) {
 	for _, input := range []string{"", "best", " BEST "} {
 		if got := normalizeStreamlinkQuality(input); got != defaultPreferredStreamQuality {

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -171,6 +171,11 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 			w.metrics.recordCycle(ctx, id, "ad_break")
 			return streamers.LLMDecision{}, nil
 		}
+		if errors.Is(err, ErrStreamlinkStreamEnded) {
+			logger.Info("stream chunk capture skipped because stream has ended or is unavailable", zap.String("streamerID", id), zap.Error(err))
+			w.metrics.recordCycle(ctx, id, "stream_unavailable")
+			return streamers.LLMDecision{}, nil
+		}
 		logger.Error("stream chunk capture failed", zap.String("streamerID", id), zap.Error(err))
 		w.metrics.recordFailure(ctx, id, "capture")
 		w.metrics.recordCycle(ctx, id, "failed")

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -250,6 +250,22 @@ func TestWorkerProcessStreamerSkipsAdBreakWithoutFailingCycle(t *testing.T) {
 	}
 }
 
+func TestWorkerProcessStreamerSkipsEndedStreamWithoutFailingCycle(t *testing.T) {
+	runStore := &countingRunStore{}
+	worker := NewWorker(fakeCapture{err: ErrStreamlinkStreamEnded}, fakeClassifier{}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, nil, runStore, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+
+	got, err := worker.ProcessStreamer(context.Background(), "str-ended")
+	if err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got != (streamers.LLMDecision{}) {
+		t.Fatalf("expected zero decision on ended stream, got %#v", got)
+	}
+	if runStore.count != 0 {
+		t.Fatalf("expected ended stream to skip run creation, got %d runs", runStore.count)
+	}
+}
+
 func TestWorkerProcessStreamerRunsGlobalDetectorAndScenarioSteps(t *testing.T) {
 	decisions := &fakeDecisionStore{}
 	scenario := prompts.ScenarioVersion{


### PR DESCRIPTION
### Motivation

- Avoid treating offline or ended Twitch streams as hard worker failures and instead let the scheduler skip and retry on the next cycle.

### Description

- Add `ErrStreamlinkStreamEnded` and a set of `streamlinkEndedMarkers` plus helper `isStreamlinkEnded` to detect Streamlink stderr messages indicating no playable streams or unavailable streams.
- Update the Streamlink capture logic in `Capture` to return `ErrStreamlinkStreamEnded` when such markers are observed and to log the event while cleaning up empty chunks.
- Update worker logic in `ProcessStreamer` to treat `ErrStreamlinkStreamEnded` the same as ad breaks by recording a `stream_unavailable` cycle metric and returning a zero decision (no failure or run creation).
- Add a docs line in `docs/local_setup.md` documenting that Streamlink reporting no playable streams is treated as a graceful skip.
- Add unit tests `TestStreamlinkCaptureAdapterReturnsStreamEndedErrorWhenNoPlayableStreamsRemain` and `TestWorkerProcessStreamerSkipsEndedStreamWithoutFailingCycle` to verify the new behavior.

### Testing

- Ran the package tests including the new adapter and worker tests; the updated test suite (`go test ./...`) completed successfully and the new tests passed (`TestStreamlinkCaptureAdapterReturnsStreamEndedErrorWhenNoPlayableStreamsRemain`, `TestWorkerProcessStreamerSkipsEndedStreamWithoutFailingCycle`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd58856848832cbc744cee7763292a)