### PR TITLE
Refine tracker-focused LLM worker flow

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -211,6 +211,9 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 	if parsed.Confidence < 0 || parsed.Confidence > 1 {
 		return StageClassification{}, ErrGeminiInvalidConfidence
 	}
+	if err := validateGeminiTrackerResponse(input.Stage, parsed); err != nil {
+		return StageClassification{}, err
+	}
 
 	label := strings.TrimSpace(parsed.Label)
 	if label == "" && len(parsed.UpdatedState) > 0 {
@@ -244,27 +247,42 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 func buildGeminiInstruction(input StageRequest) string {
 	base := `You analyze a livestream chunk for FunPot.
 Stage: %s
-Use this stage prompt as the source of truth:
+Streamer ID: %s
+Chunk captured at: %s
+Chunk reference: %s
+Use this admin-managed tracker prompt as the source of truth:
 %s`
-	if strings.TrimSpace(input.PreviousState) == "" {
+	previousState := strings.TrimSpace(input.PreviousState)
+	if previousState == "" {
+		previousState = defaultTrackerState()
+	}
+	if !isTrackerStage(input.Stage) {
 		return strings.TrimSpace(fmt.Sprintf(base+`
 Return ONLY valid JSON with keys: label, confidence, summary.
 - label: short snake_case decision for this stage.
 - confidence: number between 0 and 1.
-- summary: short rationale.`, input.Stage, strings.TrimSpace(input.Prompt.Template)))
+- summary: short rationale.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template)))
 	}
 	return strings.TrimSpace(fmt.Sprintf(base+`
 Previous persisted tracker state JSON:
 %s
-Return ONLY valid JSON. Update the tracker state using previous_state + new_chunk.
-Required keys:
-- updated_state: object
-- delta: array or object describing evidence changes
-- next_needed_evidence: array
-Optional keys:
-- hard_conflicts: array
-- final_outcome: win | loss | draw | unknown
-Do not return commentary outside JSON.`, input.Stage, strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.PreviousState)))
+Update the tracker using previous_state + new_chunk for this 10-second window.
+Return ONLY valid JSON with this exact shape:
+{
+  "label": "state_updated | finalized | unknown",
+  "confidence": 0.0,
+  "updated_state": {},
+  "delta": [],
+  "next_needed_evidence": [],
+  "hard_conflicts": [],
+  "final_outcome": "win | loss | draw | unknown"
+}
+Rules:
+- Treat one chat/session as one match.
+- Always update and return compact state JSON in updated_state.
+- Never emit narrative commentary outside JSON.
+- Keep final_outcome as unknown until direct evidence exists.
+- Store contradictions in hard_conflicts instead of overwriting prior facts.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), previousState))
 }
 
 func loadGeminiChunk(path string, maxBytes int64) ([]byte, string, error) {
@@ -370,4 +388,27 @@ func marshalRawMessage(value json.RawMessage) string {
 		return ""
 	}
 	return trimmed
+}
+
+func validateGeminiTrackerResponse(stage string, parsed geminiStageResponse) error {
+	if !isTrackerStage(stage) {
+		return nil
+	}
+	if len(parsed.UpdatedState) == 0 || strings.TrimSpace(string(parsed.UpdatedState)) == "null" {
+		return fmt.Errorf("gemini tracker response for %s must include updated_state", strings.TrimSpace(stage))
+	}
+	if len(parsed.Delta) == 0 || strings.TrimSpace(string(parsed.Delta)) == "null" {
+		return fmt.Errorf("gemini tracker response for %s must include delta", strings.TrimSpace(stage))
+	}
+	if len(parsed.NextNeededEvidence) == 0 || strings.TrimSpace(string(parsed.NextNeededEvidence)) == "null" {
+		return fmt.Errorf("gemini tracker response for %s must include next_needed_evidence", strings.TrimSpace(stage))
+	}
+	if strings.TrimSpace(parsed.FinalOutcome) != "" {
+		switch strings.TrimSpace(parsed.FinalOutcome) {
+		case "win", "loss", "draw", "unknown":
+		default:
+			return fmt.Errorf("gemini tracker response for %s has invalid final_outcome %q", strings.TrimSpace(stage), parsed.FinalOutcome)
+		}
+	}
+	return nil
 }

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/funpot/funpot-go-core/internal/prompts"
 )
@@ -162,5 +163,64 @@ func TestGeminiStageClassifierRejectsUnsupportedChunkMimeType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "video/mp4") {
 		t.Fatalf("expected conversion hint, got %v", err)
+	}
+}
+
+func TestBuildGeminiInstructionUsesTrackerContract(t *testing.T) {
+	instruction := buildGeminiInstruction(StageRequest{
+		StreamerID: "str-42",
+		Stage:      "match_update",
+		Chunk:      ChunkRef{Reference: "/tmp/chunk.mp4", CapturedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
+		Prompt:     prompts.PromptVersion{Template: "Update the CS2 tracker state"},
+	})
+	for _, fragment := range []string{
+		"Streamer ID: str-42",
+		"Chunk reference: /tmp/chunk.mp4",
+		"Previous persisted tracker state JSON:",
+		defaultTrackerState(),
+		"updated_state",
+		"next_needed_evidence",
+	} {
+		if !strings.Contains(instruction, fragment) {
+			t.Fatalf("expected instruction to contain %q, got %s", fragment, instruction)
+		}
+	}
+}
+
+func TestGeminiStageClassifierRejectsTrackerResponseWithoutStatePayload(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.93}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	_, err = classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "match_update",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt:     prompts.PromptVersion{Stage: "match_update", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+	})
+	if err == nil || !strings.Contains(err.Error(), "updated_state") {
+		t.Fatalf("expected missing updated_state error, got %v", err)
 	}
 }

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -33,6 +33,12 @@ type StageRequest struct {
 	PreviousState string
 }
 
+const (
+	trackerStageDiscovery = "match_discovery"
+	trackerStageUpdate    = "match_update"
+	trackerStageFinalize  = "match_finalize"
+)
+
 type StageClassification struct {
 	Label             string
 	Confidence        float64
@@ -217,7 +223,7 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 		logger = zap.NewNop()
 	}
 
-	activePrompts := w.prompts.ListActive(ctx)
+	activePrompts := filterTrackerPrompts(w.prompts.ListActive(ctx))
 	if len(activePrompts) == 0 {
 		logger.Warn("no active prompts found for streamer processing", zap.String("streamerID", streamerID))
 		return streamers.LLMDecision{}, prompts.ErrNotFound
@@ -236,6 +242,35 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 		lastDecision = decision
 	}
 	return lastDecision, nil
+}
+
+func filterTrackerPrompts(items []prompts.PromptVersion) []prompts.PromptVersion {
+	if len(items) == 0 {
+		return nil
+	}
+	trackerOnly := make([]prompts.PromptVersion, 0, len(items))
+	for _, item := range items {
+		if isTrackerStage(item.Stage) {
+			trackerOnly = append(trackerOnly, item)
+		}
+	}
+	if len(trackerOnly) > 0 {
+		return trackerOnly
+	}
+	return items
+}
+
+func isTrackerStage(stage string) bool {
+	switch strings.TrimSpace(strings.ToLower(stage)) {
+	case trackerStageDiscovery, trackerStageUpdate, trackerStageFinalize:
+		return true
+	default:
+		return false
+	}
+}
+
+func defaultTrackerState() string {
+	return `{"session_type":"single_match","status":"discovering","player_outcome":{"value":"unknown","confidence":0},"evidence_log":[],"uncertainties":[],"hard_conflicts":[]}`
 }
 
 func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (ChunkRef, error) {
@@ -319,7 +354,7 @@ func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.Pr
 
 func (w *Worker) resolvePreviousState(ctx context.Context, streamerID string) string {
 	if w == nil || w.decisions == nil {
-		return ""
+		return defaultTrackerState()
 	}
 	items := w.decisions.ListAllLLMDecisions(ctx, streamerID)
 	for i := len(items) - 1; i >= 0; i-- {
@@ -327,7 +362,7 @@ func (w *Worker) resolvePreviousState(ctx context.Context, streamerID string) st
 			return state
 		}
 	}
-	return ""
+	return defaultTrackerState()
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -135,6 +135,46 @@ func (s *countingRunStore) CreateRun(_ context.Context, streamerID string) (stri
 	return streamerID + "-run", nil
 }
 
+func TestWorkerProcessStreamerPrefersTrackerPromptsOverLegacyStages(t *testing.T) {
+	decisions := &fakeDecisionStore{}
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		fakeClassifier{results: map[string]StageClassification{
+			"detector":       {Label: "cs_detected", Confidence: 0.99},
+			"match_update":   {Label: "state_updated", Confidence: 0.97, UpdatedStateJSON: `{"match_status":"in_progress"}`, EvidenceDeltaJSON: `["opened session"]`, NextEvidenceJSON: `["final scoreboard"]`},
+			"match_finalize": {Label: "finalized", Confidence: 0.95, UpdatedStateJSON: `{"match_status":"finished"}`, EvidenceDeltaJSON: `["final scoreboard seen"]`, NextEvidenceJSON: `[]`, FinalOutcome: "win"},
+		}},
+		fakePromptResolver{prompts: []prompts.PromptVersion{
+			{ID: "legacy-1", Stage: "detector", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "legacy detector", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000},
+			{ID: "tracker-1", Stage: "match_update", Position: 2, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000},
+			{ID: "tracker-2", Stage: "match_finalize", Position: 3, IsActive: true, MinConfidence: 0.5, Template: "finalize tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000},
+		}},
+		nil,
+		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
+	)
+
+	got, err := worker.ProcessStreamer(context.Background(), "str-1")
+	if err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got.Stage != "match_finalize" || got.FinalOutcome != "" {
+		t.Fatalf("final decision = %#v", got)
+	}
+	if len(decisions.items) != 2 {
+		t.Fatalf("recorded %d decisions, want 2", len(decisions.items))
+	}
+	if decisions.items[0].Stage != "match_update" || decisions.items[1].Stage != "match_finalize" {
+		t.Fatalf("unexpected stage order: %#v", decisions.items)
+	}
+}
+
+func TestWorkerResolvePreviousStateDefaultsToTrackerBootstrap(t *testing.T) {
+	worker := NewWorker(fakeCapture{}, fakeClassifier{}, fakePromptResolver{}, nil, &InMemoryRunStore{}, nil, NewInMemoryLocker(), WorkerConfig{})
+	if got := worker.resolvePreviousState(context.Background(), "str-1"); got != defaultTrackerState() {
+		t.Fatalf("resolvePreviousState() = %q", got)
+	}
+}
+
 func TestWorkerProcessStreamerRunsAllOrderedStages(t *testing.T) {
 	decisions := &fakeDecisionStore{}
 	worker := NewWorker(


### PR DESCRIPTION
### Motivation
- Move the media worker toward the M2.1 state-tracker model so worker cycles send `previous_state + new_chunk` to the LLM and treat one chat as one match. 
- Prefer tracker-style prompts (`match_discovery`, `match_update`, `match_finalize`) over legacy prompt-chain stages when tracker prompts are active. 
- Enforce a strict JSON contract for tracker responses so malformed or partial outputs are rejected rather than persisted.

### Description
- Prefilter active prompts to prefer tracker stages by adding `filterTrackerPrompts`, `isTrackerStage`, and tracker constants and using them in `processExecutionPlan` in `internal/media/worker.go`.
- Bootstrap runs with a compact default state via `defaultTrackerState()` and return it from `resolvePreviousState` when no prior snapshot exists so every LLM call includes `previous_state`.
- Enrich Gemini instruction text with streamer/chunk metadata and require the tracker JSON shape for tracker stages by updating `buildGeminiInstruction` in `internal/media/gemini.go`.
- Add `validateGeminiTrackerResponse` to reject tracker responses that omit `updated_state`, `delta`, or `next_needed_evidence` and to validate `final_outcome` values.
- Add unit tests exercising tracker preference, previous-state bootstrap, instruction contents, and tracker-response validation in `internal/media/worker_test.go` and `internal/media/gemini_test.go`.
- Files changed: `internal/media/worker.go`, `internal/media/gemini.go`, `internal/media/worker_test.go`, `internal/media/gemini_test.go`.

### Testing
- Ran targeted media tests with `go test ./internal/media -run 'TestWorkerProcessStreamerPrefersTrackerPromptsOverLegacyStages|TestWorkerResolvePreviousStateDefaultsToTrackerBootstrap|TestBuildGeminiInstructionUsesTrackerContract|TestGeminiStageClassifierRejectsTrackerResponseWithoutStatePayload' -count=1` and they passed.
- Ran broader suites `go test ./internal/streamers ./internal/prompts ./internal/app` and they passed.
- Checklist alignment with M2.1 priority: worker payload includes `previous_state` and prompt/runtime params for each chunk `[x]`, worker selection is refactored to prefer tracker prompts `[x]`, remaining items such as DB persistence for tracker configs and realtime publishing remain open `[ ]`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c039ffa36c832cb97c2905a13d08b7)