### PR TITLE
Recover Gemini classifier after empty continuation response

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -151,6 +151,18 @@ type geminiStageResponse struct {
 }
 
 func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest) (StageClassification, error) {
+	result, err := c.classify(ctx, input, false)
+	if err == nil {
+		return result, nil
+	}
+	if !isGeminiSessionRecoveryError(err) {
+		return StageClassification{}, err
+	}
+	c.resetSession(geminiSessionKey(input))
+	return c.classify(ctx, input, true)
+}
+
+func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest, forceBootstrap bool) (StageClassification, error) {
 	chunkRef := strings.TrimSpace(input.Chunk.Reference)
 	if chunkRef == "" {
 		return StageClassification{}, ErrGeminiChunkRequired
@@ -166,7 +178,7 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 
 	sessionKey := geminiSessionKey(input)
 	promptFingerprint := geminiPromptFingerprint(input)
-	contents := c.prepareSessionContents(sessionKey, promptFingerprint, input, mimeType, data)
+	contents := c.prepareSessionContents(sessionKey, promptFingerprint, input, mimeType, data, forceBootstrap)
 
 	requestBody := geminiGenerateContentRequest{
 		Contents: contents,
@@ -265,6 +277,16 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 	}, nil
 }
 
+func isGeminiSessionRecoveryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrGeminiEmptyResponse) {
+		return true
+	}
+	return strings.Contains(err.Error(), ErrGeminiEmptyResponse.Error())
+}
+
 func geminiSessionKey(input StageRequest) string {
 	key := strings.TrimSpace(input.StreamerID)
 	if key == "" {
@@ -282,7 +304,7 @@ func geminiPromptFingerprint(input StageRequest) string {
 	}, "|")
 }
 
-func (c *GeminiStageClassifier) prepareSessionContents(sessionKey, promptFingerprint string, input StageRequest, mimeType string, chunk []byte) []geminiContent {
+func (c *GeminiStageClassifier) prepareSessionContents(sessionKey, promptFingerprint string, input StageRequest, mimeType string, chunk []byte, forceBootstrap bool) []geminiContent {
 	userTurn := geminiContent{
 		Role: "user",
 		Parts: []geminiPart{
@@ -291,7 +313,7 @@ func (c *GeminiStageClassifier) prepareSessionContents(sessionKey, promptFingerp
 	}
 	c.sessionsMu.Lock()
 	session, hasSession := c.sessions[sessionKey]
-	shouldRotate := !hasSession || session.TokenCount >= c.maxChatTokens || session.PromptFingerprint != promptFingerprint
+	shouldRotate := forceBootstrap || !hasSession || session.TokenCount >= c.maxChatTokens || session.PromptFingerprint != promptFingerprint
 	if shouldRotate {
 		userTurn.Parts = append([]geminiPart{{Text: buildGeminiInstruction(input)}}, userTurn.Parts...)
 		c.sessions[sessionKey] = geminiChatSession{
@@ -304,6 +326,12 @@ func (c *GeminiStageClassifier) prepareSessionContents(sessionKey, promptFingerp
 	userTurn.Parts = append([]geminiPart{{Text: buildGeminiContinuationInstruction(input)}}, userTurn.Parts...)
 	c.sessionsMu.Unlock()
 	return []geminiContent{userTurn}
+}
+
+func (c *GeminiStageClassifier) resetSession(sessionKey string) {
+	c.sessionsMu.Lock()
+	defer c.sessionsMu.Unlock()
+	delete(c.sessions, strings.ToLower(strings.TrimSpace(sessionKey)))
 }
 
 func (c *GeminiStageClassifier) storeSessionResponse(sessionKey, promptFingerprint string, requestContents []geminiContent, payload geminiGenerateContentResponse, rawText string) {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -228,6 +228,100 @@ func TestGeminiStageClassifierRotatesChatWhenTokenBudgetReached(t *testing.T) {
 	}
 }
 
+func TestGeminiStageClassifierRecoversFromEmptyContinuationResponse(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	requestBodies := make([]string, 0, 2)
+	requestCount := 0
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			requestCount++
+			requestBodies = append(requestBodies, string(body))
+			if requestCount == 1 {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.93,\"updated_state\":{\"status\":\"live\"},\"delta\":[\"score_seen\"],\"next_needed_evidence\":[\"winner_banner\"],\"final_outcome\":\"unknown\"}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 120, "candidatesTokenCount": 30, "totalTokenCount": 150}
+                }`)),
+				}, nil
+			}
+			if requestCount == 2 {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": []},
+                        "finishReason": "STOP"
+                    }],
+                    "usageMetadata": {"promptTokenCount": 90, "candidatesTokenCount": 0, "totalTokenCount": 90}
+                }`)),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.88,\"updated_state\":{\"status\":\"live\"},\"delta\":[\"winner_seen\"],\"next_needed_evidence\":[],\"final_outcome\":\"win\"}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 140, "candidatesTokenCount": 25, "totalTokenCount": 165}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	req := StageRequest{
+		StreamerID: "str-1",
+		Stage:      "match_update",
+		Chunk:      ChunkRef{Reference: chunkPath, CapturedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
+		Prompt: prompts.PromptVersion{
+			ID:       "prompt-1",
+			Stage:    "match_update",
+			Template: "Update the game state",
+			Model:    "gemini",
+		},
+		PreviousState: `{"status":"discovering"}`,
+	}
+	if _, err := classifier.Classify(context.Background(), req); err != nil {
+		t.Fatalf("first Classify() error = %v", err)
+	}
+	req.Chunk.CapturedAt = req.Chunk.CapturedAt.Add(10 * time.Second)
+	result, err := classifier.Classify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second Classify() error = %v", err)
+	}
+	if result.FinalOutcome != "win" {
+		t.Fatalf("expected recovered outcome win, got %q", result.FinalOutcome)
+	}
+	if len(requestBodies) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(requestBodies))
+	}
+	if !strings.Contains(requestBodies[1], "Continue the existing match chat session.") {
+		t.Fatalf("expected second request to be continuation, got %s", requestBodies[1])
+	}
+	if !strings.Contains(requestBodies[2], "Use this admin-managed tracker prompt as the source of truth") {
+		t.Fatalf("expected third request to reset session and bootstrap prompt, got %s", requestBodies[2])
+	}
+}
+
 func TestGeminiStageClassifierRejectsLargeChunk(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.ts")


### PR DESCRIPTION
### Motivation
- The media worker pipeline could fail a scheduler cycle when Gemini returned an empty response on a continuation turn, causing `gemini returned empty response` errors to abort processing.
- The change introduces an automatic recovery so a failed continuation turn is retried with a fresh bootstrap prompt instead of failing the entire run.

### Description
- Add a recovery path in `GeminiStageClassifier.Classify` that retries once with a fresh session when Gemini returns an empty response, by resetting the per-streamer chat session and forcing a bootstrap prompt on retry.
- Extract request logic into `classify(ctx, input, forceBootstrap bool)` and add `forceBootstrap` to `prepareSessionContents` to control whether the full tracker bootstrap is included.
- Add `isGeminiSessionRecoveryError` to detect the empty-response failure mode and `resetSession` to clear the in-memory session map; changes touch `internal/media/gemini.go` and `internal/media/gemini_test.go`.

### Testing
- Ran `go test ./internal/media -run GeminiStageClassifier -count=1` and the tests passed successfully.
- Checklist aligned with M2.1 priority checklist: [x] Recovery on empty Gemini continuation implemented and session reset added, [x] Regression test `TestGeminiStageClassifierRecoversFromEmptyContinuationResponse` added and passing, [ ] Auto-start worker after streamer onboarding (M2.1.1) not changed, [ ] Guaranteed 10s capture orchestration (M2.1.2) not changed, [ ] Full persist + live status publish (M2.1.4) not changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a4cd130c832ca53a8c71a44d7840)