### PR TITLE
Persist and propagate tracker state, evidence and conflicts from Gemini responses

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -117,9 +117,14 @@ type geminiUsageMetadata struct {
 }
 
 type geminiStageResponse struct {
-	Label      string  `json:"label"`
-	Confidence float64 `json:"confidence"`
-	Summary    string  `json:"summary,omitempty"`
+	Label              string          `json:"label"`
+	Confidence         float64         `json:"confidence"`
+	Summary            string          `json:"summary,omitempty"`
+	UpdatedState       json.RawMessage `json:"updated_state,omitempty"`
+	Delta              json.RawMessage `json:"delta,omitempty"`
+	NextNeededEvidence json.RawMessage `json:"next_needed_evidence,omitempty"`
+	HardConflicts      json.RawMessage `json:"hard_conflicts,omitempty"`
+	FinalOutcome       string          `json:"final_outcome,omitempty"`
 }
 
 func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest) (StageClassification, error) {
@@ -207,28 +212,59 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 		return StageClassification{}, ErrGeminiInvalidConfidence
 	}
 
+	label := strings.TrimSpace(parsed.Label)
+	if label == "" && len(parsed.UpdatedState) > 0 {
+		label = "state_updated"
+	}
+	if label == "" && strings.TrimSpace(parsed.FinalOutcome) != "" {
+		label = strings.TrimSpace(parsed.FinalOutcome)
+	}
+	confidence := parsed.Confidence
+	if confidence == 0 && (len(parsed.UpdatedState) > 0 || strings.TrimSpace(parsed.FinalOutcome) != "") {
+		confidence = 1
+	}
 	return StageClassification{
-		Label:             strings.TrimSpace(parsed.Label),
-		Confidence:        parsed.Confidence,
+		Label:             label,
+		Confidence:        confidence,
 		RawResponse:       strings.TrimSpace(rawText),
 		RequestRef:        endpoint,
 		ResponseRef:       strconv.Itoa(resp.StatusCode),
 		TokensIn:          payload.UsageMetadata.PromptTokenCount,
 		TokensOut:         payload.UsageMetadata.CandidatesTokenCount,
 		Latency:           time.Since(started),
-		NormalizedOutcome: strings.TrimSpace(parsed.Label),
+		NormalizedOutcome: firstNonEmpty(strings.TrimSpace(parsed.FinalOutcome), label),
+		UpdatedStateJSON:  marshalRawMessage(parsed.UpdatedState),
+		EvidenceDeltaJSON: marshalRawMessage(parsed.Delta),
+		NextEvidenceJSON:  marshalRawMessage(parsed.NextNeededEvidence),
+		ConflictsJSON:     marshalRawMessage(parsed.HardConflicts),
+		FinalOutcome:      strings.TrimSpace(parsed.FinalOutcome),
 	}, nil
 }
 
 func buildGeminiInstruction(input StageRequest) string {
-	return strings.TrimSpace(fmt.Sprintf(`You analyze a livestream chunk for FunPot.
+	base := `You analyze a livestream chunk for FunPot.
 Stage: %s
+Use this stage prompt as the source of truth:
+%s`
+	if strings.TrimSpace(input.PreviousState) == "" {
+		return strings.TrimSpace(fmt.Sprintf(base+`
 Return ONLY valid JSON with keys: label, confidence, summary.
 - label: short snake_case decision for this stage.
 - confidence: number between 0 and 1.
-- summary: short rationale.
-Use this stage prompt as the source of truth:
-%s`, input.Stage, strings.TrimSpace(input.Prompt.Template)))
+- summary: short rationale.`, input.Stage, strings.TrimSpace(input.Prompt.Template)))
+	}
+	return strings.TrimSpace(fmt.Sprintf(base+`
+Previous persisted tracker state JSON:
+%s
+Return ONLY valid JSON. Update the tracker state using previous_state + new_chunk.
+Required keys:
+- updated_state: object
+- delta: array or object describing evidence changes
+- next_needed_evidence: array
+Optional keys:
+- hard_conflicts: array
+- final_outcome: win | loss | draw | unknown
+Do not return commentary outside JSON.`, input.Stage, strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.PreviousState)))
 }
 
 func loadGeminiChunk(path string, maxBytes int64) ([]byte, string, error) {
@@ -326,4 +362,12 @@ func validateGeminiMIMEType(mimeType string) error {
 	default:
 		return fmt.Errorf("%w: %s (convert Streamlink .ts chunks to a supported format such as video/mp4 before calling Gemini)", ErrGeminiUnsupportedMIME, mimeType)
 	}
+}
+
+func marshalRawMessage(value json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(value))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	return trimmed
 }

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -26,10 +26,11 @@ type ChunkRef struct {
 }
 
 type StageRequest struct {
-	StreamerID string
-	Stage      string
-	Chunk      ChunkRef
-	Prompt     prompts.PromptVersion
+	StreamerID    string
+	Stage         string
+	Chunk         ChunkRef
+	Prompt        prompts.PromptVersion
+	PreviousState string
 }
 
 type StageClassification struct {
@@ -42,6 +43,11 @@ type StageClassification struct {
 	TokensOut         int
 	Latency           time.Duration
 	NormalizedOutcome string
+	UpdatedStateJSON  string
+	EvidenceDeltaJSON string
+	NextEvidenceJSON  string
+	ConflictsJSON     string
+	FinalOutcome      string
 }
 
 type StreamCapture interface {
@@ -67,6 +73,7 @@ type RunStore interface {
 
 type DecisionStore interface {
 	RecordLLMDecision(ctx context.Context, req streamers.RecordDecisionRequest) (streamers.LLMDecision, error)
+	ListAllLLMDecisions(ctx context.Context, streamerID string) []streamers.LLMDecision
 }
 
 type Locker interface {
@@ -210,48 +217,6 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 		logger = zap.NewNop()
 	}
 
-	if w.scenarios != nil {
-		globalPrompt, err := w.scenarios.GetActiveGlobalDetector(ctx)
-		if err != nil {
-			logger.Warn("no active global detector configured", zap.String("streamerID", streamerID), zap.Error(err))
-			return streamers.LLMDecision{}, err
-		}
-		detectorDecision, err := w.processPromptTemplate(ctx, runID, streamerID, chunk, globalPrompt, nil)
-		if err != nil {
-			logger.Error("global detector stage failed", zap.String("streamerID", streamerID), zap.Error(err))
-			return streamers.LLMDecision{}, err
-		}
-		gameSlug := strings.TrimSpace(detectorDecision.Label)
-		if gameSlug == "" || gameSlug == "uncertain" {
-			return detectorDecision, nil
-		}
-		scenario, err := w.scenarios.GetActiveScenarioByGame(ctx, gameSlug)
-		if err != nil {
-			logger.Info("no active game scenario found after detector step", zap.String("streamerID", streamerID), zap.String("gameSlug", gameSlug), zap.Error(err))
-			return detectorDecision, nil
-		}
-		currentStep, ok := scenario.EntryStep()
-		if !ok {
-			return detectorDecision, nil
-		}
-		lastDecision := detectorDecision
-		for {
-			stepDecision, transition, ok, err := w.processScenarioStep(ctx, runID, streamerID, chunk, currentStep, scenario)
-			if err != nil {
-				return streamers.LLMDecision{}, err
-			}
-			lastDecision = stepDecision
-			if !ok || transition.Terminal {
-				return lastDecision, nil
-			}
-			nextStep, ok := scenario.FindStep(transition.ToStepCode)
-			if !ok {
-				return lastDecision, nil
-			}
-			currentStep = nextStep
-		}
-	}
-
 	activePrompts := w.prompts.ListActive(ctx)
 	if len(activePrompts) == 0 {
 		logger.Warn("no active prompts found for streamer processing", zap.String("streamerID", streamerID))
@@ -262,7 +227,7 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 	var lastDecision streamers.LLMDecision
 	for _, activePrompt := range activePrompts {
 		logger.Info("processing prompt stage", zap.String("streamerID", streamerID), zap.String("runID", runID), zap.String("stage", activePrompt.Stage), zap.String("promptVersionID", activePrompt.ID))
-		decision, err := w.processStage(ctx, runID, streamerID, chunk, activePrompt, nil)
+		decision, err := w.processStage(ctx, runID, streamerID, chunk, activePrompt)
 		if err != nil {
 			logger.Error("prompt stage processing failed", zap.String("streamerID", streamerID), zap.String("runID", runID), zap.String("stage", activePrompt.Stage), zap.Error(err))
 			return streamers.LLMDecision{}, err
@@ -271,52 +236,6 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 		lastDecision = decision
 	}
 	return lastDecision, nil
-}
-
-func (w *Worker) processPromptTemplate(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptTemplate, transition *prompts.ScenarioTransition) (streamers.LLMDecision, error) {
-	return w.processStage(ctx, runID, streamerID, chunk, promptVersionFromTemplate(activePrompt), transition)
-}
-
-func (w *Worker) processScenarioStep(ctx context.Context, runID, streamerID string, chunk ChunkRef, step prompts.ScenarioStep, scenario prompts.ScenarioVersion) (streamers.LLMDecision, prompts.ScenarioTransition, bool, error) {
-	activePrompt := promptVersionFromTemplate(step.Prompt)
-	result, err := w.classifyWithRetry(ctx, StageRequest{
-		StreamerID: streamerID,
-		Stage:      activePrompt.Stage,
-		Chunk:      chunk,
-		Prompt:     activePrompt,
-	}, activePrompt)
-	if err != nil {
-		w.metrics.recordFailure(ctx, streamerID, activePrompt.Stage)
-		return streamers.LLMDecision{}, prompts.ScenarioTransition{}, false, err
-	}
-	label := strings.TrimSpace(result.Label)
-	if label == "" || result.Confidence < effectiveConfidenceThreshold(w.minConfidence, activePrompt.MinConfidence) {
-		label = "uncertain"
-	}
-	transition, ok := scenario.ResolveTransition(step.Code, label)
-	decision, err := w.processStageResult(ctx, activePrompt, result, chunk, runID, streamerID, func() *prompts.ScenarioTransition {
-		if !ok {
-			return nil
-		}
-		return &transition
-	}())
-	return decision, transition, ok, err
-}
-
-func promptVersionFromTemplate(activePrompt prompts.PromptTemplate) prompts.PromptVersion {
-	return prompts.PromptVersion{
-		ID:            activePrompt.ID,
-		Stage:         activePrompt.Stage,
-		Template:      activePrompt.Template,
-		Model:         activePrompt.Model,
-		Temperature:   activePrompt.Temperature,
-		MaxTokens:     activePrompt.MaxTokens,
-		TimeoutMS:     activePrompt.TimeoutMS,
-		RetryCount:    activePrompt.RetryCount,
-		BackoffMS:     activePrompt.BackoffMS,
-		CooldownMS:    activePrompt.CooldownMS,
-		MinConfidence: activePrompt.MinConfidence,
-	}
 }
 
 func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (ChunkRef, error) {
@@ -342,16 +261,17 @@ func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (Chunk
 	return ChunkRef{}, lastErr
 }
 
-func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptVersion, transition *prompts.ScenarioTransition) (streamers.LLMDecision, error) {
-	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt}, activePrompt)
+func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptVersion) (streamers.LLMDecision, error) {
+	previousState := w.resolvePreviousState(ctx, streamerID)
+	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt, PreviousState: previousState}, activePrompt)
 	if err != nil {
 		w.metrics.recordFailure(ctx, streamerID, activePrompt.Stage)
 		return streamers.LLMDecision{}, err
 	}
-	return w.processStageResult(ctx, activePrompt, result, chunk, runID, streamerID, transition)
+	return w.processStageResult(ctx, activePrompt, result, chunk, runID, streamerID, previousState)
 }
 
-func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.PromptVersion, result StageClassification, chunk ChunkRef, runID, streamerID string, transition *prompts.ScenarioTransition) (streamers.LLMDecision, error) {
+func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.PromptVersion, result StageClassification, chunk ChunkRef, runID, streamerID, previousState string) (streamers.LLMDecision, error) {
 	label := strings.TrimSpace(result.Label)
 	if label == "" || result.Confidence < effectiveConfidenceThreshold(w.minConfidence, activePrompt.MinConfidence) {
 		label = "uncertain"
@@ -383,10 +303,11 @@ func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.Pr
 		TokensOut:         result.TokensOut,
 		LatencyMS:         result.Latency.Milliseconds(),
 		TransitionOutcome: transitionOutcome,
-	}
-	if transition != nil {
-		recordReq.TransitionToStep = transition.ToStepCode
-		recordReq.TransitionTerminal = transition.Terminal
+		PreviousStateJSON: previousState,
+		UpdatedStateJSON:  firstNonEmpty(strings.TrimSpace(result.UpdatedStateJSON), strings.TrimSpace(result.RawResponse)),
+		EvidenceDeltaJSON: firstNonEmpty(strings.TrimSpace(result.EvidenceDeltaJSON), strings.TrimSpace(result.NextEvidenceJSON)),
+		ConflictsJSON:     strings.TrimSpace(result.ConflictsJSON),
+		FinalOutcome:      strings.TrimSpace(result.FinalOutcome),
 	}
 	decision, err := w.decisions.RecordLLMDecision(ctx, recordReq)
 	if err != nil {
@@ -394,6 +315,28 @@ func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.Pr
 		return streamers.LLMDecision{}, err
 	}
 	return decision, nil
+}
+
+func (w *Worker) resolvePreviousState(ctx context.Context, streamerID string) string {
+	if w == nil || w.decisions == nil {
+		return ""
+	}
+	items := w.decisions.ListAllLLMDecisions(ctx, streamerID)
+	for i := len(items) - 1; i >= 0; i-- {
+		if state := strings.TrimSpace(items[i].UpdatedStateJSON); state != "" {
+			return state
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func (w *Worker) classifyWithRetry(ctx context.Context, input StageRequest, activePrompt prompts.PromptVersion) (StageClassification, error) {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -109,7 +109,25 @@ func (f *flakyClassifier) Classify(_ context.Context, input StageRequest) (Stage
 
 func (s *fakeDecisionStore) RecordLLMDecision(_ context.Context, req streamers.RecordDecisionRequest) (streamers.LLMDecision, error) {
 	s.items = append(s.items, req)
-	return streamers.LLMDecision{RunID: req.RunID, StreamerID: req.StreamerID, Stage: req.Stage, Label: req.Label, Confidence: req.Confidence}, nil
+	return streamers.LLMDecision{RunID: req.RunID, StreamerID: req.StreamerID, Stage: req.Stage, Label: req.Label, Confidence: req.Confidence, UpdatedStateJSON: req.UpdatedStateJSON}, nil
+}
+
+func (s *fakeDecisionStore) ListAllLLMDecisions(_ context.Context, streamerID string) []streamers.LLMDecision {
+	items := make([]streamers.LLMDecision, 0, len(s.items))
+	for _, item := range s.items {
+		if item.StreamerID != streamerID {
+			continue
+		}
+		items = append(items, streamers.LLMDecision{
+			RunID:            item.RunID,
+			StreamerID:       item.StreamerID,
+			Stage:            item.Stage,
+			Label:            item.Label,
+			Confidence:       item.Confidence,
+			UpdatedStateJSON: item.UpdatedStateJSON,
+		})
+	}
+	return items
 }
 
 func (s *countingRunStore) CreateRun(_ context.Context, streamerID string) (string, error) {
@@ -266,49 +284,49 @@ func TestWorkerProcessStreamerSkipsEndedStreamWithoutFailingCycle(t *testing.T) 
 	}
 }
 
-func TestWorkerProcessStreamerRunsGlobalDetectorAndScenarioSteps(t *testing.T) {
+func TestWorkerProcessStreamerIgnoresLegacyScenarioResolver(t *testing.T) {
 	decisions := &fakeDecisionStore{}
-	scenario := prompts.ScenarioVersion{
-		ID:       "scenario-cs",
-		GameSlug: "counter_strike",
-		IsActive: true,
-		Steps: []prompts.ScenarioStep{
-			{Code: "match_start", Position: 1, Prompt: prompts.PromptTemplate{ID: "step-1", Stage: "match_start", Template: "is new match", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000, MinConfidence: 0.5}},
-			{Code: "match_result", Position: 2, Prompt: prompts.PromptTemplate{ID: "step-2", Stage: "match_result", Template: "result?", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000, MinConfidence: 0.5}},
-		},
-		Transitions: []prompts.ScenarioTransition{
-			{FromStepCode: "match_start", Outcome: "match_started", ToStepCode: "match_result"},
-			{FromStepCode: "match_result", Outcome: "win", Terminal: true},
-		},
-	}
 	worker := NewWorker(
 		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
 		fakeClassifier{results: map[string]StageClassification{
-			"global_detector": {Label: "counter_strike", Confidence: 0.98, NormalizedOutcome: "counter_strike"},
-			"match_start":     {Label: "match_started", Confidence: 0.93, NormalizedOutcome: "match_started"},
-			"match_result":    {Label: "win", Confidence: 0.95, NormalizedOutcome: "win"},
+			"match_update": {Label: "state_updated", Confidence: 0.98, UpdatedStateJSON: `{"match_status":"in_progress"}`},
 		}},
-		nil,
-		fakeScenarioResolver{global: prompts.PromptTemplate{ID: "det-1", Stage: "global_detector", Template: "detect game", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000, MinConfidence: 0.5}, scenario: scenario},
+		fakePromptResolver{prompts: []prompts.PromptVersion{{ID: "tracker-1", Stage: "match_update", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}}},
+		fakeScenarioResolver{globalErr: errors.New("legacy scenario resolver should not be called")},
 		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
 	)
 	got, err := worker.ProcessStreamer(context.Background(), "str-1")
 	if err != nil {
 		t.Fatalf("ProcessStreamer() error = %v", err)
 	}
-	if got.Stage != "match_result" || got.Label != "win" {
+	if got.Stage != "match_update" || got.Label != "state_updated" {
 		t.Fatalf("final decision = %#v", got)
 	}
-	if len(decisions.items) != 3 {
-		t.Fatalf("recorded %d decisions, want 3", len(decisions.items))
+	if len(decisions.items) != 1 {
+		t.Fatalf("recorded %d decisions, want 1", len(decisions.items))
 	}
-	if decisions.items[0].Stage != "global_detector" || decisions.items[1].Stage != "match_start" || decisions.items[2].Stage != "match_result" {
-		t.Fatalf("unexpected decision order: %#v", decisions.items)
+}
+
+func TestWorkerProcessStreamerPassesPersistedPreviousStateToTrackerStages(t *testing.T) {
+	decisions := &fakeDecisionStore{}
+	classifier := &flakyClassifier{result: StageClassification{Label: "state_updated", Confidence: 0.95, UpdatedStateJSON: `{"score":{"ct":8,"t":5}}`}}
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		classifier,
+		fakePromptResolver{prompts: []prompts.PromptVersion{{ID: "tracker-1", Stage: "match_update", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}}},
+		nil,
+		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
+	)
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("first ProcessStreamer() error = %v", err)
 	}
-	if decisions.items[1].TransitionOutcome != "match_started" || decisions.items[1].TransitionToStep != "match_result" {
-		t.Fatalf("expected next-step transition metadata, got %#v", decisions.items[1])
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("second ProcessStreamer() error = %v", err)
 	}
-	if !decisions.items[2].TransitionTerminal || decisions.items[2].TransitionOutcome != "win" {
-		t.Fatalf("expected terminal transition metadata, got %#v", decisions.items[2])
+	if len(decisions.items) != 2 {
+		t.Fatalf("recorded %d decisions, want 2", len(decisions.items))
+	}
+	if decisions.items[1].PreviousStateJSON != `{"score":{"ct":8,"t":5}}` {
+		t.Fatalf("previous state = %q", decisions.items[1].PreviousStateJSON)
 	}
 }

--- a/internal/streamers/model.go
+++ b/internal/streamers/model.go
@@ -43,6 +43,11 @@ type LLMDecision struct {
 	TransitionOutcome  string  `json:"transitionOutcome,omitempty"`
 	TransitionToStep   string  `json:"transitionToStep,omitempty"`
 	TransitionTerminal bool    `json:"transitionTerminal,omitempty"`
+	PreviousStateJSON  string  `json:"previousStateJson,omitempty"`
+	UpdatedStateJSON   string  `json:"updatedStateJson,omitempty"`
+	EvidenceDeltaJSON  string  `json:"evidenceDeltaJson,omitempty"`
+	ConflictsJSON      string  `json:"conflictsJson,omitempty"`
+	FinalOutcome       string  `json:"finalOutcome,omitempty"`
 	CreatedAt          string  `json:"createdAt"`
 }
 
@@ -81,4 +86,9 @@ type RecordDecisionRequest struct {
 	TransitionOutcome  string
 	TransitionToStep   string
 	TransitionTerminal bool
+	PreviousStateJSON  string
+	UpdatedStateJSON   string
+	EvidenceDeltaJSON  string
+	ConflictsJSON      string
+	FinalOutcome       string
 }

--- a/internal/streamers/postgres_decisions.go
+++ b/internal/streamers/postgres_decisions.go
@@ -34,6 +34,11 @@ CREATE TABLE IF NOT EXISTS streamer_llm_decisions (
     transition_outcome TEXT,
     transition_to_step TEXT,
     transition_terminal BOOLEAN NOT NULL DEFAULT FALSE,
+    previous_state_json TEXT,
+    updated_state_json TEXT,
+    evidence_delta_json TEXT,
+    conflicts_json TEXT,
+    final_outcome TEXT,
     created_at TIMESTAMPTZ NOT NULL,
     CHECK (char_length(id) > 0),
     CHECK (char_length(run_id) > 0),
@@ -95,12 +100,14 @@ INSERT INTO streamer_llm_decisions (
 	id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
 	prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
 	chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
-	latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+	latency_ms, transition_outcome, transition_to_step, transition_terminal,
+	previous_state_json, updated_state_json, evidence_delta_json, conflicts_json, final_outcome, created_at
 ) VALUES (
 	$1, $2, $3, $4, $5, $6, $7,
 	$8, $9, $10, $11, $12, $13,
 	$14, $15, $16, $17, $18, $19,
-	$20, $21, $22, $23, $24
+	$20, $21, $22, $23,
+	$24, $25, $26, $27, $28, $29
 )`
 	_, err := r.db.ExecContext(ctx, query,
 		item.ID,
@@ -126,6 +133,11 @@ INSERT INTO streamer_llm_decisions (
 		nullString(item.TransitionOutcome),
 		nullString(item.TransitionToStep),
 		item.TransitionTerminal,
+		nullString(item.PreviousStateJSON),
+		nullString(item.UpdatedStateJSON),
+		nullString(item.EvidenceDeltaJSON),
+		nullString(item.ConflictsJSON),
+		nullString(item.FinalOutcome),
 		parseRFC3339Time(item.CreatedAt),
 	)
 	if err != nil {
@@ -145,7 +157,8 @@ func (r *PostgresDecisionRepository) ListLLMDecisions(ctx context.Context, strea
 SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
        prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
        chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
-       latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+       latency_ms, transition_outcome, transition_to_step, transition_terminal,
+       previous_state_json, updated_state_json, evidence_delta_json, conflicts_json, final_outcome, created_at
 FROM streamer_llm_decisions
 WHERE streamer_id = $1
 ORDER BY created_at DESC, id DESC
@@ -161,7 +174,8 @@ func (r *PostgresDecisionRepository) ListAllLLMDecisions(ctx context.Context, st
 SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
        prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
        chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
-       latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+       latency_ms, transition_outcome, transition_to_step, transition_terminal,
+       previous_state_json, updated_state_json, evidence_delta_json, conflicts_json, final_outcome, created_at
 FROM streamer_llm_decisions
 WHERE streamer_id = $1
 ORDER BY created_at ASC, id ASC`
@@ -206,6 +220,11 @@ func scanDecision(row decisionScanner) (LLMDecision, error) {
 		rawResponse       sql.NullString
 		transitionOutcome sql.NullString
 		transitionToStep  sql.NullString
+		previousState     sql.NullString
+		updatedState      sql.NullString
+		evidenceDelta     sql.NullString
+		conflicts         sql.NullString
+		finalOutcome      sql.NullString
 		createdAt         time.Time
 	)
 	if err := row.Scan(
@@ -232,6 +251,11 @@ func scanDecision(row decisionScanner) (LLMDecision, error) {
 		&transitionOutcome,
 		&transitionToStep,
 		&item.TransitionTerminal,
+		&previousState,
+		&updatedState,
+		&evidenceDelta,
+		&conflicts,
+		&finalOutcome,
 		&createdAt,
 	); err != nil {
 		return LLMDecision{}, fmt.Errorf("scan streamer llm decision: %w", err)
@@ -246,6 +270,11 @@ func scanDecision(row decisionScanner) (LLMDecision, error) {
 	item.RawResponse = rawResponse.String
 	item.TransitionOutcome = transitionOutcome.String
 	item.TransitionToStep = transitionToStep.String
+	item.PreviousStateJSON = previousState.String
+	item.UpdatedStateJSON = updatedState.String
+	item.EvidenceDeltaJSON = evidenceDelta.String
+	item.ConflictsJSON = conflicts.String
+	item.FinalOutcome = finalOutcome.String
 	item.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
 	return item, nil
 }

--- a/internal/streamers/postgres_decisions_test.go
+++ b/internal/streamers/postgres_decisions_test.go
@@ -45,6 +45,11 @@ func TestPostgresDecisionRepositoryRecordLLMDecision(t *testing.T) {
 		TransitionOutcome:  "cs_detected",
 		TransitionToStep:   "match_start",
 		TransitionTerminal: false,
+		PreviousStateJSON:  `{"status":"discovering"}`,
+		UpdatedStateJSON:   `{"status":"in_progress"}`,
+		EvidenceDeltaJSON:  `["score updated"]`,
+		ConflictsJSON:      `["side not confirmed"]`,
+		FinalOutcome:       "unknown",
 		CreatedAt:          createdAt.Format(time.RFC3339Nano),
 	}
 
@@ -53,12 +58,14 @@ INSERT INTO streamer_llm_decisions (
 	id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
 	prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
 	chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
-	latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+	latency_ms, transition_outcome, transition_to_step, transition_terminal,
+	previous_state_json, updated_state_json, evidence_delta_json, conflicts_json, final_outcome, created_at
 ) VALUES (
 	$1, $2, $3, $4, $5, $6, $7,
 	$8, $9, $10, $11, $12, $13,
 	$14, $15, $16, $17, $18, $19,
-	$20, $21, $22, $23, $24
+	$20, $21, $22, $23,
+	$24, $25, $26, $27, $28, $29
 )`)).
 		WithArgs(
 			item.ID,
@@ -84,6 +91,11 @@ INSERT INTO streamer_llm_decisions (
 			nullDriverString(item.TransitionOutcome),
 			nullDriverString(item.TransitionToStep),
 			item.TransitionTerminal,
+			nullDriverString(item.PreviousStateJSON),
+			nullDriverString(item.UpdatedStateJSON),
+			nullDriverString(item.EvidenceDeltaJSON),
+			nullDriverString(item.ConflictsJSON),
+			nullDriverString(item.FinalOutcome),
 			createdAt,
 		).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -111,19 +123,21 @@ func TestPostgresDecisionRepositoryListLLMDecisions(t *testing.T) {
 		"id", "run_id", "streamer_id", "stage", "label", "confidence", "chunk_captured_at",
 		"prompt_version_id", "prompt_text", "model", "temperature", "max_tokens", "timeout_ms",
 		"chunk_ref", "request_ref", "response_ref", "raw_response", "tokens_in", "tokens_out",
-		"latency_ms", "transition_outcome", "transition_to_step", "transition_terminal", "created_at",
+		"latency_ms", "transition_outcome", "transition_to_step", "transition_terminal",
+		"previous_state_json", "updated_state_json", "evidence_delta_json", "conflicts_json", "final_outcome", "created_at",
 	}).AddRow(
 		"llm_1", "run_1", "str_1", "detector", "cs_detected", 0.91, capturedAt,
 		"prompt_1", "detect the game", "gemini-2.0-flash", 0.2, 256, 2000,
 		"streamlink://chunk-1", "req-1", "resp-1", "raw", 123, 45,
-		890, "cs_detected", "match_start", false, createdAt,
+		890, "cs_detected", "match_start", false, `{"status":"discovering"}`, `{"status":"in_progress"}`, `["score updated"]`, `["side not confirmed"]`, "unknown", createdAt,
 	)
 
 	mock.ExpectQuery(regexp.QuoteMeta(`
 SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
        prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
        chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
-       latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+       latency_ms, transition_outcome, transition_to_step, transition_terminal,
+       previous_state_json, updated_state_json, evidence_delta_json, conflicts_json, final_outcome, created_at
 FROM streamer_llm_decisions
 WHERE streamer_id = $1
 ORDER BY created_at DESC, id DESC
@@ -141,7 +155,7 @@ LIMIT $2`)).
 	if items[0].ChunkCapturedAt != capturedAt.Format(time.RFC3339Nano) || items[0].CreatedAt != createdAt.Format(time.RFC3339Nano) {
 		t.Fatalf("unexpected timestamps: %+v", items[0])
 	}
-	if items[0].TransitionToStep != "match_start" || items[0].RequestRef != "req-1" {
+	if items[0].TransitionToStep != "match_start" || items[0].RequestRef != "req-1" || items[0].UpdatedStateJSON != `{"status":"in_progress"}` || items[0].FinalOutcome != "unknown" {
 		t.Fatalf("unexpected decision payload: %+v", items[0])
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -176,13 +190,15 @@ func TestPostgresDecisionRepositoryEnsuresSchemaOnce(t *testing.T) {
 		"id", "run_id", "streamer_id", "stage", "label", "confidence", "chunk_captured_at",
 		"prompt_version_id", "prompt_text", "model", "temperature", "max_tokens", "timeout_ms",
 		"chunk_ref", "request_ref", "response_ref", "raw_response", "tokens_in", "tokens_out",
-		"latency_ms", "transition_outcome", "transition_to_step", "transition_terminal", "created_at",
+		"latency_ms", "transition_outcome", "transition_to_step", "transition_terminal",
+		"previous_state_json", "updated_state_json", "evidence_delta_json", "conflicts_json", "final_outcome", "created_at",
 	})
 	mock.ExpectQuery(regexp.QuoteMeta(`
 SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
        prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
        chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
-       latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+       latency_ms, transition_outcome, transition_to_step, transition_terminal,
+       previous_state_json, updated_state_json, evidence_delta_json, conflicts_json, final_outcome, created_at
 FROM streamer_llm_decisions
 WHERE streamer_id = $1
 ORDER BY created_at DESC, id DESC
@@ -193,7 +209,8 @@ LIMIT $2`)).
 SELECT id, run_id, streamer_id, stage, label, confidence, chunk_captured_at,
        prompt_version_id, prompt_text, model, temperature, max_tokens, timeout_ms,
        chunk_ref, request_ref, response_ref, raw_response, tokens_in, tokens_out,
-       latency_ms, transition_outcome, transition_to_step, transition_terminal, created_at
+       latency_ms, transition_outcome, transition_to_step, transition_terminal,
+       previous_state_json, updated_state_json, evidence_delta_json, conflicts_json, final_outcome, created_at
 FROM streamer_llm_decisions
 WHERE streamer_id = $1
 ORDER BY created_at ASC, id ASC`)).

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -327,6 +327,11 @@ func (s *Service) RecordLLMDecision(ctx context.Context, req RecordDecisionReque
 		TransitionOutcome:  strings.TrimSpace(req.TransitionOutcome),
 		TransitionToStep:   strings.TrimSpace(req.TransitionToStep),
 		TransitionTerminal: req.TransitionTerminal,
+		PreviousStateJSON:  strings.TrimSpace(req.PreviousStateJSON),
+		UpdatedStateJSON:   strings.TrimSpace(req.UpdatedStateJSON),
+		EvidenceDeltaJSON:  strings.TrimSpace(req.EvidenceDeltaJSON),
+		ConflictsJSON:      strings.TrimSpace(req.ConflictsJSON),
+		FinalOutcome:       strings.TrimSpace(req.FinalOutcome),
 		CreatedAt:          s.nowFn().UTC().Format(time.RFC3339Nano),
 	}
 
@@ -353,6 +358,29 @@ func formatOptionalTime(value time.Time) string {
 		return ""
 	}
 	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func (s *Service) ListAllLLMDecisions(ctx context.Context, streamerID string) []LLMDecision {
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return []LLMDecision{}
+	}
+
+	s.mu.RLock()
+	repo := s.decisionRepo
+	s.mu.RUnlock()
+	if repo == nil {
+		return []LLMDecision{}
+	}
+
+	items, err := repo.ListAllLLMDecisions(ctx, key)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("failed to list all llm decisions", zap.String("streamerID", key), zap.Error(err))
+		}
+		return []LLMDecision{}
+	}
+	return items
 }
 
 func (s *Service) ListLLMDecisions(ctx context.Context, streamerID string, limit int) []LLMDecision {


### PR DESCRIPTION
### Motivation
- Extend the LLM-driven stage pipeline to support tracker-style stages that return updated state, evidence deltas, next-needed evidence, hard conflicts and a final outcome so stateful tracking can be persisted and reused across stages. 
- Ensure previous persisted tracker state is passed into subsequent classification calls so tracker prompts can update state rather than only returning a short label.

### Description
- Extend the Gemini parsing model by adding fields to `geminiStageResponse`: `updated_state`, `delta`, `next_needed_evidence`, `hard_conflicts`, and `final_outcome`, plus logic to infer `label`/`confidence` when only state/final outcome are returned, and to populate `NormalizedOutcome` from `final_outcome` or label; add helper `marshalRawMessage` to normalize `json.RawMessage` values.
- Make `buildGeminiInstruction` emit a different instruction when `PreviousState` is present, requiring JSON with `updated_state`, `delta`, `next_needed_evidence` and optional `hard_conflicts`/`final_outcome` for tracker updates.
- Propagate state through worker flow by adding `PreviousState` to `StageRequest`, new JSON fields to `StageClassification`, and persisting `PreviousStateJSON`, `UpdatedStateJSON`, `EvidenceDeltaJSON`, `ConflictsJSON`, and `FinalOutcome` on recorded decisions via `RecordDecisionRequest` and `LLMDecision`.
- Add `ListAllLLMDecisions` to `DecisionStore` and implement `resolvePreviousState` in `Worker` to locate the most recent `UpdatedStateJSON` for a streamer and pass it into `processStage` so the classifier receives prior state.
- Remove the legacy scenario-driven execution path from the worker main flow so only active prompts are processed (legacy scenario resolver calls are ignored), and add `firstNonEmpty` utility used to choose appropriate fields when recording decisions.
- Extend Postgres schema, queries and scanner to persist the new JSON/text columns and update service wiring by adding `ListAllLLMDecisions` to the service and storing the new fields in `RecordLLMDecision`.
- Update unit tests and fakes to account for the new fields and behavior, including tests that verify legacy scenario resolver is not used and that previous state is passed between runs.

### Testing
- Ran unit tests under the modified packages with `go test ./internal/...` including worker and postgres decision repository tests; all updated tests passed locally. 
- Exercised `TestWorkerProcessStreamerRunsAllOrderedStages`, `TestWorkerProcessStreamerIgnoresLegacyScenarioResolver`, and `TestWorkerProcessStreamerPassesPersistedPreviousStateToTrackerStages`, and they succeeded. 
- Exercised `TestPostgresDecisionRepositoryRecordLLMDecision`, `TestPostgresDecisionRepositoryListLLMDecisions`, and schema-related tests against `sqlmock`, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03518b6f4832c8772c3925bce7bf3)