### PR TITLE
Normalize and merge tracker state JSON, handle legacy tracker stages and labels

### DIFF
--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -258,7 +258,7 @@ func filterTrackerPrompts(items []prompts.PromptVersion) []prompts.PromptVersion
 
 func isTrackerStage(stage string) bool {
 	switch strings.TrimSpace(strings.ToLower(stage)) {
-	case trackerStageDiscovery, trackerStageUpdate, trackerStageFinalize:
+	case trackerStageDiscovery, trackerStageUpdate, trackerStageFinalize, "start", "update", "finalize", "finish", "end":
 		return true
 	default:
 		return false
@@ -304,7 +304,8 @@ func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chu
 }
 
 func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.PromptVersion, result StageClassification, chunk ChunkRef, runID, streamerID, previousState string) (streamers.LLMDecision, error) {
-	label := strings.TrimSpace(result.Label)
+	updatedStateJSON := normalizeStateSnapshot(previousState, result)
+	label := normalizeDecisionLabel(result, updatedStateJSON)
 	if label == "" || result.Confidence < effectiveConfidenceThreshold(w.minConfidence, activePrompt.MinConfidence) {
 		label = "uncertain"
 	}
@@ -336,7 +337,7 @@ func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.Pr
 		LatencyMS:         result.Latency.Milliseconds(),
 		TransitionOutcome: transitionOutcome,
 		PreviousStateJSON: previousState,
-		UpdatedStateJSON:  firstNonEmpty(strings.TrimSpace(result.UpdatedStateJSON), strings.TrimSpace(result.RawResponse)),
+		UpdatedStateJSON:  updatedStateJSON,
 		EvidenceDeltaJSON: firstNonEmpty(strings.TrimSpace(result.EvidenceDeltaJSON), strings.TrimSpace(result.NextEvidenceJSON)),
 		ConflictsJSON:     strings.TrimSpace(result.ConflictsJSON),
 		FinalOutcome:      strings.TrimSpace(result.FinalOutcome),
@@ -360,6 +361,200 @@ func (w *Worker) resolvePreviousState(ctx context.Context, streamerID string) st
 		}
 	}
 	return defaultTrackerState()
+}
+
+func normalizeDecisionLabel(result StageClassification, updatedStateJSON string) string {
+	label := strings.TrimSpace(result.Label)
+	if label != "" {
+		return label
+	}
+	if strings.TrimSpace(result.FinalOutcome) != "" && !strings.EqualFold(strings.TrimSpace(result.FinalOutcome), "unknown") {
+		return "finalized"
+	}
+	if strings.TrimSpace(updatedStateJSON) != "" {
+		return "state_updated"
+	}
+	return ""
+}
+
+func normalizeStateSnapshot(previousState string, result StageClassification) string {
+	current := firstNonEmpty(strings.TrimSpace(result.UpdatedStateJSON), strings.TrimSpace(result.RawResponse))
+	if current == "" {
+		return strings.TrimSpace(previousState)
+	}
+	normalizedCurrent := normalizeStateJSON(current)
+	if normalizedCurrent == "" {
+		return strings.TrimSpace(previousState)
+	}
+	normalizedPrevious := normalizeStateJSON(previousState)
+	if normalizedPrevious == "" {
+		return normalizedCurrent
+	}
+	merged, ok := mergeStateSnapshots(normalizedPrevious, normalizedCurrent)
+	if !ok {
+		return normalizedCurrent
+	}
+	return merged
+}
+
+func normalizeStateJSON(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
+		return trimmed
+	}
+	normalized := normalizeStateValue(decoded)
+	body, err := json.Marshal(normalized)
+	if err != nil {
+		return trimmed
+	}
+	return string(body)
+}
+
+func normalizeStateValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		if state, ok := typed["updated_state"]; ok {
+			finalOutcome := strings.TrimSpace(stringValue(valueFromMap(typed, "final_outcome")))
+			typed = map[string]any{
+				"state": state,
+			}
+			if finalOutcome != "" {
+				typed["final_outcome"] = finalOutcome
+			}
+		}
+		if state, ok := typed["state"]; ok {
+			if stateMap, ok := state.(map[string]any); ok {
+				typed["state"] = normalizeStateFields(stateMap)
+			}
+		}
+		for key, item := range typed {
+			if key == "state" {
+				continue
+			}
+			typed[key] = normalizeStateValue(item)
+		}
+		return typed
+	case []any:
+		for idx, item := range typed {
+			typed[idx] = normalizeStateValue(item)
+		}
+		return typed
+	default:
+		return typed
+	}
+}
+
+func normalizeStateFields(fields map[string]any) map[string]any {
+	normalized := make(map[string]any, len(fields))
+	for key, item := range fields {
+		switch typed := item.(type) {
+		case map[string]any:
+			if rawValue, ok := typed["value"]; ok {
+				normalized[key] = normalizeStateValue(rawValue)
+				continue
+			}
+			normalized[key] = normalizeStateValue(typed)
+		default:
+			normalized[key] = normalizeStateValue(item)
+		}
+	}
+	return normalized
+}
+
+func mergeStateSnapshots(previousState, currentState string) (string, bool) {
+	var previous any
+	if err := json.Unmarshal([]byte(previousState), &previous); err != nil {
+		return "", false
+	}
+	var current any
+	if err := json.Unmarshal([]byte(currentState), &current); err != nil {
+		return "", false
+	}
+	merged := mergeStateValue(previous, current)
+	body, err := json.Marshal(merged)
+	if err != nil {
+		return "", false
+	}
+	return string(body), true
+}
+
+func mergeStateValue(previous, current any) any {
+	switch currentTyped := current.(type) {
+	case map[string]any:
+		previousTyped, _ := previous.(map[string]any)
+		merged := make(map[string]any, len(previousTyped)+len(currentTyped))
+		for key, item := range previousTyped {
+			merged[key] = item
+		}
+		for key, item := range currentTyped {
+			merged[key] = mergeStateValue(previousTyped[key], item)
+		}
+		return merged
+	case []any:
+		if len(currentTyped) == 0 {
+			if previousTyped, ok := previous.([]any); ok && len(previousTyped) > 0 {
+				return previousTyped
+			}
+		}
+		return currentTyped
+	case string:
+		if isPlaceholderString(currentTyped) {
+			if previousTyped, ok := previous.(string); ok && strings.TrimSpace(previousTyped) != "" {
+				return previousTyped
+			}
+		}
+		return currentTyped
+	case float64:
+		if currentTyped == 0 {
+			if previousTyped, ok := previous.(float64); ok && previousTyped != 0 {
+				return previousTyped
+			}
+		}
+		return currentTyped
+	case bool:
+		if !currentTyped {
+			if previousTyped, ok := previous.(bool); ok && previousTyped {
+				return previousTyped
+			}
+		}
+		return currentTyped
+	case nil:
+		if previous != nil {
+			return previous
+		}
+		return nil
+	default:
+		return currentTyped
+	}
+}
+
+func isPlaceholderString(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "unknown", "null", "nil", "n/a", "none", "unset":
+		return true
+	default:
+		return false
+	}
+}
+
+func stringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func valueFromMap(values map[string]any, key string) any {
+	if values == nil {
+		return nil
+	}
+	return values[key]
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -342,7 +343,69 @@ func TestWorkerProcessStreamerPassesPersistedPreviousStateToTrackerStages(t *tes
 	if len(decisions.items) != 2 {
 		t.Fatalf("recorded %d decisions, want 2", len(decisions.items))
 	}
-	if decisions.items[1].PreviousStateJSON != `{"score":{"ct":8,"t":5}}` {
+	if !strings.Contains(decisions.items[1].PreviousStateJSON, `"score":{"ct":8,"t":5}`) {
 		t.Fatalf("previous state = %q", decisions.items[1].PreviousStateJSON)
+	}
+}
+
+func TestWorkerProcessStreamerNormalizesLegacyStatePayloads(t *testing.T) {
+	decisions := &fakeDecisionStore{}
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		fakeClassifier{results: map[string]StageClassification{
+			"start": {
+				Confidence: 0.91,
+				RawResponse: `{
+					"state": {
+						"mode": {"value": "competitive", "confidence": 0.9},
+						"ct_score": {"value": 8, "confidence": 0.9},
+						"t_score": {"value": 5, "confidence": 0.9}
+					},
+					"final_outcome": "unknown"
+				}`,
+			},
+		}},
+		fakePromptResolver{prompts: []prompts.PromptVersion{{ID: "tracker-1", Stage: "start", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}}},
+		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
+	)
+	got, err := worker.ProcessStreamer(context.Background(), "str-1")
+	if err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got.Label != "state_updated" {
+		t.Fatalf("label = %q, want state_updated", got.Label)
+	}
+	if len(decisions.items) != 1 {
+		t.Fatalf("recorded %d decisions, want 1", len(decisions.items))
+	}
+	if got := decisions.items[0].UpdatedStateJSON; !strings.Contains(got, `"state":{"ct_score":8,"mode":"competitive","t_score":5}`) || !strings.Contains(got, `"final_outcome":"unknown"`) {
+		t.Fatalf("updated state = %q", decisions.items[0].UpdatedStateJSON)
+	}
+}
+
+func TestWorkerProcessStreamerPreservesKnownScoreWhenModelReturnsUnknownPlaceholders(t *testing.T) {
+	decisions := &fakeDecisionStore{}
+	classifier := &flakyClassifier{
+		result: StageClassification{
+			Label:            "state_updated",
+			Confidence:       0.95,
+			UpdatedStateJSON: `{"state":{"ct_score":0,"t_score":0,"mode":"unknown"},"final_outcome":"unknown"}`,
+		},
+	}
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		classifier,
+		fakePromptResolver{prompts: []prompts.PromptVersion{{ID: "tracker-1", Stage: "match_update", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}}},
+		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
+	)
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("first ProcessStreamer() error = %v", err)
+	}
+	decisions.items[0].UpdatedStateJSON = `{"state":{"ct_score":8,"t_score":5,"mode":"competitive"},"final_outcome":"unknown"}`
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("second ProcessStreamer() error = %v", err)
+	}
+	if got := decisions.items[1].UpdatedStateJSON; got != `{"final_outcome":"unknown","state":{"ct_score":8,"mode":"competitive","t_score":5}}` {
+		t.Fatalf("updated state = %q", got)
 	}
 }


### PR DESCRIPTION
### Motivation

- Ensure tracker stage outputs are normalized into a consistent JSON shape so persisted state remains stable across prompt/response formats.
- Preserve existing known values when models return placeholder/unknown values and avoid losing score information during state updates.
- Accept legacy tracker stage names and map empty labels to meaningful outcomes so older prompts/responses are still processed correctly.

### Description

- Added state normalization and merging helpers (`normalizeStateSnapshot`, `normalizeStateJSON`, `normalizeStateValue`, `normalizeStateFields`, `mergeStateSnapshots`, `mergeStateValue`, `isPlaceholderString`, `stringValue`, `valueFromMap`) to canonicalize and merge previous and current tracker snapshots.
- Added `normalizeDecisionLabel` to synthesize a decision label from `Label`, `FinalOutcome`, and whether state changed, and updated `processStageResult` to use normalized state and label and to persist the merged `UpdatedStateJSON`.
- Extended `isTrackerStage` to accept legacy stage names (`"start"`, `"update"`, `"finalize"`, `"finish"`, `"end"`).
- Updated tests and imports in `internal/media/worker_test.go`, modified an assertion to use `strings.Contains`, and added tests `TestWorkerProcessStreamerNormalizesLegacyStatePayloads` and `TestWorkerProcessStreamerPreservesKnownScoreWhenModelReturnsUnknownPlaceholders` to cover normalization and placeholder-preservation behavior.

### Testing

- Ran unit tests for the media package including `TestWorkerProcessStreamerPassesPersistedPreviousStateToTrackerStages`, `TestWorkerProcessStreamerNormalizesLegacyStatePayloads`, and `TestWorkerProcessStreamerPreservesKnownScoreWhenModelReturnsUnknownPlaceholders`, and they passed.
- The updated assertions in `worker_test.go` were exercised and validated by the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c130936df4832cb68d2b7015ec4591)