### PR TITLE
Fix nil final_outcome handling in Gemini tracker parsing

### DIFF
--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -458,6 +458,47 @@ func TestGeminiStageClassifierBackfillsTrackerStartPayload(t *testing.T) {
 	}
 }
 
+func TestGeminiStageClassifierBackfillsTrackerStartPayloadWithNullFinalOutcome(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.93,\"updated_state\":{\"status\":\"live\"},\"delta\":[],\"next_needed_evidence\":[],\"final_outcome\":null}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	result, err := classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "Start",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt:     prompts.PromptVersion{Stage: "Start", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+	})
+	if err != nil {
+		t.Fatalf("expected null final_outcome to be normalized, got error %v", err)
+	}
+	if strings.TrimSpace(result.FinalOutcome) != "unknown" {
+		t.Fatalf("expected unknown final_outcome fallback, got %q", result.FinalOutcome)
+	}
+}
+
 func TestGeminiStageClassifierReportsEmptyResponseDiagnostics(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.mp4")

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -543,6 +543,8 @@ func isPlaceholderString(value string) bool {
 
 func stringValue(value any) string {
 	switch typed := value.(type) {
+	case nil:
+		return ""
 	case string:
 		return typed
 	default:


### PR DESCRIPTION
### Motivation
- Gemini tracker responses sometimes include `final_outcome: null` which was being stringified to `"<nil>"` and then rejected by the tracker whitelist, causing Start-stage runs to fail and scheduler cycles to abort. 
- The intent is to normalize nullable tracker fields so tracker start/backup logic and validation succeed instead of producing spurious errors.

### Description
- Treat JSON `nil` values as empty strings by returning `""` from `stringValue(nil)` in `internal/media/worker.go`, preventing `"<nil>"` from entering validation logic.
- Add a regression test `TestGeminiStageClassifierBackfillsTrackerStartPayloadWithNullFinalOutcome` in `internal/media/gemini_test.go` that simulates `final_outcome: null` and asserts it normalizes to `unknown` for the Start stage.
- Files changed: `internal/media/worker.go`, `internal/media/gemini_test.go`.
- Checklist aligned to M2.1 implementation plan: [x] Capture + prompt-stage pipeline continues reliably when tracker payload includes nullable fields; [ ] Automatic worker start after streamer onboarding; [ ] 10-second chunk capture cadence verification; [ ] Persist + publish live status updates end-to-end verification.

### Testing
- Ran targeted unit tests: `go test ./internal/media -run 'TestGeminiStageClassifierBackfillsTrackerStartPayload|TestGeminiStageClassifierBackfillsTrackerStartPayloadWithNullFinalOutcome'` and they passed.
- Ran package tests for the media package: `go test ./internal/media` which completed successfully (`ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a1f35498832c9b8fa82243f88622)