### PR TITLE
Backfill missing fields for Gemini tracker start responses

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -227,6 +227,7 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 	if err != nil {
 		return StageClassification{}, err
 	}
+	parsed = normalizeGeminiTrackerResponse(input, parsed)
 	if parsed.Confidence < 0 || parsed.Confidence > 1 {
 		return StageClassification{}, ErrGeminiInvalidConfidence
 	}
@@ -592,4 +593,36 @@ func validateGeminiTrackerResponse(stage string, parsed geminiStageResponse) err
 		}
 	}
 	return nil
+}
+
+func normalizeGeminiTrackerResponse(input StageRequest, parsed geminiStageResponse) geminiStageResponse {
+	if !isTrackerStage(input.Stage) || !isTrackerStartStage(input.Stage) {
+		return parsed
+	}
+	if len(parsed.UpdatedState) == 0 || strings.TrimSpace(string(parsed.UpdatedState)) == "null" {
+		fallbackState := strings.TrimSpace(input.PreviousState)
+		if fallbackState == "" {
+			fallbackState = defaultTrackerState()
+		}
+		parsed.UpdatedState = json.RawMessage(fallbackState)
+	}
+	if len(parsed.Delta) == 0 || strings.TrimSpace(string(parsed.Delta)) == "null" {
+		parsed.Delta = json.RawMessage("[]")
+	}
+	if len(parsed.NextNeededEvidence) == 0 || strings.TrimSpace(string(parsed.NextNeededEvidence)) == "null" {
+		parsed.NextNeededEvidence = json.RawMessage("[]")
+	}
+	if strings.TrimSpace(parsed.FinalOutcome) == "" {
+		parsed.FinalOutcome = "unknown"
+	}
+	return parsed
+}
+
+func isTrackerStartStage(stage string) bool {
+	switch strings.TrimSpace(strings.ToLower(stage)) {
+	case trackerStageDiscovery, "start", "discovery":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -408,6 +408,56 @@ func TestGeminiStageClassifierRejectsTrackerResponseWithoutStatePayload(t *testi
 	}
 }
 
+func TestGeminiStageClassifierBackfillsTrackerStartPayload(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.93}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	result, err := classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "Start",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt:     prompts.PromptVersion{Stage: "Start", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+	})
+	if err != nil {
+		t.Fatalf("expected start stage fallback payload, got error %v", err)
+	}
+	if strings.TrimSpace(result.UpdatedStateJSON) == "" {
+		t.Fatalf("expected updated_state fallback, got empty value")
+	}
+	if strings.TrimSpace(result.EvidenceDeltaJSON) != "[]" {
+		t.Fatalf("expected empty delta fallback, got %q", result.EvidenceDeltaJSON)
+	}
+	if strings.TrimSpace(result.NextEvidenceJSON) != "[]" {
+		t.Fatalf("expected empty next_needed_evidence fallback, got %q", result.NextEvidenceJSON)
+	}
+	if strings.TrimSpace(result.FinalOutcome) != "unknown" {
+		t.Fatalf("expected unknown final_outcome fallback, got %q", result.FinalOutcome)
+	}
+}
+
 func TestGeminiStageClassifierReportsEmptyResponseDiagnostics(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.mp4")


### PR DESCRIPTION
### Motivation

- Ensure tracker "start"/discovery responses from Gemini include required fields so downstream validation does not fail when the model omits them.
- Provide sensible defaults for `updated_state`, `delta`, `next_needed_evidence`, and `final_outcome` on tracker start to make responses robust to partial model outputs.

### Description

- Added `normalizeGeminiTrackerResponse` which backfills missing tracker fields for start/discovery stages with defaults: `updated_state` falls back to `PreviousState` or `defaultTrackerState()`, `delta` and `next_needed_evidence` default to `[]`, and `final_outcome` defaults to `"unknown"`.
- Invoked `normalizeGeminiTrackerResponse` in `Classify` after parsing the raw Gemini response and before validating the tracker response.
- Added helper `isTrackerStartStage` to detect canonical tracker start/discovery stage names.
- Added unit test `TestGeminiStageClassifierBackfillsTrackerStartPayload` to exercise the backfill behavior for start-stage responses.

### Testing

- Ran unit tests for the media classifier package including `TestGeminiStageClassifierBackfillsTrackerStartPayload`; tests passed.
- Existing Gemini classifier tests (e.g. missing-state validation and empty-response diagnostics) were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29e3d5dc8832c8dce874d6b118b9b)