### PR TITLE
Add tracker config CRUD and include active tracker config in worker LLM payload

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -91,6 +91,36 @@ func scenarioRequestToCreateRequest(req scenarioCreateRequest, actorID string) p
 	}
 }
 
+func stateSchemaRequestToCreateRequest(req stateSchemaCreateRequest, actorID string) prompts.StateSchemaCreateRequest {
+	fields := make([]prompts.StateFieldDefinition, 0, len(req.Fields))
+	for _, field := range req.Fields {
+		fields = append(fields, prompts.StateFieldDefinition{
+			Key:                field.Key,
+			Label:              field.Label,
+			Description:        field.Description,
+			Type:               field.Type,
+			EnumValues:         field.EnumValues,
+			ConfidenceRequired: field.ConfidenceRequired,
+			EvidenceBearing:    field.EvidenceBearing,
+			Inferred:           field.Inferred,
+			FinalOnly:          field.FinalOnly,
+		})
+	}
+	return prompts.StateSchemaCreateRequest{GameSlug: req.GameSlug, Name: req.Name, Description: req.Description, Fields: fields, ActorID: actorID}
+}
+
+func ruleSetRequestToCreateRequest(req ruleSetCreateRequest, actorID string) prompts.RuleSetCreateRequest {
+	ruleItems := make([]prompts.RuleItem, 0, len(req.RuleItems))
+	for idx, item := range req.RuleItems {
+		ruleItems = append(ruleItems, prompts.RuleItem{ID: "rule-item-" + strconv.Itoa(idx+1), FieldKey: item.FieldKey, Operation: item.Operation, EvidenceKinds: item.EvidenceKinds, ConfidenceMode: item.ConfidenceMode, FinalOnly: item.FinalOnly})
+	}
+	finalizationRules := make([]prompts.RuleCondition, 0, len(req.FinalizationRules))
+	for idx, item := range req.FinalizationRules {
+		finalizationRules = append(finalizationRules, prompts.RuleCondition{ID: "rule-condition-" + strconv.Itoa(idx+1), Priority: item.Priority, Condition: item.Condition, Action: item.Action, TargetField: item.TargetField})
+	}
+	return prompts.RuleSetCreateRequest{GameSlug: req.GameSlug, Name: req.Name, Description: req.Description, RuleItems: ruleItems, FinalizationRules: finalizationRules, ActorID: actorID}
+}
+
 type configLimits struct {
 	VotePerMin int `json:"votePerMin"`
 }
@@ -173,6 +203,48 @@ type llmDecisionRecordRequest struct {
 	TransitionOutcome  string  `json:"transitionOutcome"`
 	TransitionToStep   string  `json:"transitionToStep"`
 	TransitionTerminal bool    `json:"transitionTerminal"`
+}
+
+type stateFieldRequest struct {
+	Key                string   `json:"key"`
+	Label              string   `json:"label"`
+	Description        string   `json:"description"`
+	Type               string   `json:"type"`
+	EnumValues         []string `json:"enumValues"`
+	ConfidenceRequired bool     `json:"confidenceRequired"`
+	EvidenceBearing    bool     `json:"evidenceBearing"`
+	Inferred           bool     `json:"inferred"`
+	FinalOnly          bool     `json:"finalOnly"`
+}
+
+type stateSchemaCreateRequest struct {
+	GameSlug    string              `json:"gameSlug"`
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	Fields      []stateFieldRequest `json:"fields"`
+}
+
+type ruleItemRequest struct {
+	FieldKey       string   `json:"fieldKey"`
+	Operation      string   `json:"operation"`
+	EvidenceKinds  []string `json:"evidenceKinds"`
+	ConfidenceMode string   `json:"confidenceMode"`
+	FinalOnly      bool     `json:"finalOnly"`
+}
+
+type ruleConditionRequest struct {
+	Priority    int    `json:"priority"`
+	Condition   string `json:"condition"`
+	Action      string `json:"action"`
+	TargetField string `json:"targetField"`
+}
+
+type ruleSetCreateRequest struct {
+	GameSlug          string                 `json:"gameSlug"`
+	Name              string                 `json:"name"`
+	Description       string                 `json:"description"`
+	RuleItems         []ruleItemRequest      `json:"ruleItems"`
+	FinalizationRules []ruleConditionRequest `json:"finalizationRules"`
 }
 
 type meResponse struct {
@@ -686,6 +758,242 @@ func NewHandler(
 		}
 
 		if promptsService != nil {
+			mux.Handle("/api/admin/llm/state-schemas", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, promptsService.ListStateSchemas(r.Context()))
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req stateSchemaCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					created, err := promptsService.CreateStateSchema(r.Context(), stateSchemaRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusCreated, created)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/llm/state-schemas/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/admin/llm/state-schemas/"), "/")
+				if path == "" {
+					writeError(w, http.StatusBadRequest, "state schema id is required")
+					return
+				}
+				if strings.HasSuffix(path, "/activate") {
+					id := strings.Trim(strings.TrimSuffix(path, "/activate"), "/")
+					if r.Method != http.MethodPost {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					item, err := promptsService.ActivateStateSchema(r.Context(), id, claims.Subject)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrStateSchemaNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					item, err := promptsService.GetStateSchema(r.Context(), path)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrStateSchemaNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req stateSchemaCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					item, err := promptsService.UpdateStateSchema(r.Context(), path, stateSchemaRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrStateSchemaNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodDelete:
+					if err := promptsService.DeleteStateSchema(r.Context(), path); err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrStateSchemaNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/llm/rule-sets", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, promptsService.ListRuleSets(r.Context()))
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req ruleSetCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					created, err := promptsService.CreateRuleSet(r.Context(), ruleSetRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusCreated, created)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/llm/rule-sets/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/admin/llm/rule-sets/"), "/")
+				if path == "" {
+					writeError(w, http.StatusBadRequest, "rule set id is required")
+					return
+				}
+				if strings.HasSuffix(path, "/activate") {
+					id := strings.Trim(strings.TrimSuffix(path, "/activate"), "/")
+					if r.Method != http.MethodPost {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					item, err := promptsService.ActivateRuleSet(r.Context(), id, claims.Subject)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrRuleSetNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					item, err := promptsService.GetRuleSet(r.Context(), path)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrRuleSetNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req ruleSetCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					item, err := promptsService.UpdateRuleSet(r.Context(), path, ruleSetRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrRuleSetNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodDelete:
+					if err := promptsService.DeleteRuleSet(r.Context(), path); err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrRuleSetNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
 			mux.Handle("/api/admin/prompts", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				claims, ok := auth.ClaimsFromContext(r.Context())
 				if !ok {

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/funpot/funpot-go-core/internal/admin"
+	"github.com/funpot/funpot-go-core/internal/prompts"
+	"github.com/funpot/funpot-go-core/internal/streamers"
+)
+
+func TestAdminLLMStateSchemaAndRuleSetRoutes(t *testing.T) {
+	promptsService := prompts.NewService()
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamers.NewService(),
+		nil,
+		promptsService,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+	adminToken := buildToken(t, "admin-1")
+
+	stateSchemaBody, _ := json.Marshal(map[string]any{
+		"gameSlug": "cs2",
+		"name":     "CS2 tracker",
+		"fields":   []map[string]any{{"key": "score.ct", "type": "number"}},
+	})
+	stateReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/state-schemas", bytes.NewReader(stateSchemaBody))
+	stateReq.Header.Set("Authorization", "Bearer "+adminToken)
+	stateRes := httptest.NewRecorder()
+	handler.ServeHTTP(stateRes, stateReq)
+	if stateRes.Code != http.StatusCreated {
+		t.Fatalf("state schema create status = %d body=%s", stateRes.Code, stateRes.Body.String())
+	}
+
+	ruleBody, _ := json.Marshal(map[string]any{
+		"gameSlug":          "cs2",
+		"name":              "CS2 rules",
+		"ruleItems":         []map[string]any{{"fieldKey": "score.ct", "operation": "set", "confidenceMode": "strict"}},
+		"finalizationRules": []map[string]any{{"priority": 1, "condition": "final_banner_seen", "action": "finalize_win"}},
+	})
+	ruleReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/rule-sets", bytes.NewReader(ruleBody))
+	ruleReq.Header.Set("Authorization", "Bearer "+adminToken)
+	ruleRes := httptest.NewRecorder()
+	handler.ServeHTTP(ruleRes, ruleReq)
+	if ruleRes.Code != http.StatusCreated {
+		t.Fatalf("rule set create status = %d body=%s", ruleRes.Code, ruleRes.Body.String())
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/state-schemas", nil)
+	listReq.Header.Set("Authorization", "Bearer "+adminToken)
+	listRes := httptest.NewRecorder()
+	handler.ServeHTTP(listRes, listReq)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("state schema list status = %d", listRes.Code)
+	}
+
+	ruleListReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/rule-sets", nil)
+	ruleListReq.Header.Set("Authorization", "Bearer "+adminToken)
+	ruleListRes := httptest.NewRecorder()
+	handler.ServeHTTP(ruleListRes, ruleListReq)
+	if ruleListRes.Code != http.StatusOK {
+		t.Fatalf("rule set list status = %d", ruleListRes.Code)
+	}
+}

--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -251,6 +251,10 @@ Streamer ID: %s
 Chunk captured at: %s
 Chunk reference: %s
 Use this admin-managed tracker prompt as the source of truth:
+%s
+Active state schema:
+%s
+Active rule set:
 %s`
 	previousState := strings.TrimSpace(input.PreviousState)
 	if previousState == "" {
@@ -261,7 +265,7 @@ Use this admin-managed tracker prompt as the source of truth:
 Return ONLY valid JSON with keys: label, confidence, summary.
 - label: short snake_case decision for this stage.
 - confidence: number between 0 and 1.
-- summary: short rationale.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template)))
+- summary: short rationale.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.RuleSet)))
 	}
 	return strings.TrimSpace(fmt.Sprintf(base+`
 Previous persisted tracker state JSON:
@@ -282,7 +286,7 @@ Rules:
 - Always update and return compact state JSON in updated_state.
 - Never emit narrative commentary outside JSON.
 - Keep final_outcome as unknown until direct evidence exists.
-- Store contradictions in hard_conflicts instead of overwriting prior facts.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), previousState))
+- Store contradictions in hard_conflicts instead of overwriting prior facts.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.RuleSet), previousState))
 }
 
 func loadGeminiChunk(path string, maxBytes int64) ([]byte, string, error) {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -168,10 +168,12 @@ func TestGeminiStageClassifierRejectsUnsupportedChunkMimeType(t *testing.T) {
 
 func TestBuildGeminiInstructionUsesTrackerContract(t *testing.T) {
 	instruction := buildGeminiInstruction(StageRequest{
-		StreamerID: "str-42",
-		Stage:      "match_update",
-		Chunk:      ChunkRef{Reference: "/tmp/chunk.mp4", CapturedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
-		Prompt:     prompts.PromptVersion{Template: "Update the CS2 tracker state"},
+		StreamerID:  "str-42",
+		Stage:       "match_update",
+		Chunk:       ChunkRef{Reference: "/tmp/chunk.mp4", CapturedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
+		Prompt:      prompts.PromptVersion{Template: "Update the CS2 tracker state"},
+		StateSchema: `state_schema[CS2 v1]: [{"key":"score.ct"}]`,
+		RuleSet:     `rule_set[CS2 rules v1]: rule_items=[{"fieldKey":"score.ct"}]`,
 	})
 	for _, fragment := range []string{
 		"Streamer ID: str-42",
@@ -180,6 +182,10 @@ func TestBuildGeminiInstructionUsesTrackerContract(t *testing.T) {
 		defaultTrackerState(),
 		"updated_state",
 		"next_needed_evidence",
+		"Active state schema:",
+		"state_schema[CS2 v1]",
+		"Active rule set:",
+		"rule_set[CS2 rules v1]",
 	} {
 		if !strings.Contains(instruction, fragment) {
 			t.Fatalf("expected instruction to contain %q, got %s", fragment, instruction)

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -2,6 +2,7 @@ package media
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -31,6 +32,8 @@ type StageRequest struct {
 	Chunk         ChunkRef
 	Prompt        prompts.PromptVersion
 	PreviousState string
+	StateSchema   string
+	RuleSet       string
 }
 
 const (
@@ -298,7 +301,8 @@ func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (Chunk
 
 func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptVersion) (streamers.LLMDecision, error) {
 	previousState := w.resolvePreviousState(ctx, streamerID)
-	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt, PreviousState: previousState}, activePrompt)
+	stateSchema, ruleSet := w.resolveTrackerConfig(ctx)
+	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt, PreviousState: previousState, StateSchema: stateSchema, RuleSet: ruleSet}, activePrompt)
 	if err != nil {
 		w.metrics.recordFailure(ctx, streamerID, activePrompt.Stage)
 		return streamers.LLMDecision{}, err
@@ -439,4 +443,40 @@ func sleepContext(ctx context.Context, delay time.Duration) error {
 	case <-timer.C:
 		return nil
 	}
+}
+
+type activeStateSchemaResolver interface {
+	GetActiveStateSchema(ctx context.Context, gameSlug string) (prompts.StateSchemaVersion, error)
+}
+
+type activeRuleSetResolver interface {
+	GetActiveRuleSet(ctx context.Context, gameSlug string) (prompts.RuleSetVersion, error)
+}
+
+func (w *Worker) resolveTrackerConfig(ctx context.Context) (string, string) {
+	const gameSlug = "cs2"
+	var stateSchema string
+	if resolver, ok := w.prompts.(activeStateSchemaResolver); ok {
+		if item, err := resolver.GetActiveStateSchema(ctx, gameSlug); err == nil {
+			stateSchema = fmt.Sprintf("state_schema[%s v%d]: %s", item.Name, item.Version, compactJSON(item.Fields))
+		}
+	}
+	var ruleSet string
+	if resolver, ok := w.prompts.(activeRuleSetResolver); ok {
+		if item, err := resolver.GetActiveRuleSet(ctx, gameSlug); err == nil {
+			ruleSet = fmt.Sprintf("rule_set[%s v%d]: rule_items=%s finalization_rules=%s", item.Name, item.Version, compactJSON(item.RuleItems), compactJSON(item.FinalizationRules))
+		}
+	}
+	return stateSchema, ruleSet
+}
+
+func compactJSON(value any) string {
+	if value == nil {
+		return ""
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }

--- a/internal/prompts/service.go
+++ b/internal/prompts/service.go
@@ -11,13 +11,19 @@ import (
 
 // Service manages versioned LLM prompt templates for each stage.
 type Service struct {
-	mu       sync.RWMutex
-	counter  int
-	versions map[string][]PromptVersion
+	mu           sync.RWMutex
+	counter      int
+	versions     map[string][]PromptVersion
+	stateSchemas map[string][]StateSchemaVersion
+	ruleSets     map[string][]RuleSetVersion
 }
 
 func NewService() *Service {
-	return &Service{versions: map[string][]PromptVersion{}}
+	return &Service{
+		versions:     map[string][]PromptVersion{},
+		stateSchemas: map[string][]StateSchemaVersion{},
+		ruleSets:     map[string][]RuleSetVersion{},
+	}
 }
 
 func (s *Service) List(_ context.Context) []PromptVersion {

--- a/internal/prompts/tracker_config.go
+++ b/internal/prompts/tracker_config.go
@@ -1,0 +1,456 @@
+package prompts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	ErrInvalidStateSchemaName    = errors.New("state schema name must not be empty")
+	ErrInvalidStateFieldKey      = errors.New("state field key must not be empty")
+	ErrInvalidStateFieldType     = errors.New("state field type must not be empty")
+	ErrStateSchemaNotFound       = errors.New("state schema not found")
+	ErrInvalidRuleSetName        = errors.New("rule set name must not be empty")
+	ErrInvalidRuleFieldKey       = errors.New("rule item fieldKey must not be empty")
+	ErrInvalidRuleOperation      = errors.New("rule item operation must not be empty")
+	ErrInvalidRuleConfidenceMode = errors.New("rule item confidenceMode must not be empty")
+	ErrInvalidRuleCondition      = errors.New("rule condition must not be empty")
+	ErrInvalidRuleAction         = errors.New("rule action must not be empty")
+	ErrRuleSetNotFound           = errors.New("rule set not found")
+)
+
+type StateFieldDefinition struct {
+	Key                string   `json:"key"`
+	Label              string   `json:"label"`
+	Description        string   `json:"description,omitempty"`
+	Type               string   `json:"type"`
+	EnumValues         []string `json:"enumValues,omitempty"`
+	ConfidenceRequired bool     `json:"confidenceRequired"`
+	EvidenceBearing    bool     `json:"evidenceBearing"`
+	Inferred           bool     `json:"inferred"`
+	FinalOnly          bool     `json:"finalOnly"`
+}
+
+type StateSchemaCreateRequest struct {
+	GameSlug    string
+	Name        string
+	Description string
+	Fields      []StateFieldDefinition
+	ActorID     string
+}
+
+type StateSchemaVersion struct {
+	ID          string                 `json:"id"`
+	GameSlug    string                 `json:"gameSlug"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	Version     int                    `json:"version"`
+	Fields      []StateFieldDefinition `json:"fields"`
+	IsActive    bool                   `json:"isActive"`
+	CreatedBy   string                 `json:"createdBy"`
+	ActivatedBy string                 `json:"activatedBy,omitempty"`
+	CreatedAt   time.Time              `json:"createdAt"`
+	ActivatedAt time.Time              `json:"activatedAt,omitempty"`
+}
+
+type RuleItem struct {
+	ID             string   `json:"id"`
+	FieldKey       string   `json:"fieldKey"`
+	Operation      string   `json:"operation"`
+	EvidenceKinds  []string `json:"evidenceKinds,omitempty"`
+	ConfidenceMode string   `json:"confidenceMode"`
+	FinalOnly      bool     `json:"finalOnly"`
+}
+
+type RuleCondition struct {
+	ID          string `json:"id"`
+	Priority    int    `json:"priority"`
+	Condition   string `json:"condition"`
+	Action      string `json:"action"`
+	TargetField string `json:"targetField,omitempty"`
+}
+
+type RuleSetCreateRequest struct {
+	GameSlug          string
+	Name              string
+	Description       string
+	RuleItems         []RuleItem
+	FinalizationRules []RuleCondition
+	ActorID           string
+}
+
+type RuleSetVersion struct {
+	ID                string          `json:"id"`
+	GameSlug          string          `json:"gameSlug"`
+	Name              string          `json:"name"`
+	Description       string          `json:"description,omitempty"`
+	Version           int             `json:"version"`
+	RuleItems         []RuleItem      `json:"ruleItems"`
+	FinalizationRules []RuleCondition `json:"finalizationRules"`
+	IsActive          bool            `json:"isActive"`
+	CreatedBy         string          `json:"createdBy"`
+	ActivatedBy       string          `json:"activatedBy,omitempty"`
+	CreatedAt         time.Time       `json:"createdAt"`
+	ActivatedAt       time.Time       `json:"activatedAt,omitempty"`
+}
+
+func ValidateStateSchemaCreateRequest(req StateSchemaCreateRequest) error {
+	if strings.TrimSpace(req.GameSlug) == "" {
+		return ErrInvalidGameSlug
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return ErrInvalidStateSchemaName
+	}
+	if len(req.Fields) == 0 {
+		return ErrInvalidStateFieldKey
+	}
+	seen := map[string]struct{}{}
+	for _, field := range req.Fields {
+		key := strings.TrimSpace(field.Key)
+		if key == "" {
+			return ErrInvalidStateFieldKey
+		}
+		if strings.TrimSpace(field.Type) == "" {
+			return ErrInvalidStateFieldType
+		}
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("duplicate state field key: %s", key)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+func ValidateRuleSetCreateRequest(req RuleSetCreateRequest) error {
+	if strings.TrimSpace(req.GameSlug) == "" {
+		return ErrInvalidGameSlug
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return ErrInvalidRuleSetName
+	}
+	if len(req.RuleItems) == 0 {
+		return ErrInvalidRuleFieldKey
+	}
+	if len(req.FinalizationRules) == 0 {
+		return ErrInvalidRuleCondition
+	}
+	for _, item := range req.RuleItems {
+		if strings.TrimSpace(item.FieldKey) == "" {
+			return ErrInvalidRuleFieldKey
+		}
+		if strings.TrimSpace(item.Operation) == "" {
+			return ErrInvalidRuleOperation
+		}
+		if strings.TrimSpace(item.ConfidenceMode) == "" {
+			return ErrInvalidRuleConfidenceMode
+		}
+	}
+	for _, item := range req.FinalizationRules {
+		if strings.TrimSpace(item.Condition) == "" {
+			return ErrInvalidRuleCondition
+		}
+		if strings.TrimSpace(item.Action) == "" {
+			return ErrInvalidRuleAction
+		}
+	}
+	return nil
+}
+
+func (s *Service) initTrackerConfigMaps() {
+	if s.stateSchemas == nil {
+		s.stateSchemas = map[string][]StateSchemaVersion{}
+	}
+	if s.ruleSets == nil {
+		s.ruleSets = map[string][]RuleSetVersion{}
+	}
+}
+
+func (s *Service) ListStateSchemas(_ context.Context) []StateSchemaVersion {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]StateSchemaVersion, 0)
+	for _, versions := range s.stateSchemas {
+		items = append(items, versions...)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].GameSlug == items[j].GameSlug {
+			return items[i].Version > items[j].Version
+		}
+		return items[i].GameSlug < items[j].GameSlug
+	})
+	return items
+}
+
+func (s *Service) CreateStateSchema(_ context.Context, req StateSchemaCreateRequest) (StateSchemaVersion, error) {
+	if err := ValidateStateSchemaCreateRequest(req); err != nil {
+		return StateSchemaVersion{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initTrackerConfigMaps()
+	gameSlug := strings.TrimSpace(req.GameSlug)
+	now := time.Now().UTC()
+	s.counter++
+	item := StateSchemaVersion{ID: fmt.Sprintf("state-schema-%d", s.counter), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: len(s.stateSchemas[gameSlug]) + 1, Fields: append([]StateFieldDefinition(nil), req.Fields...), CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	if len(s.stateSchemas[gameSlug]) == 0 {
+		item.IsActive = true
+		item.ActivatedBy = strings.TrimSpace(req.ActorID)
+		item.ActivatedAt = now
+	}
+	s.stateSchemas[gameSlug] = append(s.stateSchemas[gameSlug], item)
+	return item, nil
+}
+
+func (s *Service) GetStateSchema(_ context.Context, id string) (StateSchemaVersion, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, versions := range s.stateSchemas {
+		for _, item := range versions {
+			if item.ID == strings.TrimSpace(id) {
+				return item, nil
+			}
+		}
+	}
+	return StateSchemaVersion{}, ErrStateSchemaNotFound
+}
+
+func (s *Service) UpdateStateSchema(_ context.Context, id string, req StateSchemaCreateRequest) (StateSchemaVersion, error) {
+	if err := ValidateStateSchemaCreateRequest(req); err != nil {
+		return StateSchemaVersion{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initTrackerConfigMaps()
+	lookup := strings.TrimSpace(id)
+	for gameSlug, versions := range s.stateSchemas {
+		for i, item := range versions {
+			if item.ID != lookup {
+				continue
+			}
+			updated := item
+			updated.GameSlug = strings.TrimSpace(req.GameSlug)
+			updated.Name = strings.TrimSpace(req.Name)
+			updated.Description = strings.TrimSpace(req.Description)
+			updated.Fields = append([]StateFieldDefinition(nil), req.Fields...)
+			if updated.GameSlug != gameSlug {
+				s.stateSchemas[gameSlug] = append(versions[:i], versions[i+1:]...)
+				s.stateSchemas[updated.GameSlug] = append(s.stateSchemas[updated.GameSlug], updated)
+			} else {
+				versions[i] = updated
+				s.stateSchemas[gameSlug] = versions
+			}
+			return updated, nil
+		}
+	}
+	return StateSchemaVersion{}, ErrStateSchemaNotFound
+}
+
+func (s *Service) DeleteStateSchema(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initTrackerConfigMaps()
+	lookup := strings.TrimSpace(id)
+	for gameSlug, versions := range s.stateSchemas {
+		for i, item := range versions {
+			if item.ID != lookup {
+				continue
+			}
+			s.stateSchemas[gameSlug] = append(versions[:i], versions[i+1:]...)
+			if item.IsActive && len(s.stateSchemas[gameSlug]) > 0 {
+				s.stateSchemas[gameSlug][0].IsActive = true
+			}
+			return nil
+		}
+	}
+	return ErrStateSchemaNotFound
+}
+
+func (s *Service) ActivateStateSchema(_ context.Context, id, actorID string) (StateSchemaVersion, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initTrackerConfigMaps()
+	lookup := strings.TrimSpace(id)
+	for gameSlug, versions := range s.stateSchemas {
+		active := -1
+		for i := range versions {
+			if versions[i].ID == lookup {
+				active = i
+				break
+			}
+		}
+		if active == -1 {
+			continue
+		}
+		now := time.Now().UTC()
+		for i := range versions {
+			versions[i].IsActive = i == active
+			if i == active {
+				versions[i].ActivatedAt = now
+				versions[i].ActivatedBy = strings.TrimSpace(actorID)
+			}
+		}
+		s.stateSchemas[gameSlug] = versions
+		return versions[active], nil
+	}
+	return StateSchemaVersion{}, ErrStateSchemaNotFound
+}
+
+func (s *Service) GetActiveStateSchema(_ context.Context, gameSlug string) (StateSchemaVersion, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, item := range s.stateSchemas[strings.TrimSpace(gameSlug)] {
+		if item.IsActive {
+			return item, nil
+		}
+	}
+	return StateSchemaVersion{}, ErrStateSchemaNotFound
+}
+
+func (s *Service) ListRuleSets(_ context.Context) []RuleSetVersion {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]RuleSetVersion, 0)
+	for _, versions := range s.ruleSets {
+		items = append(items, versions...)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].GameSlug == items[j].GameSlug {
+			return items[i].Version > items[j].Version
+		}
+		return items[i].GameSlug < items[j].GameSlug
+	})
+	return items
+}
+
+func (s *Service) CreateRuleSet(_ context.Context, req RuleSetCreateRequest) (RuleSetVersion, error) {
+	if err := ValidateRuleSetCreateRequest(req); err != nil {
+		return RuleSetVersion{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initTrackerConfigMaps()
+	gameSlug := strings.TrimSpace(req.GameSlug)
+	now := time.Now().UTC()
+	s.counter++
+	item := RuleSetVersion{ID: fmt.Sprintf("rule-set-%d", s.counter), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: len(s.ruleSets[gameSlug]) + 1, RuleItems: append([]RuleItem(nil), req.RuleItems...), FinalizationRules: append([]RuleCondition(nil), req.FinalizationRules...), CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	if len(s.ruleSets[gameSlug]) == 0 {
+		item.IsActive = true
+		item.ActivatedAt = now
+		item.ActivatedBy = strings.TrimSpace(req.ActorID)
+	}
+	s.ruleSets[gameSlug] = append(s.ruleSets[gameSlug], item)
+	return item, nil
+}
+
+func (s *Service) GetRuleSet(_ context.Context, id string) (RuleSetVersion, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, versions := range s.ruleSets {
+		for _, item := range versions {
+			if item.ID == strings.TrimSpace(id) {
+				return item, nil
+			}
+		}
+	}
+	return RuleSetVersion{}, ErrRuleSetNotFound
+}
+
+func (s *Service) UpdateRuleSet(_ context.Context, id string, req RuleSetCreateRequest) (RuleSetVersion, error) {
+	if err := ValidateRuleSetCreateRequest(req); err != nil {
+		return RuleSetVersion{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initTrackerConfigMaps()
+	lookup := strings.TrimSpace(id)
+	for gameSlug, versions := range s.ruleSets {
+		for i, item := range versions {
+			if item.ID != lookup {
+				continue
+			}
+			updated := item
+			updated.GameSlug = strings.TrimSpace(req.GameSlug)
+			updated.Name = strings.TrimSpace(req.Name)
+			updated.Description = strings.TrimSpace(req.Description)
+			updated.RuleItems = append([]RuleItem(nil), req.RuleItems...)
+			updated.FinalizationRules = append([]RuleCondition(nil), req.FinalizationRules...)
+			if updated.GameSlug != gameSlug {
+				s.ruleSets[gameSlug] = append(versions[:i], versions[i+1:]...)
+				s.ruleSets[updated.GameSlug] = append(s.ruleSets[updated.GameSlug], updated)
+			} else {
+				versions[i] = updated
+				s.ruleSets[gameSlug] = versions
+			}
+			return updated, nil
+		}
+	}
+	return RuleSetVersion{}, ErrRuleSetNotFound
+}
+
+func (s *Service) DeleteRuleSet(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initTrackerConfigMaps()
+	lookup := strings.TrimSpace(id)
+	for gameSlug, versions := range s.ruleSets {
+		for i, item := range versions {
+			if item.ID != lookup {
+				continue
+			}
+			s.ruleSets[gameSlug] = append(versions[:i], versions[i+1:]...)
+			if item.IsActive && len(s.ruleSets[gameSlug]) > 0 {
+				s.ruleSets[gameSlug][0].IsActive = true
+			}
+			return nil
+		}
+	}
+	return ErrRuleSetNotFound
+}
+
+func (s *Service) ActivateRuleSet(_ context.Context, id, actorID string) (RuleSetVersion, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initTrackerConfigMaps()
+	lookup := strings.TrimSpace(id)
+	for gameSlug, versions := range s.ruleSets {
+		active := -1
+		for i := range versions {
+			if versions[i].ID == lookup {
+				active = i
+				break
+			}
+		}
+		if active == -1 {
+			continue
+		}
+		now := time.Now().UTC()
+		for i := range versions {
+			versions[i].IsActive = i == active
+			if i == active {
+				versions[i].ActivatedAt = now
+				versions[i].ActivatedBy = strings.TrimSpace(actorID)
+			}
+		}
+		s.ruleSets[gameSlug] = versions
+		return versions[active], nil
+	}
+	return RuleSetVersion{}, ErrRuleSetNotFound
+}
+
+func (s *Service) GetActiveRuleSet(_ context.Context, gameSlug string) (RuleSetVersion, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, item := range s.ruleSets[strings.TrimSpace(gameSlug)] {
+		if item.IsActive {
+			return item, nil
+		}
+	}
+	return RuleSetVersion{}, ErrRuleSetNotFound
+}
+
+var _ sync.Locker

--- a/internal/prompts/tracker_config_test.go
+++ b/internal/prompts/tracker_config_test.go
@@ -1,0 +1,65 @@
+package prompts
+
+import (
+	"context"
+	"testing"
+)
+
+func TestServiceStateSchemaLifecycle(t *testing.T) {
+	svc := NewService()
+	created, err := svc.CreateStateSchema(context.Background(), StateSchemaCreateRequest{
+		GameSlug: "cs2",
+		Name:     "CS2 baseline",
+		Fields:   []StateFieldDefinition{{Key: "score.ct", Type: "number"}},
+		ActorID:  "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateStateSchema() error = %v", err)
+	}
+	if !created.IsActive {
+		t.Fatal("expected first schema to be active")
+	}
+	updated, err := svc.UpdateStateSchema(context.Background(), created.ID, StateSchemaCreateRequest{
+		GameSlug: "cs2",
+		Name:     "CS2 baseline v2",
+		Fields:   []StateFieldDefinition{{Key: "score.t", Type: "number"}},
+		ActorID:  "admin-2",
+	})
+	if err != nil {
+		t.Fatalf("UpdateStateSchema() error = %v", err)
+	}
+	if updated.Name != "CS2 baseline v2" {
+		t.Fatalf("updated name = %q", updated.Name)
+	}
+	active, err := svc.GetActiveStateSchema(context.Background(), "cs2")
+	if err != nil {
+		t.Fatalf("GetActiveStateSchema() error = %v", err)
+	}
+	if active.ID != created.ID {
+		t.Fatalf("active id = %q, want %q", active.ID, created.ID)
+	}
+}
+
+func TestServiceRuleSetLifecycle(t *testing.T) {
+	svc := NewService()
+	created, err := svc.CreateRuleSet(context.Background(), RuleSetCreateRequest{
+		GameSlug:          "cs2",
+		Name:              "CS2 rules",
+		RuleItems:         []RuleItem{{FieldKey: "score.ct", Operation: "set", ConfidenceMode: "strict"}},
+		FinalizationRules: []RuleCondition{{Priority: 1, Condition: "final_banner_seen", Action: "finalize_win"}},
+		ActorID:           "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateRuleSet() error = %v", err)
+	}
+	if !created.IsActive {
+		t.Fatal("expected first rule set to be active")
+	}
+	fetched, err := svc.GetRuleSet(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetRuleSet() error = %v", err)
+	}
+	if fetched.Name != created.Name {
+		t.Fatalf("fetched name = %q, want %q", fetched.Name, created.Name)
+	}
+}


### PR DESCRIPTION
### Motivation
- Move the tracker flow closer to the M2.1 state-tracker design by providing admin-managed state schema and rule-set configuration and ensuring the worker includes that configuration when calling the LLM.

### Description
- Add in-memory tracker configuration models, validation and service methods (`StateSchemaVersion`, `RuleSetVersion`, create/list/get/update/delete/activate) under `internal/prompts` and wire them into the existing `prompts.Service` as `stateSchemas` and `ruleSets` (new file `internal/prompts/tracker_config.go` and updates to `internal/prompts/service.go`).
- Expose admin HTTP endpoints for tracker config management (`/api/admin/llm/state-schemas` and `/api/admin/llm/rule-sets`) with create/list/get/update/delete/activate handlers and request→domain mapping in `internal/app/router.go`.
- Enrich the worker payload so each tracker LLM call now carries `previous_state` plus the active state schema and active rule set resolved from the prompts service, and include these in `StageRequest` and in the Gemini instruction builder to make LLM prompts data-driven (`internal/media/worker.go`, `internal/media/gemini.go`).
- Add unit tests covering tracker config lifecycle and admin routes and update Gemini instruction tests to assert the active tracker context is included (`internal/prompts/tracker_config_test.go`, `internal/app/router_admin_llm_test.go`, updates to `internal/media/gemini_test.go`).

M2.1 checklist (aligned to `docs/implementation_plan.md`):
- [x] Auto-start Streamlink analysis job after `POST /api/streamers` success (existing scheduler wiring unchanged).
- [x] Provide a stop-tracking control path so clients can end per-streamer monitoring (existing `StopTracking` hook remains wired).
- [x] Fixed 10-second capture cadence with lock/idempotency protections (scheduler/locker already present).
- [x] Resolve the active tracker configuration (schema + rules + prompts) from admin configuration and include it in the worker payload (in-memory resolver implemented).
- [x] Worker payload includes `previous_state`, prompt text, runtime params, and the new chunk payload for each 10-second window (payload extended with `StateSchema` and `RuleSet`).
- [ ] Delete or refactor legacy detector/scenario-chain codepaths before enabling the new tracker flow in production.
- [ ] Persist the active state schema, rule set, and prompt package in the database with audit/version history (current implementation is in-memory; DB-backed storage is next).
- [ ] Provide admin CRUD for tracked state fields, evidence categories, and finalization rules in a DB-backed repository (in-memory CRUD implemented; DB migration pending).
- [ ] Persist chunk metadata, LLM request/response refs, updated state snapshot, evidence delta, conflicts, and finalization outcome when available (decision recording paths exist but durable match/session modeling and final outcome tables remain to be added).
- [ ] Publish realtime `LLM_MATCH_STATE_UPDATED` / `LLM_MATCH_FINALIZED` events and provide REST backfill/history (realtime fan-out to be implemented).
- [ ] Add retry/backoff + DLQ behavior for Streamlink and LLM failures, and observability for M2.1 metrics (follow-up work).

### Testing
- Ran `go test ./...` and all tests passed locally, including new/updated tests in `internal/prompts`, `internal/media`, and `internal/app`.
- Unit tests added: `internal/prompts/tracker_config_test.go` (state schema & rule set lifecycle) and `internal/app/router_admin_llm_test.go` (admin routes), and `internal/media/gemini_test.go` updated to assert tracker prompt contract.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03c33598c832c99fd7a21a75be472)