### PR TITLE
Use UUIDs for LLM decision IDs to avoid duplicate PKs

### DIFF
--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
@@ -55,8 +56,6 @@ type Service struct {
 	rateLimitMu      sync.Mutex
 	rateLimitByKey   map[string]submissionLimit
 	nowFn            func() time.Time
-	counterMu        sync.Mutex
-	counter          int64
 	onSubmittedMu    sync.RWMutex
 	onSubmitted      func(context.Context, string) error
 	onTrackingStopMu sync.RWMutex
@@ -304,13 +303,8 @@ func (s *Service) RecordLLMDecision(ctx context.Context, req RecordDecisionReque
 		return LLMDecision{}, errors.New("confidence must be between 0 and 1")
 	}
 
-	s.counterMu.Lock()
-	s.counter++
-	id := fmt.Sprintf("llm_%d", s.counter)
-	s.counterMu.Unlock()
-
 	item := LLMDecision{
-		ID:                 id,
+		ID:                 "llm_" + uuid.NewString(),
 		RunID:              runID,
 		StreamerID:         streamerID,
 		Stage:              stage,

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -128,6 +128,42 @@ func TestRecordAndListLLMDecisions(t *testing.T) {
 	if items[0].PromptVersionID != "prompt-2" || items[0].ChunkRef == "" || items[0].LatencyMS != 180 || items[0].RequestRef == "" || items[0].TransitionToStep != "wait_for_result" {
 		t.Fatalf("expected metadata to be persisted, got %#v", items[0])
 	}
+	if items[0].ID == "" || items[0].ID[:4] != "llm_" {
+		t.Fatalf("expected generated llm id, got %q", items[0].ID)
+	}
+}
+
+func TestRecordLLMDecisionGeneratesUniqueIDs(t *testing.T) {
+	svc := NewService()
+
+	first, err := svc.RecordLLMDecision(context.Background(), RecordDecisionRequest{
+		RunID:      "run-1",
+		StreamerID: "str-1",
+		Stage:      "detector",
+		Label:      "counter_strike",
+		Confidence: 0.95,
+	})
+	if err != nil {
+		t.Fatalf("first RecordLLMDecision() error = %v", err)
+	}
+
+	second, err := svc.RecordLLMDecision(context.Background(), RecordDecisionRequest{
+		RunID:      "run-2",
+		StreamerID: "str-1",
+		Stage:      "detector",
+		Label:      "valorant",
+		Confidence: 0.91,
+	})
+	if err != nil {
+		t.Fatalf("second RecordLLMDecision() error = %v", err)
+	}
+
+	if first.ID == second.ID {
+		t.Fatalf("expected unique ids, got %q and %q", first.ID, second.ID)
+	}
+	if first.ID == "" || second.ID == "" || first.ID[:4] != "llm_" || second.ID[:4] != "llm_" {
+		t.Fatalf("expected llm-prefixed ids, got %q and %q", first.ID, second.ID)
+	}
 }
 
 func TestRecordLLMDecisionValidation(t *testing.T) {


### PR DESCRIPTION
### Motivation
- Worker cycles were failing at the decision persistence step with `duplicate key value violates unique constraint "streamer_llm_decisions_pkey"` because `LLMDecision.ID` was generated from an in-memory incremental counter that resets across process restarts, causing primary key collisions in Postgres.
- The intent is to make persisted LLM decision IDs globally unique and stable across restarts so analysis runs and live status/history continue to be persisted reliably.

### Description
- Replace in-memory incremental ID generation with UUID-based IDs by importing `github.com/google/uuid` and setting `LLMDecision.ID = "llm_" + uuid.NewString()` in `internal/streamers/service.go`.
- Remove the in-memory counter fields/logic used to generate numeric `llm_N` IDs in the service.
- Add/adjust unit tests in `internal/streamers/service_test.go` to assert the `llm_` prefix and uniqueness of generated IDs (`TestRecordLLMDecisionGeneratesUniqueIDs`) and to validate ID presence in `TestRecordAndListLLMDecisions`.
- Files changed: `internal/streamers/service.go`, `internal/streamers/service_test.go`.

Checklist (aligned with docs/implementation_plan.md M2.1 priority list):
- [x] Prevent duplicate primary keys on `streamer_llm_decisions` by switching to UUID IDs so inserts succeed across restarts.
- [x] Ensure decisions can be persisted reliably between service restarts (LLM decision persistence fixed).
- [x] Reduce chance of scheduler/worker cycles failing due to PK collisions, restoring analysis pipeline stability.
- [ ] End-to-end verification of 10s chunk capture cadence (not covered here).
- [ ] End-to-end UI/websocket live-status publication verification (not covered here).

### Testing
- Added unit tests: `TestRecordLLMDecisionGeneratesUniqueIDs` and a small assertion in `TestRecordAndListLLMDecisions` to check ID format and presence.
- Automated test runs executed:
  - `go test ./internal/streamers -count=1 -timeout=30s` — OK
  - `go test ./internal/media -count=1 -timeout=30s` — OK
- All affected tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd73440808832cb0b106c961fa232b)