### PR TITLE
Accept Gemini tracker responses missing label and preserve tracker payloads

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -342,7 +342,7 @@ func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {
 
 	var parsed geminiStageResponse
 	if err := json.Unmarshal([]byte(cleaned), &parsed); err == nil {
-		if strings.TrimSpace(parsed.Label) != "" {
+		if hasGeminiResponsePayload(parsed) {
 			return parsed, nil
 		}
 	}
@@ -351,8 +351,8 @@ func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {
 	if err := json.Unmarshal([]byte(cleaned), &generic); err != nil {
 		return geminiStageResponse{}, fmt.Errorf("parse gemini stage response: %w", err)
 	}
-	parsed.Label = strings.TrimSpace(fmt.Sprint(generic["label"]))
-	parsed.Summary = strings.TrimSpace(fmt.Sprint(generic["summary"]))
+	parsed.Label = strings.TrimSpace(stringValue(generic["label"]))
+	parsed.Summary = strings.TrimSpace(stringValue(generic["summary"]))
 	switch value := generic["confidence"].(type) {
 	case float64:
 		parsed.Confidence = value
@@ -363,10 +363,30 @@ func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {
 		}
 		parsed.Confidence = confidence
 	}
-	if parsed.Label == "" {
+	parsed.UpdatedState = rawMessageFromGenericValue(generic["updated_state"])
+	parsed.Delta = rawMessageFromGenericValue(generic["delta"])
+	parsed.NextNeededEvidence = rawMessageFromGenericValue(generic["next_needed_evidence"])
+	parsed.HardConflicts = rawMessageFromGenericValue(generic["hard_conflicts"])
+	parsed.FinalOutcome = strings.TrimSpace(stringValue(generic["final_outcome"]))
+	if !hasGeminiResponsePayload(parsed) {
 		return geminiStageResponse{}, ErrGeminiEmptyResponse
 	}
 	return parsed, nil
+}
+
+func hasGeminiResponsePayload(parsed geminiStageResponse) bool {
+	return strings.TrimSpace(parsed.Label) != "" || len(parsed.UpdatedState) > 0 || strings.TrimSpace(parsed.FinalOutcome) != ""
+}
+
+func rawMessageFromGenericValue(value any) json.RawMessage {
+	if value == nil {
+		return nil
+	}
+	body, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+	return json.RawMessage(body)
 }
 
 func normalizeGeminiModel(model string) string {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -193,6 +193,53 @@ func TestBuildGeminiInstructionUsesTrackerContract(t *testing.T) {
 	}
 }
 
+func TestGeminiStageClassifierAcceptsTrackerResponseWithoutLabel(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"confidence\":0.93,\"updated_state\":{\"status\":\"live\"},\"delta\":[\"score_seen\"],\"next_needed_evidence\":[\"winner_banner\"],\"final_outcome\":\"unknown\"}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	result, err := classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "match_update",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt:     prompts.PromptVersion{Stage: "match_update", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+	})
+	if err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+	if result.Label != "state_updated" {
+		t.Fatalf("expected synthesized label state_updated, got %q", result.Label)
+	}
+	if result.UpdatedStateJSON != `{"status":"live"}` {
+		t.Fatalf("expected updated state payload, got %s", result.UpdatedStateJSON)
+	}
+	if result.FinalOutcome != "unknown" {
+		t.Fatalf("expected final outcome unknown, got %q", result.FinalOutcome)
+	}
+}
+
 func TestGeminiStageClassifierRejectsTrackerResponseWithoutStatePayload(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.mp4")


### PR DESCRIPTION
### Motivation
- The scheduler logged `gemini returned empty response` when the Gemini parser rejected responses that omitted `label` even though tracker fields like `updated_state` or `final_outcome` were present. The intent is to make tracker-stage parsing resilient to valid LLM shapes that omit `label` but include state payloads.

### Description
- Relax `parseGeminiStageResponse` to consider a response valid when it contains a tracker payload (`updated_state`/`final_outcome`) even if `label` is missing.
- Preserve tracker fields on the generic JSON fallback by extracting `updated_state`, `delta`, `next_needed_evidence`, `hard_conflicts`, and `final_outcome` into `geminiStageResponse` via `rawMessageFromGenericValue`.
- Add helper `hasGeminiResponsePayload` and reuse `stringValue` for safer generic extraction.
- Add regression test `TestGeminiStageClassifierAcceptsTrackerResponseWithoutLabel` to cover the case where Gemini returns tracker JSON without a `label`.

### Testing
- Ran unit tests for the media package: `go test ./internal/media -run 'TestGeminiStageClassifier|TestBuildGeminiInstruction' -count=1 -timeout 30s` and targeted the new regression `TestGeminiStageClassifierAcceptsTrackerResponseWithoutLabel`; all exercised tests passed.
- Changes committed with message `Fix tracker Gemini responses without labels`.

Checklist (aligned to M2.1 / priority):
- [x] Parser accepts tracker state payloads from Gemini (prevents spurious `ErrGeminiEmptyResponse`).
- [x] Improved resilience of chunk analysis to LLM response shape variance.
- [ ] Implement full stream capture worker pipeline and realtime publish (outstanding).
- [ ] Add DLQ / extended retry/backoff behavior for LLM failures (outstanding).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c137f17b98832ca60ecda3340b9ac9)