### PR TITLE
Add streamer tracking stop endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -136,6 +136,10 @@ func main() {
 	streamersService.SetSubmissionHook(func(_ context.Context, streamerID string) error {
 		return streamScheduler.Start(streamerID)
 	})
+	streamersService.SetTrackingStopHook(func(_ context.Context, streamerID string) error {
+		streamScheduler.Stop(streamerID)
+		return nil
+	})
 
 	authService, err := auth.NewService(logger, cfg.Auth, userService)
 	if err != nil {

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -31,6 +31,7 @@ stream analysis immediately after a streamer is added:
 
 ### Priority checklist (must be tracked in status updates)
 - [x] Auto-start Streamlink analysis job after `POST /api/streamers` success.
+- [x] Provide a stop-tracking control path so clients can end per-streamer monitoring without restarting the service.
 - [x] Fixed 10-second capture cadence with lock/idempotency protections.
 - [ ] Persist the active global game-detection prompt in the database with audit/version history.
 - [ ] Persist active per-game scenarios in the database, including linked steps and expected transitions.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -156,6 +156,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `POST /api/streamers` – submits a Twitch streamer nickname for moderation/validation, then immediately starts the per-streamer Streamlink analysis scheduler when background orchestration is configured.
 - When Streamlink reports that a Twitch URL has no playable streams (for example, the stream ended or is offline), the scheduler treats that cycle as a graceful skip instead of a hard worker failure and retries on the next 10-second window.
 - `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM detector/scenario status for a streamer.
+- `DELETE /api/streamers/{streamerId}/tracking` – stops the active Streamlink/LLM tracking loop for a streamer and returns the updated `stopped` status so the client can disable the tracking button immediately.
 - When PostgreSQL is enabled, detailed LLM decision history (`chunkRef`, prompt/runtime params, request/response refs, transition outcome) is persisted in `streamer_llm_decisions` so `/api/streamers/{streamerId}/llm-decisions` and `/status` survive service restarts. The API now bootstraps this table/index set on first access if migrations were missed, but versioned migrations remain the canonical deployment path.
 - `GET /api/streamers/{streamerId}/llm-decisions?limit=` – returns recent detector/scenario decision history for a streamer.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -193,6 +193,26 @@ paths:
                 $ref: '#/components/schemas/LLMStatus'
         default:
           $ref: '#/components/responses/Error'
+  /api/streamers/{streamerId}/tracking:
+    delete:
+      summary: Stop streamer analysis tracking
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: streamerId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Updated streamer tracking status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMStatus'
+        default:
+          $ref: '#/components/responses/Error'
   /api/streamers/{streamerId}/llm-decisions:
     get:
       summary: List latest LLM stage decisions for streamer

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -482,6 +482,21 @@ func NewHandler(
 						return
 					}
 					writeJSON(w, http.StatusOK, streamersService.GetLLMStatus(r.Context(), streamerID))
+				case "tracking":
+					if r.Method != http.MethodDelete {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					if err := streamersService.StopTracking(r.Context(), streamerID); err != nil {
+						if errors.Is(err, streamers.ErrNotFound) {
+							writeError(w, http.StatusNotFound, err.Error())
+							return
+						}
+						logger.Error("failed to stop streamer tracking", zap.String("streamerID", streamerID), zap.Error(err))
+						writeError(w, http.StatusInternalServerError, "failed to stop streamer tracking")
+						return
+					}
+					writeJSON(w, http.StatusOK, streamersService.GetLLMStatus(r.Context(), streamerID))
 				case "llm-decisions":
 					switch r.Method {
 					case http.MethodGet:

--- a/internal/app/router_streamers_status_test.go
+++ b/internal/app/router_streamers_status_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -114,5 +115,57 @@ func TestStreamerStatusReturnsIdleWhenNoDecisionsYet(t *testing.T) {
 	}
 	if got["state"] != "idle" {
 		t.Fatalf("expected idle state, got %#v", got)
+	}
+}
+
+func TestStreamerTrackingDeleteStopsMonitoring(t *testing.T) {
+	streamersService := streamers.NewService()
+	if _, err := streamersService.Submit(context.Background(), "stopstreamer", "user-1"); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	items := streamersService.List(context.Background(), "stopstreamer", "pending", 1)
+	if len(items) != 1 {
+		t.Fatalf("expected one streamer, got %d", len(items))
+	}
+
+	stoppedID := ""
+	streamersService.SetTrackingStopHook(func(_ context.Context, streamerID string) error {
+		stoppedID = streamerID
+		return nil
+	})
+	streamersService.MarkAnalysisActive(items[0].ID)
+
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamersService,
+		nil,
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/streamers/"+items[0].ID+"/tracking", nil)
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+	if stoppedID != items[0].ID {
+		t.Fatalf("expected stop hook for %q, got %q", items[0].ID, stoppedID)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(res.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if got["state"] != "stopped" {
+		t.Fatalf("expected stopped state, got %#v", got)
 	}
 }

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -46,19 +46,21 @@ type analysisState struct {
 }
 
 type Service struct {
-	logger         *zap.Logger
-	mu             sync.RWMutex
-	items          []Streamer
-	decisionRepo   DecisionRepository
-	analysis       map[string]analysisState
-	validator      TwitchValidator
-	rateLimitMu    sync.Mutex
-	rateLimitByKey map[string]submissionLimit
-	nowFn          func() time.Time
-	counterMu      sync.Mutex
-	counter        int64
-	onSubmittedMu  sync.RWMutex
-	onSubmitted    func(context.Context, string) error
+	logger           *zap.Logger
+	mu               sync.RWMutex
+	items            []Streamer
+	decisionRepo     DecisionRepository
+	analysis         map[string]analysisState
+	validator        TwitchValidator
+	rateLimitMu      sync.Mutex
+	rateLimitByKey   map[string]submissionLimit
+	nowFn            func() time.Time
+	counterMu        sync.Mutex
+	counter          int64
+	onSubmittedMu    sync.RWMutex
+	onSubmitted      func(context.Context, string) error
+	onTrackingStopMu sync.RWMutex
+	onTrackingStop   func(context.Context, string) error
 }
 
 func NewService() *Service {
@@ -112,6 +114,18 @@ func (s *Service) submissionHook() func(context.Context, string) error {
 	s.onSubmittedMu.RLock()
 	defer s.onSubmittedMu.RUnlock()
 	return s.onSubmitted
+}
+
+func (s *Service) SetTrackingStopHook(hook func(context.Context, string) error) {
+	s.onTrackingStopMu.Lock()
+	s.onTrackingStop = hook
+	s.onTrackingStopMu.Unlock()
+}
+
+func (s *Service) trackingStopHook() func(context.Context, string) error {
+	s.onTrackingStopMu.RLock()
+	defer s.onTrackingStopMu.RUnlock()
+	return s.onTrackingStop
 }
 
 func (s *Service) List(_ context.Context, query, status string, page int) []Streamer {
@@ -238,6 +252,35 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 
 	logger.Info("streamer submission completed", zap.String("streamerID", id), zap.String("status", "pending"))
 	return Submission{ID: id, Status: "pending", Reason: nil}, nil
+}
+
+func (s *Service) StopTracking(ctx context.Context, streamerID string) error {
+	id := strings.TrimSpace(streamerID)
+	if id == "" {
+		return ErrNotFound
+	}
+
+	s.mu.RLock()
+	exists := false
+	for _, item := range s.items {
+		if item.ID == id {
+			exists = true
+			break
+		}
+	}
+	s.mu.RUnlock()
+	if !exists {
+		return ErrNotFound
+	}
+
+	if hook := s.trackingStopHook(); hook != nil {
+		if err := hook(ctx, id); err != nil {
+			return err
+		}
+	}
+
+	s.MarkAnalysisInactive(id)
+	return nil
 }
 
 func (s *Service) RecordLLMDecision(ctx context.Context, req RecordDecisionRequest) (LLMDecision, error) {
@@ -367,9 +410,15 @@ func (s *Service) GetLLMStatus(ctx context.Context, streamerID string) LLMStatus
 			items = loaded
 		}
 	}
-	if ok && state.active {
-		status.State = "active"
+	if ok {
 		status.UpdatedAt = state.updatedAt
+		if state.active {
+			if status.State != "stopped" {
+				status.State = "active"
+			}
+		} else {
+			status.State = "stopped"
+		}
 	}
 	if len(items) == 0 {
 		return status
@@ -380,8 +429,10 @@ func (s *Service) GetLLMStatus(ctx context.Context, streamerID string) LLMStatus
 	status.CurrentStage = latest.Stage
 	status.CurrentLabel = latest.Label
 	status.CurrentConfidence = latest.Confidence
-	status.UpdatedAt = latest.CreatedAt
-	status.State = "active"
+	if status.State != "stopped" {
+		status.UpdatedAt = latest.CreatedAt
+		status.State = "active"
+	}
 	status.DetectedGameKey = inferDetectedGameKey(items)
 
 	orderedStages := make([]string, 0)

--- a/internal/streamers/service_stop_test.go
+++ b/internal/streamers/service_stop_test.go
@@ -1,0 +1,43 @@
+package streamers
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestStopTrackingMarksStreamerStoppedAndCallsHook(t *testing.T) {
+	svc := NewService()
+	if _, err := svc.Submit(context.Background(), "streamername", "user-1"); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	items := svc.List(context.Background(), "streamername", "pending", 1)
+	if len(items) != 1 {
+		t.Fatalf("expected one streamer, got %d", len(items))
+	}
+
+	called := false
+	svc.SetTrackingStopHook(func(_ context.Context, streamerID string) error {
+		called = streamerID == items[0].ID
+		return nil
+	})
+
+	if err := svc.StopTracking(context.Background(), items[0].ID); err != nil {
+		t.Fatalf("StopTracking() error = %v", err)
+	}
+	if !called {
+		t.Fatal("expected stop hook to be called")
+	}
+
+	status := svc.GetLLMStatus(context.Background(), items[0].ID)
+	if status.State != "stopped" {
+		t.Fatalf("expected stopped state, got %q", status.State)
+	}
+}
+
+func TestStopTrackingReturnsNotFoundForUnknownStreamer(t *testing.T) {
+	svc := NewService()
+	if err := svc.StopTracking(context.Background(), "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a server-side control for the UI stop button so users can end per-streamer monitoring without restarting the backend, and ensure the scheduler is cancelled and API status reflects the stopped state.
- Make stopping tracking observable in the LLM status model so clients receive an immediate `stopped` state instead of the status remaining `active` after scheduler shutdown.

### Description
- Added `SetTrackingStopHook` and `StopTracking` to `internal/streamers/service.go`, and updated LLM status computation to surface a `stopped` state when analysis is inactive. 
- Exposed a new authenticated route `DELETE /api/streamers/{streamerId}/tracking` in `internal/app/router.go` that calls `StopTracking` and returns the updated `LLMStatus` payload.
- Wired the stop hook in `cmd/server/main.go` to call `streamScheduler.Stop(streamerID)` so the in-process Streamlink scheduler cancels the per-streamer job on stop.
- Added unit-level coverage: `internal/streamers/service_stop_test.go` for service-level stop behavior and `internal/app/router_streamers_status_test.go` extension to exercise the delete endpoint, and updated OpenAPI (`docs/openapi.yaml`), `docs/local_setup.md`, and `docs/implementation_plan.md` to document the new API and checklist item.

### Testing
- Added unit tests `TestStopTrackingMarksStreamerStoppedAndCallsHook` and `TestStreamerTrackingDeleteStopsMonitoring` which validate the new service hook, `StopTracking` behavior, and router integration; these tests are included in the change set.
- Attempted to run targeted test suites (`go test ./internal/streamers`, `go test ./internal/app`, and `go test ./cmd/server`) in the rollout environment, but the `go test` runs hung in this environment and did not fully complete; the new tests should be run in CI or locally to verify green.
- Verified code formatting and committed the changes (`git commit "Add streamer tracking stop endpoint"`).

### Implementation-plan checklist (aligned with docs/implementation_plan.md M2.1)
- [x] Auto-start Streamlink analysis job after `POST /api/streamers` success.
- [x] Provide a stop-tracking control path so clients can end per-streamer monitoring without restarting the service.
- [x] Fixed 10-second capture cadence with lock/idempotency protections.
- [ ] Persist the active global game-detection prompt in the database with audit/version history.
- [ ] Persist active per-game scenarios in the database, including linked steps and expected transitions.

Please run the new unit tests in CI or locally (`go test ./internal/streamers -run TestStopTrackingMarksStreamerStoppedAndCallsHook`, `go test ./internal/app -run TestStreamerTrackingDeleteStopsMonitoring`) and report results so I can iterate on any failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd664c4210832c9b28cda42ef649b0)