### PR TITLE
Update test to expect "stopped" state from MarkAnalysisInactive

### DIFF
--- a/internal/streamers/service_hook_test.go
+++ b/internal/streamers/service_hook_test.go
@@ -61,7 +61,7 @@ func TestResolveStreamlinkChannel(t *testing.T) {
 	}
 }
 
-func TestMarkAnalysisInactiveResetsIdleStatusWithoutDecisions(t *testing.T) {
+func TestMarkAnalysisInactiveMarksStoppedStatusWithoutDecisions(t *testing.T) {
 	svc := NewService()
 	result, err := svc.Submit(context.Background(), "stream_name", "user-1")
 	if err != nil {
@@ -71,7 +71,7 @@ func TestMarkAnalysisInactiveResetsIdleStatusWithoutDecisions(t *testing.T) {
 	svc.MarkAnalysisInactive(result.ID)
 
 	status := svc.GetLLMStatus(context.Background(), result.ID)
-	if status.State != "idle" {
-		t.Fatalf("expected idle status after deactivation, got %q", status.State)
+	if status.State != "stopped" {
+		t.Fatalf("expected stopped status after deactivation, got %q", status.State)
 	}
 }


### PR DESCRIPTION
### Motivation
- Align the unit test with the updated behavior where `MarkAnalysisInactive` marks analysis LLM status as `stopped` instead of `idle`.

### Description
- Rename the test to `TestMarkAnalysisInactiveMarksStoppedStatusWithoutDecisions` and update the assertion to expect `status.State` to equal `"stopped"` instead of `"idle"`.

### Testing
- Ran `go test ./...` and all tests in the affected package passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd6e8da9e4832c8920aa14ce8bd283)