### PR TITLE
Do not auto-reset Gemini session on empty continuation responses; add debug context to empty-response errors

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -151,15 +151,7 @@ type geminiStageResponse struct {
 }
 
 func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest) (StageClassification, error) {
-	result, err := c.classify(ctx, input, false)
-	if err == nil {
-		return result, nil
-	}
-	if !isGeminiSessionRecoveryError(err) {
-		return StageClassification{}, err
-	}
-	c.resetSession(geminiSessionKey(input))
-	return c.classify(ctx, input, true)
+	return c.classify(ctx, input, false)
 }
 
 func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest, forceBootstrap bool) (StageClassification, error) {
@@ -232,7 +224,8 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 	}
 	rawText := extractGeminiResponseText(payload)
 	if rawText == "" {
-		return StageClassification{}, describeGeminiEmptyResponse(payload, responseBody)
+		err := describeGeminiEmptyResponse(payload, responseBody)
+		return StageClassification{}, fmt.Errorf("%v; stage=%s streamer_id=%s session_key=%s prompt_id=%s force_bootstrap=%t", err, strings.TrimSpace(input.Stage), strings.TrimSpace(input.StreamerID), sessionKey, strings.TrimSpace(input.Prompt.ID), forceBootstrap)
 	}
 
 	parsed, err := parseGeminiStageResponse(rawText)
@@ -277,16 +270,6 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 	}, nil
 }
 
-func isGeminiSessionRecoveryError(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, ErrGeminiEmptyResponse) {
-		return true
-	}
-	return strings.Contains(err.Error(), ErrGeminiEmptyResponse.Error())
-}
-
 func geminiSessionKey(input StageRequest) string {
 	key := strings.TrimSpace(input.StreamerID)
 	if key == "" {
@@ -326,12 +309,6 @@ func (c *GeminiStageClassifier) prepareSessionContents(sessionKey, promptFingerp
 	userTurn.Parts = append([]geminiPart{{Text: buildGeminiContinuationInstruction(input)}}, userTurn.Parts...)
 	c.sessionsMu.Unlock()
 	return []geminiContent{userTurn}
-}
-
-func (c *GeminiStageClassifier) resetSession(sessionKey string) {
-	c.sessionsMu.Lock()
-	defer c.sessionsMu.Unlock()
-	delete(c.sessions, strings.ToLower(strings.TrimSpace(sessionKey)))
 }
 
 func (c *GeminiStageClassifier) storeSessionResponse(sessionKey, promptFingerprint string, requestContents []geminiContent, payload geminiGenerateContentResponse, rawText string) {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -228,14 +228,14 @@ func TestGeminiStageClassifierRotatesChatWhenTokenBudgetReached(t *testing.T) {
 	}
 }
 
-func TestGeminiStageClassifierRecoversFromEmptyContinuationResponse(t *testing.T) {
+func TestGeminiStageClassifierDoesNotResetSessionOnEmptyContinuationResponse(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.mp4")
 	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
 		t.Fatalf("write chunk: %v", err)
 	}
 
-	requestBodies := make([]string, 0, 2)
+	requestBodies := make([]string, 0, 4)
 	requestCount := 0
 	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
 		APIKey:  "gemini-key",
@@ -304,9 +304,17 @@ func TestGeminiStageClassifierRecoversFromEmptyContinuationResponse(t *testing.T
 		t.Fatalf("first Classify() error = %v", err)
 	}
 	req.Chunk.CapturedAt = req.Chunk.CapturedAt.Add(10 * time.Second)
+	if _, err := classifier.Classify(context.Background(), req); err == nil {
+		t.Fatal("expected second Classify() to fail with empty response")
+	} else {
+		if !strings.Contains(err.Error(), ErrGeminiEmptyResponse.Error()) {
+			t.Fatalf("expected empty response error, got %v", err)
+		}
+	}
+	req.Chunk.CapturedAt = req.Chunk.CapturedAt.Add(10 * time.Second)
 	result, err := classifier.Classify(context.Background(), req)
 	if err != nil {
-		t.Fatalf("second Classify() error = %v", err)
+		t.Fatalf("third Classify() error = %v", err)
 	}
 	if result.FinalOutcome != "win" {
 		t.Fatalf("expected recovered outcome win, got %q", result.FinalOutcome)
@@ -317,8 +325,8 @@ func TestGeminiStageClassifierRecoversFromEmptyContinuationResponse(t *testing.T
 	if !strings.Contains(requestBodies[1], "Continue the existing match chat session.") {
 		t.Fatalf("expected second request to be continuation, got %s", requestBodies[1])
 	}
-	if !strings.Contains(requestBodies[2], "Use this admin-managed tracker prompt as the source of truth") {
-		t.Fatalf("expected third request to reset session and bootstrap prompt, got %s", requestBodies[2])
+	if !strings.Contains(requestBodies[2], "Continue the existing match chat session.") {
+		t.Fatalf("expected third request to keep existing chat session after empty response, got %s", requestBodies[2])
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Avoid silently resetting the Gemini chat session and retrying when the model returns an empty continuation response, so callers can handle empty-response failures explicitly.
- Improve diagnostics for empty Gemini responses by including request context in the returned error.

### Description

- Removed the automatic retry-and-reset logic in `GeminiStageClassifier.Classify`, so it no longer calls `resetSession` and retries on empty/response-recovery errors. 
- Eliminated the `isGeminiSessionRecoveryError` helper and the `resetSession` method since sessions are no longer auto-rotated on error.
- When the Gemini response contains no text, wrap the descriptive empty-response error with additional context including `stage`, `streamer_id`, `session_key`, `prompt_id`, and `force_bootstrap`.
- Updated unit test `TestGeminiStageClassifierRecoversFromEmptyContinuationResponse` (renamed to `TestGeminiStageClassifierDoesNotResetSessionOnEmptyContinuationResponse`) to assert that an empty continuation response surfaces an error and does not reset the existing session, and adjusted request expectations accordingly.

### Testing

- Ran `go test ./internal/media` with the updated tests and the modified `TestGeminiStageClassifierDoesNotResetSessionOnEmptyContinuationResponse` passed.
- Verified that chat-rotation behavior test `TestGeminiStageClassifierRotatesChatWhenTokenBudgetReached` continues to pass after the changes.
- No other automated test failures were observed when running the package tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2aecd56f0832ca5bdb7a2a9356868)