### PR TITLE
media/gemini: include safety ratings and richer diagnostics for empty Gemini responses

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -94,7 +94,14 @@ type geminiGenerateContentResponse struct {
 }
 
 type geminiPromptFeedback struct {
-	BlockReason string `json:"blockReason"`
+	BlockReason   string               `json:"blockReason"`
+	SafetyRatings []geminiSafetyRating `json:"safetyRatings"`
+}
+
+type geminiSafetyRating struct {
+	Category    string `json:"category"`
+	Probability string `json:"probability"`
+	Blocked     bool   `json:"blocked"`
 }
 
 type geminiCandidate struct {
@@ -198,10 +205,7 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 	}
 	rawText := extractGeminiResponseText(payload)
 	if rawText == "" {
-		if payload.PromptFeedback.BlockReason != "" {
-			return StageClassification{}, fmt.Errorf("gemini blocked prompt: %s", payload.PromptFeedback.BlockReason)
-		}
-		return StageClassification{}, ErrGeminiEmptyResponse
+		return StageClassification{}, describeGeminiEmptyResponse(payload, responseBody)
 	}
 
 	parsed, err := parseGeminiStageResponse(rawText)
@@ -331,6 +335,71 @@ func extractGeminiResponseText(payload geminiGenerateContentResponse) string {
 		}
 	}
 	return ""
+}
+
+func describeGeminiEmptyResponse(payload geminiGenerateContentResponse, responseBody []byte) error {
+	parts := []string{ErrGeminiEmptyResponse.Error()}
+	if len(payload.Candidates) == 0 {
+		parts = append(parts, "candidates=0")
+	}
+	if reasons := geminiFinishReasons(payload.Candidates); len(reasons) > 0 {
+		parts = append(parts, "finish_reasons="+strings.Join(reasons, ","))
+	}
+	if reason := strings.TrimSpace(payload.PromptFeedback.BlockReason); reason != "" {
+		parts = append(parts, "block_reason="+reason)
+	}
+	if ratings := geminiBlockedSafetyCategories(payload.PromptFeedback.SafetyRatings); len(ratings) > 0 {
+		parts = append(parts, "blocked_safety_categories="+strings.Join(ratings, ","))
+	}
+	if body := strings.TrimSpace(string(responseBody)); body != "" {
+		if len(body) > 512 {
+			body = body[:512] + "..."
+		}
+		parts = append(parts, "body="+strconv.Quote(body))
+	}
+	return errors.New(strings.Join(parts, "; "))
+}
+
+func geminiFinishReasons(candidates []geminiCandidate) []string {
+	if len(candidates) == 0 {
+		return nil
+	}
+	reasons := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		reason := strings.TrimSpace(candidate.FinishReason)
+		if reason == "" {
+			continue
+		}
+		if _, ok := seen[reason]; ok {
+			continue
+		}
+		seen[reason] = struct{}{}
+		reasons = append(reasons, reason)
+	}
+	return reasons
+}
+
+func geminiBlockedSafetyCategories(ratings []geminiSafetyRating) []string {
+	if len(ratings) == 0 {
+		return nil
+	}
+	categories := make([]string, 0, len(ratings))
+	for _, rating := range ratings {
+		if !rating.Blocked {
+			continue
+		}
+		category := strings.TrimSpace(rating.Category)
+		if category == "" {
+			category = "unknown"
+		}
+		probability := strings.TrimSpace(rating.Probability)
+		if probability != "" {
+			category += ":" + probability
+		}
+		categories = append(categories, category)
+	}
+	return categories
 }
 
 func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -277,3 +277,83 @@ func TestGeminiStageClassifierRejectsTrackerResponseWithoutStatePayload(t *testi
 		t.Fatalf("expected missing updated_state error, got %v", err)
 	}
 }
+
+func TestGeminiStageClassifierReportsEmptyResponseDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+	                    "candidates": [{"finishReason": "MAX_TOKENS", "content": {"parts": []}}],
+	                    "promptFeedback": {"blockReason": "SAFETY", "safetyRatings": [{"category": "HARM_CATEGORY_HATE_SPEECH", "probability": "HIGH", "blocked": true}]}
+	                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	_, err = classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "match_update",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt:     prompts.PromptVersion{Stage: "match_update", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+	})
+	if err == nil {
+		t.Fatal("expected empty response diagnostics error")
+	}
+	for _, fragment := range []string{
+		ErrGeminiEmptyResponse.Error(),
+		"finish_reasons=MAX_TOKENS",
+		"block_reason=SAFETY",
+		"blocked_safety_categories=HARM_CATEGORY_HATE_SPEECH:HIGH",
+		`body="{`,
+	} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("expected error to contain %q, got %v", fragment, err)
+		}
+	}
+}
+
+func TestGeminiStageClassifierReportsNoCandidatesInEmptyResponse(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"candidates": []}`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	_, err = classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "detector",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt:     prompts.PromptVersion{Stage: "detector", Template: "Detect the game", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+	})
+	if err == nil || !strings.Contains(err.Error(), "candidates=0") {
+		t.Fatalf("expected candidates=0 diagnostic, got %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Improve observability and debugging when Gemini returns an empty generation by surfacing finish reasons, block reasons, blocked safety categories, and a clipped response body.
- Capture per-category safety ratings from Gemini prompt feedback so downstream logic can report which categories caused blocking.

### Description
- Add `SafetyRatings` to `geminiPromptFeedback` and introduce `geminiSafetyRating` to parse category, probability, and blocked flag from Gemini responses.
- Centralize empty-response handling in `describeGeminiEmptyResponse`, which composes a diagnostic error containing `candidates` count, finish reasons, `block_reason`, blocked safety categories, and a clipped `body` snippet.
- Implement helper functions `geminiFinishReasons` and `geminiBlockedSafetyCategories` to deduplicate finish reasons and format blocked safety categories with optional probability.
- Update `Classify` to call `describeGeminiEmptyResponse` when the extracted text is empty, and add unit tests exercising the new diagnostics and the no-candidates case.

### Testing
- Ran package unit tests with `go test ./internal/media -v`, which included the new tests `TestGeminiStageClassifierReportsEmptyResponseDiagnostics` and `TestGeminiStageClassifierReportsNoCandidatesInEmptyResponse`, and they passed.
- Existing `TestGeminiStageClassifierRejectsTrackerResponseWithoutStatePayload` was also exercised and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c13ca5e6ac832c810f492d772b2dca)