### PR TITLE
Normalize Streamlink .ts chunks to .mp4 using configurable ffmpeg

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -219,6 +219,7 @@ func buildStreamCapture(cfg config.Config, streamersService *streamers.Service) 
 
 	return media.NewStreamlinkCaptureAdapter(media.StreamlinkCaptureConfig{
 		BinaryPath:     cfg.Streamlink.BinaryPath,
+		FFmpegBinary:   cfg.Streamlink.FFmpegBinary,
 		Quality:        cfg.Streamlink.Quality,
 		CaptureTimeout: cfg.Streamlink.CaptureTimeout,
 		OutputDir:      cfg.Streamlink.OutputDir,

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -41,6 +41,7 @@ FUNPOT_REDIS_DB=0
 FUNPOT_REDIS_CONNECT_TIMEOUT=2s
 FUNPOT_STREAMLINK_ENABLED=false
 FUNPOT_STREAMLINK_BINARY=streamlink
+FUNPOT_STREAMLINK_FFMPEG_BINARY=ffmpeg
 FUNPOT_STREAMLINK_QUALITY=1080p60,1080p,720p60,720p,936p60,936p,648p60,648p,480p,best
 FUNPOT_STREAMLINK_CAPTURE_TIMEOUT=25s
 FUNPOT_STREAMLINK_OUTPUT_DIR=tmp/stream_chunks
@@ -76,6 +77,10 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 
 > `FUNPOT_STREAMLINK_ENABLED=true` requires the `streamlink` binary to be
 > available in PATH (or pointed to by `FUNPOT_STREAMLINK_BINARY`).
+
+> Live Gemini analysis also remuxes Streamlink `.ts` chunks into `.mp4`, so
+> `FUNPOT_STREAMLINK_FFMPEG_BINARY` must point to a working `ffmpeg` binary
+> when Streamlink capture is enabled.
 
 > Set `FUNPOT_GEMINI_API_KEY` to enable real Gemini stage classification. When
 > it is unset, the server falls back to the deterministic placeholder

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 type StreamlinkConfig struct {
 	Enabled        bool
 	BinaryPath     string
+	FFmpegBinary   string
 	Quality        string
 	CaptureTimeout time.Duration
 	OutputDir      string
@@ -420,6 +421,7 @@ func Load() (Config, error) {
 		Streamlink: StreamlinkConfig{
 			Enabled:        streamlinkEnabled,
 			BinaryPath:     getString("FUNPOT_STREAMLINK_BINARY", "streamlink"),
+			FFmpegBinary:   getString("FUNPOT_STREAMLINK_FFMPEG_BINARY", "ffmpeg"),
 			Quality:        getString("FUNPOT_STREAMLINK_QUALITY", defaultStreamlinkQuality()),
 			CaptureTimeout: streamlinkCaptureTimeout,
 			OutputDir:      getString("FUNPOT_STREAMLINK_OUTPUT_DIR", "tmp/stream_chunks"),
@@ -469,6 +471,9 @@ func Load() (Config, error) {
 	if cfg.Streamlink.Enabled {
 		if strings.TrimSpace(cfg.Streamlink.BinaryPath) == "" {
 			return Config{}, fmt.Errorf("FUNPOT_STREAMLINK_BINARY must be set when FUNPOT_STREAMLINK_ENABLED=true")
+		}
+		if strings.TrimSpace(cfg.Streamlink.FFmpegBinary) == "" {
+			return Config{}, fmt.Errorf("FUNPOT_STREAMLINK_FFMPEG_BINARY must be set when FUNPOT_STREAMLINK_ENABLED=true")
 		}
 		if strings.TrimSpace(cfg.Streamlink.Quality) == "" {
 			return Config{}, fmt.Errorf("FUNPOT_STREAMLINK_QUALITY must be set when FUNPOT_STREAMLINK_ENABLED=true")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,6 +39,7 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	t.Setenv("FUNPOT_REDIS_HEALTHCHECK_TIMEOUT", "7s")
 	t.Setenv("FUNPOT_STREAMLINK_ENABLED", "true")
 	t.Setenv("FUNPOT_STREAMLINK_BINARY", "/usr/local/bin/streamlink")
+	t.Setenv("FUNPOT_STREAMLINK_FFMPEG_BINARY", "/usr/local/bin/ffmpeg")
 	t.Setenv("FUNPOT_STREAMLINK_QUALITY", "best")
 	t.Setenv("FUNPOT_STREAMLINK_CAPTURE_TIMEOUT", "14s")
 	t.Setenv("FUNPOT_STREAMLINK_OUTPUT_DIR", "tmp/chunks")
@@ -132,6 +133,9 @@ func TestLoadDatabaseConfig(t *testing.T) {
 	}
 	if cfg.Streamlink.BinaryPath != "/usr/local/bin/streamlink" {
 		t.Fatalf("expected streamlink binary to be set")
+	}
+	if cfg.Streamlink.FFmpegBinary != "/usr/local/bin/ffmpeg" {
+		t.Fatalf("expected streamlink ffmpeg binary to be set")
 	}
 	if cfg.Streamlink.CaptureTimeout != 14*time.Second {
 		t.Fatalf("expected streamlink capture timeout 14s, got %s", cfg.Streamlink.CaptureTimeout)

--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -60,6 +60,7 @@ func (r execStreamlinkRunner) Run(ctx context.Context, stdout io.Writer, stderr 
 
 type StreamlinkCaptureConfig struct {
 	BinaryPath     string
+	FFmpegBinary   string
 	Quality        string
 	CaptureTimeout time.Duration
 	OutputDir      string
@@ -69,16 +70,20 @@ type StreamlinkCaptureConfig struct {
 // StreamlinkCaptureAdapter captures live stream bytes via streamlink and stores each
 // polling cycle into a local chunk file reference.
 type StreamlinkCaptureAdapter struct {
-	logger   *zap.Logger
-	cfg      StreamlinkCaptureConfig
-	resolver StreamlinkChannelResolver
-	runner   StreamlinkCommandRunner
-	nowFn    func() time.Time
+	logger     *zap.Logger
+	cfg        StreamlinkCaptureConfig
+	resolver   StreamlinkChannelResolver
+	runner     StreamlinkCommandRunner
+	normalizer ChunkNormalizer
+	nowFn      func() time.Time
 }
 
 func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver StreamlinkChannelResolver, runner StreamlinkCommandRunner) *StreamlinkCaptureAdapter {
 	if strings.TrimSpace(cfg.BinaryPath) == "" {
 		cfg.BinaryPath = "streamlink"
+	}
+	if strings.TrimSpace(cfg.FFmpegBinary) == "" {
+		cfg.FFmpegBinary = "ffmpeg"
 	}
 	cfg.Quality = normalizeStreamlinkQuality(cfg.Quality)
 	if cfg.CaptureTimeout <= 0 || cfg.CaptureTimeout < minimumStreamlinkCaptureTimeout {
@@ -93,7 +98,14 @@ func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver Streamlin
 	if runner == nil {
 		runner = execStreamlinkRunner{}
 	}
-	return &StreamlinkCaptureAdapter{logger: zap.NewNop(), cfg: cfg, resolver: resolver, runner: runner, nowFn: time.Now}
+	return &StreamlinkCaptureAdapter{
+		logger:     zap.NewNop(),
+		cfg:        cfg,
+		resolver:   resolver,
+		runner:     runner,
+		normalizer: NewFFmpegChunkNormalizer(cfg.FFmpegBinary, runner),
+		nowFn:      time.Now,
+	}
 }
 
 func (a *StreamlinkCaptureAdapter) SetLogger(logger *zap.Logger) {
@@ -191,7 +203,19 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 	}
 
 	logger.Info("stream capture completed", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.Int64("bytes", stat.Size()))
-	return ChunkRef{Reference: chunkPath, CapturedAt: a.nowFn().UTC()}, nil
+	chunk := ChunkRef{Reference: chunkPath, CapturedAt: a.nowFn().UTC()}
+	if a.normalizer == nil {
+		return chunk, nil
+	}
+	normalized, err := a.normalizer.Normalize(ctx, chunk)
+	if err != nil {
+		logger.Error("stream chunk normalization failed", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.Error(err))
+		return ChunkRef{}, err
+	}
+	if normalized.Reference != chunk.Reference {
+		logger.Info("stream chunk normalized", zap.String("streamerID", id), zap.String("sourceChunkPath", chunk.Reference), zap.String("normalizedChunkPath", normalized.Reference))
+	}
+	return normalized, nil
 }
 
 func sanitizeToken(value string) string {

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -29,11 +29,34 @@ type fakeCommandRunner struct {
 	stderrOutput string
 	lastName     string
 	lastArgs     []string
+	names        []string
+	argsHistory  [][]string
+	runFn        func(name string, args ...string) error
 }
 
 func (f *fakeCommandRunner) Run(_ context.Context, stdout io.Writer, stderr io.Writer, name string, args ...string) error {
 	f.lastName = name
 	f.lastArgs = append([]string(nil), args...)
+	f.names = append(f.names, name)
+	f.argsHistory = append(f.argsHistory, append([]string(nil), args...))
+	if f.runFn != nil {
+		return f.runFn(name, args...)
+	}
+	if strings.Contains(name, "ffmpeg") && len(args) > 0 {
+		outputPath := args[len(args)-1]
+		inputPath := ""
+		for i := 0; i < len(args)-1; i++ {
+			if args[i] == "-i" && i+1 < len(args) {
+				inputPath = args[i+1]
+				break
+			}
+		}
+		data, err := os.ReadFile(inputPath)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(outputPath, data, 0o644)
+	}
 	if len(f.writeData) > 0 {
 		_, _ = stdout.Write(f.writeData)
 	}
@@ -61,13 +84,13 @@ func TestStreamlinkCaptureAdapterCaptureSuccess(t *testing.T) {
 	if chunk.Reference == "" {
 		t.Fatal("expected chunk reference")
 	}
-	if runner.lastName != "streamlink-bin" {
-		t.Fatalf("runner binary = %q", runner.lastName)
+	if len(runner.names) < 2 || runner.names[0] != "streamlink-bin" {
+		t.Fatalf("runner binaries = %#v", runner.names)
 	}
-	if got := runner.lastArgs[len(runner.lastArgs)-1]; got != defaultPreferredStreamQuality {
+	if got := runner.argsHistory[0][len(runner.argsHistory[0])-1]; got != defaultPreferredStreamQuality {
 		t.Fatalf("runner quality = %q, want %q", got, defaultPreferredStreamQuality)
 	}
-	joined := strings.Join(runner.lastArgs, " ")
+	joined := strings.Join(runner.argsHistory[0], " ")
 	if !strings.Contains(joined, "https://twitch.tv/shroud") {
 		t.Fatalf("expected resolved channel in args, got %q", joined)
 	}
@@ -81,6 +104,9 @@ func TestStreamlinkCaptureAdapterCaptureSuccess(t *testing.T) {
 	}
 	if !strings.HasPrefix(chunk.Reference, filepath.Join(outDir, "str_1")) {
 		t.Fatalf("unexpected chunk path: %q", chunk.Reference)
+	}
+	if filepath.Ext(chunk.Reference) != ".mp4" {
+		t.Fatalf("expected normalized mp4 chunk, got %q", chunk.Reference)
 	}
 }
 
@@ -161,6 +187,41 @@ func TestStreamlinkCaptureAdapterReturnsStreamEndedErrorWhenNoPlayableStreamsRem
 	}
 	if len(files) != 0 {
 		t.Fatalf("expected offline empty chunk to be removed, found %d files", len(files))
+	}
+}
+
+func TestFFmpegChunkNormalizerRemuxesTSChunksToMP4(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "chunk.ts")
+	if err := os.WriteFile(inputPath, []byte("transport-stream"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	runner := &fakeCommandRunner{
+		runFn: func(name string, args ...string) error {
+			if name != "ffmpeg-bin" {
+				t.Fatalf("runner binary = %q, want ffmpeg-bin", name)
+			}
+			if got := args[len(args)-1]; got != filepath.Join(dir, "chunk.mp4") {
+				t.Fatalf("output path = %q", got)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "chunk.mp4"), []byte("mp4-bytes"), 0o644); err != nil {
+				t.Fatalf("WriteFile(normalized) error = %v", err)
+			}
+			return nil
+		},
+	}
+
+	normalizer := NewFFmpegChunkNormalizer("ffmpeg-bin", runner)
+	normalized, err := normalizer.Normalize(context.Background(), ChunkRef{Reference: inputPath})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if normalized.Reference != filepath.Join(dir, "chunk.mp4") {
+		t.Fatalf("normalized reference = %q", normalized.Reference)
+	}
+	if _, err := os.Stat(inputPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected source ts file removal, err=%v", err)
 	}
 }
 

--- a/internal/media/normalize.go
+++ b/internal/media/normalize.go
@@ -1,0 +1,74 @@
+package media
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var ErrChunkNormalizationFailed = errors.New("chunk normalization failed")
+
+type ChunkNormalizer interface {
+	Normalize(ctx context.Context, chunk ChunkRef) (ChunkRef, error)
+}
+
+type FFmpegChunkNormalizer struct {
+	binaryPath string
+	runner     StreamlinkCommandRunner
+}
+
+func NewFFmpegChunkNormalizer(binaryPath string, runner StreamlinkCommandRunner) *FFmpegChunkNormalizer {
+	trimmed := strings.TrimSpace(binaryPath)
+	if trimmed == "" {
+		trimmed = "ffmpeg"
+	}
+	if runner == nil {
+		runner = execStreamlinkRunner{}
+	}
+	return &FFmpegChunkNormalizer{binaryPath: trimmed, runner: runner}
+}
+
+func (n *FFmpegChunkNormalizer) Normalize(ctx context.Context, chunk ChunkRef) (ChunkRef, error) {
+	path := strings.TrimSpace(chunk.Reference)
+	if path == "" {
+		return chunk, nil
+	}
+	if strings.EqualFold(filepath.Ext(path), ".mp4") {
+		return chunk, nil
+	}
+	if !strings.EqualFold(filepath.Ext(path), ".ts") {
+		return chunk, nil
+	}
+
+	outputPath := strings.TrimSuffix(path, filepath.Ext(path)) + ".mp4"
+	args := []string{
+		"-y",
+		"-i", path,
+		"-c", "copy",
+		"-movflags", "+faststart",
+		outputPath,
+	}
+
+	var stderr strings.Builder
+	if err := n.runner.Run(ctx, io.Discard, &stderr, n.binaryPath, args...); err != nil {
+		return ChunkRef{}, fmt.Errorf("%w: remux %s -> %s: %v (stderr=%s)", ErrChunkNormalizationFailed, path, outputPath, err, strings.TrimSpace(stderr.String()))
+	}
+
+	stat, err := os.Stat(outputPath)
+	if err != nil {
+		return ChunkRef{}, fmt.Errorf("%w: stat normalized chunk %s: %v", ErrChunkNormalizationFailed, outputPath, err)
+	}
+	if stat.Size() == 0 {
+		return ChunkRef{}, fmt.Errorf("%w: normalized chunk %s is empty", ErrChunkNormalizationFailed, outputPath)
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return ChunkRef{}, fmt.Errorf("%w: remove source chunk %s: %v", ErrChunkNormalizationFailed, path, err)
+	}
+
+	chunk.Reference = outputPath
+	return chunk, nil
+}


### PR DESCRIPTION
### Motivation

- Gemini live analysis requires MP4 input, so stream capture that produces `.ts` chunks must be remuxed to `.mp4` before further processing.
- Make the `ffmpeg` binary configurable so environments without `ffmpeg` in PATH can point to a custom binary.

### Description

- Added `FUNPOT_STREAMLINK_FFMPEG_BINARY` config option and `StreamlinkConfig.FFmpegBinary` field and validated it when stream capture is enabled.
- Extended `StreamlinkCaptureConfig` and `NewStreamlinkCaptureAdapter` to default and propagate the FFmpeg binary, and wired a `ChunkNormalizer` into the capture adapter.
- Implemented `FFmpegChunkNormalizer` in `internal/media/normalize.go` which remuxes `.ts` chunks to `.mp4` by invoking the configured `ffmpeg` via the existing command runner abstraction and removes the source `.ts` on success.
- Updated stream capture flow to normalize captured chunks automatically and surface normalization errors.
- Updated tests and test helpers to simulate `ffmpeg` runs, added `TestFFmpegChunkNormalizerRemuxesTSChunksToMP4`, and adjusted existing `adapters` and `config` tests to account for the new config and normalization behavior.
- Documented the new environment variable in `docs/local_setup.md` and noted the requirement when stream capture is enabled.

### Testing

- Ran configuration unit tests via `go test ./internal/config -v` which passed and confirm `FUNPOT_STREAMLINK_FFMPEG_BINARY` is read and validated.
- Ran media adapter tests via `go test ./internal/media -v` which passed and include `TestFFmpegChunkNormalizerRemuxesTSChunksToMP4` and updated `StreamlinkCaptureAdapter` tests.
- Ran the full test suite via `go test ./...` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff38e4df4832cb92798dbbceb8d34)