### PR TITLE
Fix Gemini media request validation

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -23,6 +23,7 @@ var (
 	ErrGeminiChunkTooLarge     = errors.New("gemini chunk exceeds inline upload limit")
 	ErrGeminiEmptyResponse     = errors.New("gemini returned empty response")
 	ErrGeminiInvalidConfidence = errors.New("gemini confidence must be between 0 and 1")
+	ErrGeminiUnsupportedMIME   = errors.New("gemini does not support the chunk mime type")
 )
 
 type GeminiClassifierConfig struct {
@@ -70,13 +71,8 @@ type geminiContent struct {
 }
 
 type geminiPart struct {
-	Text            string                 `json:"text,omitempty"`
-	InlineData      *geminiInlineData      `json:"inlineData,omitempty"`
-	MediaResolution *geminiMediaResolution `json:"mediaResolution,omitempty"`
-}
-
-type geminiMediaResolution struct {
-	Level string `json:"level"`
+	Text       string            `json:"text,omitempty"`
+	InlineData *geminiInlineData `json:"inlineData,omitempty"`
 }
 
 type geminiInlineData struct {
@@ -88,6 +84,7 @@ type geminiGenerationConfig struct {
 	Temperature      float64 `json:"temperature,omitempty"`
 	MaxOutputTokens  int     `json:"maxOutputTokens,omitempty"`
 	ResponseMIMEType string  `json:"responseMimeType,omitempty"`
+	MediaResolution  string  `json:"mediaResolution,omitempty"`
 }
 
 type geminiGenerateContentResponse struct {
@@ -135,20 +132,22 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 		return StageClassification{}, err
 	}
 
+	if err := validateGeminiMIMEType(mimeType); err != nil {
+		return StageClassification{}, err
+	}
+
 	requestBody := geminiGenerateContentRequest{
 		Contents: []geminiContent{{
 			Parts: []geminiPart{
 				{Text: buildGeminiInstruction(input)},
-				{
-					InlineData:      &geminiInlineData{MimeType: mimeType, Data: base64.StdEncoding.EncodeToString(data)},
-					MediaResolution: &geminiMediaResolution{Level: "media_resolution_low"},
-				},
+				{InlineData: &geminiInlineData{MimeType: mimeType, Data: base64.StdEncoding.EncodeToString(data)}},
 			},
 		}},
 		GenerationConfig: geminiGenerationConfig{
 			Temperature:      input.Prompt.Temperature,
 			MaxOutputTokens:  input.Prompt.MaxTokens,
 			ResponseMIMEType: "application/json",
+			MediaResolution:  "LOW",
 		},
 	}
 
@@ -157,10 +156,7 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 		return StageClassification{}, err
 	}
 
-	model := strings.TrimSpace(input.Prompt.Model)
-	if model == "" {
-		model = "gemini-2.0-flash"
-	}
+	model := normalizeGeminiModel(input.Prompt.Model)
 
 	requestCtx := ctx
 	cancel := func() {}
@@ -313,4 +309,21 @@ func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {
 		return geminiStageResponse{}, ErrGeminiEmptyResponse
 	}
 	return parsed, nil
+}
+
+func normalizeGeminiModel(model string) string {
+	trimmed := strings.TrimSpace(model)
+	if trimmed == "" || strings.EqualFold(trimmed, "gemini") {
+		return "gemini-2.0-flash"
+	}
+	return trimmed
+}
+
+func validateGeminiMIMEType(mimeType string) error {
+	switch strings.TrimSpace(strings.ToLower(mimeType)) {
+	case "video/mp4", "video/mpeg", "video/mov", "video/avi", "video/x-flv", "video/mpg", "video/webm", "video/wmv", "video/3gpp", "audio/mpeg", "audio/wav":
+		return nil
+	default:
+		return fmt.Errorf("%w: %s (convert Streamlink .ts chunks to a supported format such as video/mp4 before calling Gemini)", ErrGeminiUnsupportedMIME, mimeType)
+	}
 }

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -27,7 +27,7 @@ func TestNewGeminiStageClassifierRequiresAPIKey(t *testing.T) {
 
 func TestGeminiStageClassifierClassify(t *testing.T) {
 	dir := t.TempDir()
-	chunkPath := filepath.Join(dir, "chunk.ts")
+	chunkPath := filepath.Join(dir, "chunk.mp4")
 	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
 		t.Fatalf("write chunk: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestGeminiStageClassifierClassify(t *testing.T) {
 		Prompt: prompts.PromptVersion{
 			Stage:       "detector",
 			Template:    "Detect the game being played",
-			Model:       "gemini-2.0-flash",
+			Model:       "gemini",
 			Temperature: 0.2,
 			MaxTokens:   128,
 			TimeoutMS:   1000,
@@ -86,11 +86,11 @@ func TestGeminiStageClassifierClassify(t *testing.T) {
 	if result.TokensIn != 111 || result.TokensOut != 22 {
 		t.Fatalf("unexpected token usage: in=%d out=%d", result.TokensIn, result.TokensOut)
 	}
-	if !strings.Contains(gotBody, `"mimeType":"video/mp2t"`) {
+	if !strings.Contains(gotBody, `"mimeType":"video/mp4"`) {
 		t.Fatalf("expected transport stream mime type in request body: %s", gotBody)
 	}
-	if !strings.Contains(gotBody, `"mediaResolution":{"level":"media_resolution_low"}`) {
-		t.Fatalf("expected low media resolution in request body: %s", gotBody)
+	if !strings.Contains(gotBody, `"mediaResolution":"LOW"`) {
+		t.Fatalf("expected low media resolution in generation config: %s", gotBody)
 	}
 	if !strings.Contains(gotBody, "Detect the game being played") {
 		t.Fatalf("expected prompt template in request body: %s", gotBody)
@@ -127,5 +127,40 @@ func TestGeminiStageClassifierRejectsLargeChunk(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), ErrGeminiChunkTooLarge.Error()) {
 		t.Fatalf("expected large chunk error, got %v", err)
+	}
+}
+
+func TestGeminiStageClassifierRejectsUnsupportedChunkMimeType(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.ts")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:     "gemini-key",
+		BaseURL:    "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, fmt.Errorf("unexpected request") })},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	_, err = classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "detector",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt: prompts.PromptVersion{
+			Stage:     "detector",
+			Template:  "Detect the game being played",
+			Model:     "gemini",
+			MaxTokens: 128,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), ErrGeminiUnsupportedMIME.Error()) {
+		t.Fatalf("expected unsupported mime error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "video/mp4") {
+		t.Fatalf("expected conversion hint, got %v", err)
 	}
 }


### PR DESCRIPTION
### Motivation
- Requests to Gemini were failing with `INVALID_ARGUMENT` because the media payload and model handling did not match the GenerateContent API expectations and unsupported `.ts` chunks were being sent transparently.
- Make failures actionable and avoid opaque 400s by validating chunk MIME and normalizing model names before issuing requests.

### Description
- Add `ErrGeminiUnsupportedMIME` and validate chunk MIME early in `GeminiStageClassifier.Classify`, returning a clear conversion hint for unsupported types (e.g. `video/mp2t`).
- Move `mediaResolution` into `generationConfig` and remove it from `parts` so the request matches the GenerateContent API contract, and set `MediaResolution: "LOW"` when sending media.
- Normalize prompt model alias `gemini` to the concrete `gemini-2.0-flash` model via `normalizeGeminiModel`.
- Update tests: switch the main happy-path test to use an `.mp4` chunk, add `TestGeminiStageClassifierRejectsUnsupportedChunkMimeType`, and adapt assertions to the new payload shape.
- Note: Streamlink still produces `.ts` chunks; this change fails fast with an actionable error rather than attempting an unsupported send, and a follow-up to transcode/remux `.ts`→supported format is required.

### Testing
- Ran `go test ./internal/media ./internal/prompts` and the suite passed after changes. 
- Executed `TestGeminiStageClassifierClassify` and the added `TestGeminiStageClassifierRejectsUnsupportedChunkMimeType`, both succeeded.
- Automated tests confirm request body now contains `"mediaResolution":"LOW"`, the `gemini` alias resolves to `gemini-2.0-flash`, and unsupported `.ts` MIME is rejected with a helpful error.

M2.1 checklist (aligned with docs/implementation_plan.md):
- [x] Worker payload includes prompt text + runtime params (model, temperature, token limits) for the resolved step.
- [x] Gemini request payload now matches the API contract for media resolution.
- [x] Failure mode now clearly explains why unsupported media is rejected so live status/debugging is easier.
- [ ] Streamlink chunks are still captured as `.ts`; implement automatic transcoding/upload to a Gemini-supported format in a follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfef299bec832cb94dfcdf7fbb5371)