### PR TITLE
Fix Gemini media resolution enum

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -147,7 +147,7 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 			Temperature:      input.Prompt.Temperature,
 			MaxOutputTokens:  input.Prompt.MaxTokens,
 			ResponseMIMEType: "application/json",
-			MediaResolution:  "LOW",
+			MediaResolution:  "MEDIA_RESOLUTION_LOW",
 		},
 	}
 

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -89,7 +89,7 @@ func TestGeminiStageClassifierClassify(t *testing.T) {
 	if !strings.Contains(gotBody, `"mimeType":"video/mp4"`) {
 		t.Fatalf("expected transport stream mime type in request body: %s", gotBody)
 	}
-	if !strings.Contains(gotBody, `"mediaResolution":"LOW"`) {
+	if !strings.Contains(gotBody, `"mediaResolution":"MEDIA_RESOLUTION_LOW"`) {
 		t.Fatalf("expected low media resolution in generation config: %s", gotBody)
 	}
 	if !strings.Contains(gotBody, "Detect the game being played") {


### PR DESCRIPTION
### Motivation
- Gemini `generateContent` calls were failing with `400 INVALID_ARGUMENT` because `generationConfig.mediaResolution` used the invalid literal `"LOW"` instead of the documented enum name, causing stream chunk analysis to error.
- Status checklist (aligned with M2.1): [x] Fix Gemini `mediaResolution` to `MEDIA_RESOLUTION_LOW`; [x] Update media classifier test to assert the corrected payload; [ ] Persist the active global game-detection prompt in DB; [ ] Persist per-game scenarios in DB; [ ] Publish realtime `LLM_STAGE_UPDATED` events; [ ] Add retry/backoff + DLQ and observability for media/LLM pipeline.

### Description
- Replace the literal `"LOW"` with the documented enum string `"MEDIA_RESOLUTION_LOW"` in `internal/media/gemini.go` so `GenerationConfig.MediaResolution` matches Gemini API expectations.
- Update `internal/media/gemini_test.go` to assert the corrected `"mediaResolution":"MEDIA_RESOLUTION_LOW"` value in the outgoing JSON payload.

### Testing
- Ran `gofmt -w internal/media/gemini.go internal/media/gemini_test.go` and code was formatted.
- Ran `go test ./internal/media/...` and the media package tests passed (`PASS`).
- Committed the change with message: `Fix Gemini media resolution enum`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff8d2427c832c95e1c194cc555c7d)