### PR TITLE
Improve Gemini empty-response diagnostics

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -230,6 +230,9 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 
 	parsed, err := parseGeminiStageResponse(rawText)
 	if err != nil {
+		if errors.Is(err, ErrGeminiEmptyResponse) {
+			return StageClassification{}, fmt.Errorf("%v; stage=%s streamer_id=%s session_key=%s prompt_id=%s raw_text=%s", err, strings.TrimSpace(input.Stage), strings.TrimSpace(input.StreamerID), sessionKey, strings.TrimSpace(input.Prompt.ID), strconv.Quote(trimForLog(rawText, 512)))
+		}
 		return StageClassification{}, err
 	}
 	parsed = normalizeGeminiTrackerResponse(input, parsed)
@@ -535,6 +538,14 @@ func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {
 		return geminiStageResponse{}, ErrGeminiEmptyResponse
 	}
 	return parsed, nil
+}
+
+func trimForLog(value string, max int) string {
+	trimmed := strings.TrimSpace(value)
+	if max <= 0 || len(trimmed) <= max {
+		return trimmed
+	}
+	return trimmed[:max] + "..."
 }
 
 func hasGeminiResponsePayload(parsed geminiStageResponse) bool {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -680,3 +680,56 @@ func TestGeminiStageClassifierReportsNoCandidatesInEmptyResponse(t *testing.T) {
 		t.Fatalf("expected candidates=0 diagnostic, got %v", err)
 	}
 }
+
+func TestGeminiStageClassifierReportsEmptyParsedPayloadDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+	                    "candidates": [{"content": {"parts": [{"text": "{}"}]}}]
+	                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	_, err = classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "Start",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt: prompts.PromptVersion{
+			ID:        "prompt-start",
+			Stage:     "Start",
+			Template:  "Update tracker state",
+			Model:     "gemini",
+			MaxTokens: 128,
+			TimeoutMS: 1000,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected parsed empty response diagnostics error")
+	}
+	for _, fragment := range []string{
+		ErrGeminiEmptyResponse.Error(),
+		"stage=Start",
+		"streamer_id=str-1",
+		"prompt_id=prompt-start",
+		`raw_text="{}"`,
+	} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("expected error to contain %q, got %v", fragment, err)
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- Make root-cause of `gemini returned empty response` errors actionable by distinguishing between truly empty API responses and responses that contain text which parses to an empty/insufficient payload.

### Description
- Add contextual diagnostics when a Gemini text candidate parses to an empty tracker payload by returning an error that includes `stage`, `streamer_id`, `session_key`, `prompt_id` and a bounded `raw_text` excerpt.
- Return the enhanced error only for parsed-empty payloads while preserving existing diagnostics for no-candidate / blocked responses.
- Add `trimForLog` helper to safely truncate raw response excerpts for inclusion in errors.
- Add a regression test `TestGeminiStageClassifierReportsEmptyParsedPayloadDiagnostics` asserting the new diagnostics are present when Gemini returns e.g. `text: "{}"`.

### Testing
- Ran targeted tests: `go test ./internal/media -run 'TestGeminiStageClassifierReports(EmptyResponseDiagnostics|NoCandidatesInEmptyResponse|EmptyParsedPayloadDiagnostics)|TestGeminiStageClassifierAllowsContinuationAfterEmptyResponse'` and the command succeeded.
- Ran package tests: `go test ./internal/media` and the suite passed.

Checklist (aligned with docs/implementation_plan.md M2.1)
- [x] Added detailed LLM empty-response diagnostics for parsed-empty payloads.
- [x] Added regression test covering parsed-empty Gemini responses.
- [ ] Implement auto-retry / forced session bootstrap on empty response as a behavior improvement.
- [ ] End-to-end validation of Streamlink → LLM → persistence with the scheduler enabled in staging.
- [ ] Full M2.1 integration tests for automatic worker start, 10s chunking, LLM dispatch, and live status publication.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b3ab4c9c832c879f204f66feb252)