### PR TITLE
Coerce legacy tracker state payloads into tracker 'state_updated' responses

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -228,7 +228,7 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 		return StageClassification{}, fmt.Errorf("%v; stage=%s streamer_id=%s session_key=%s prompt_id=%s force_bootstrap=%t", err, strings.TrimSpace(input.Stage), strings.TrimSpace(input.StreamerID), sessionKey, strings.TrimSpace(input.Prompt.ID), forceBootstrap)
 	}
 
-	parsed, err := parseGeminiStageResponse(rawText)
+	parsed, err := parseGeminiStageResponse(rawText, input.Stage)
 	if err != nil {
 		if errors.Is(err, ErrGeminiEmptyResponse) {
 			return StageClassification{}, fmt.Errorf("%v; stage=%s streamer_id=%s session_key=%s prompt_id=%s raw_text=%s", err, strings.TrimSpace(input.Stage), strings.TrimSpace(input.StreamerID), sessionKey, strings.TrimSpace(input.Prompt.ID), strconv.Quote(trimForLog(rawText, 512)))
@@ -499,7 +499,7 @@ func geminiBlockedSafetyCategories(ratings []geminiSafetyRating) []string {
 	return categories
 }
 
-func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {
+func parseGeminiStageResponse(raw string, stage string) (geminiStageResponse, error) {
 	cleaned := strings.TrimSpace(raw)
 	cleaned = strings.TrimPrefix(cleaned, "```json")
 	cleaned = strings.TrimPrefix(cleaned, "```")
@@ -535,6 +535,9 @@ func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {
 	parsed.HardConflicts = rawMessageFromGenericValue(generic["hard_conflicts"])
 	parsed.FinalOutcome = strings.TrimSpace(stringValue(generic["final_outcome"]))
 	if !hasGeminiResponsePayload(parsed) {
+		if coerced, ok := coerceTrackerStateObjectResponse(stage, generic); ok {
+			return coerced, nil
+		}
 		return geminiStageResponse{}, ErrGeminiEmptyResponse
 	}
 	return parsed, nil
@@ -550,6 +553,63 @@ func trimForLog(value string, max int) string {
 
 func hasGeminiResponsePayload(parsed geminiStageResponse) bool {
 	return strings.TrimSpace(parsed.Label) != "" || len(parsed.UpdatedState) > 0 || strings.TrimSpace(parsed.FinalOutcome) != ""
+}
+
+func coerceTrackerStateObjectResponse(stage string, payload map[string]any) (geminiStageResponse, bool) {
+	if !isTrackerStage(stage) || len(payload) == 0 {
+		return geminiStageResponse{}, false
+	}
+	if !looksLikeTrackerStatePayload(payload) {
+		return geminiStageResponse{}, false
+	}
+	confidence := confidenceFromGeneric(payload["confidence"])
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return geminiStageResponse{}, false
+	}
+	return geminiStageResponse{
+		Label:              "state_updated",
+		Confidence:         confidence,
+		UpdatedState:       json.RawMessage(body),
+		Delta:              json.RawMessage("[]"),
+		NextNeededEvidence: json.RawMessage("[]"),
+		HardConflicts:      json.RawMessage("[]"),
+		FinalOutcome:       "unknown",
+	}, true
+}
+
+func confidenceFromGeneric(value any) float64 {
+	switch typed := value.(type) {
+	case float64:
+		return typed
+	case string:
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(typed), 64)
+		if err == nil {
+			return parsed
+		}
+	}
+	return 0
+}
+
+func looksLikeTrackerStatePayload(payload map[string]any) bool {
+	for _, key := range []string{
+		"session_type",
+		"status",
+		"ct_score",
+		"t_score",
+		"mode",
+		"player_outcome",
+		"team_side",
+		"evidence_log",
+		"uncertainties",
+		"final_banner_seen",
+		"state",
+	} {
+		if _, ok := payload[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func rawMessageFromGenericValue(value any) json.RawMessage {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -601,6 +601,103 @@ func TestGeminiStageClassifierBackfillsTrackerStartPayloadWithNullFinalOutcome(t
 	}
 }
 
+func TestGeminiStageClassifierCoercesStartStatePayloadToUpdatedState(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"ct_score\":{\"confidence\":0,\"value\":0},\"evidence_log\":[],\"final_banner_seen\":{\"confidence\":0,\"value\":false},\"hard_conflicts\":[],\"mode\":{\"confidence\":0,\"value\":\"unknown\"},\"player_outcome\":{\"confidence\":0,\"value\":\"unknown\"},\"session_type\":\"single_match\",\"status\":\"discovering\",\"t_score\":{\"confidence\":0,\"value\":0},\"team_side\":{\"confidence\":0,\"value\":\"unknown\"},\"uncertainties\":[]}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	result, err := classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "Start",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt:     prompts.PromptVersion{Stage: "Start", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+	})
+	if err != nil {
+		t.Fatalf("expected start state payload coercion, got error %v", err)
+	}
+	if strings.TrimSpace(result.Label) != "state_updated" {
+		t.Fatalf("expected state_updated label, got %q", result.Label)
+	}
+	if !strings.Contains(result.UpdatedStateJSON, `"session_type":"single_match"`) {
+		t.Fatalf("expected updated_state to include legacy tracker state, got %q", result.UpdatedStateJSON)
+	}
+	if strings.TrimSpace(result.EvidenceDeltaJSON) != "[]" {
+		t.Fatalf("expected empty delta fallback, got %q", result.EvidenceDeltaJSON)
+	}
+	if strings.TrimSpace(result.NextEvidenceJSON) != "[]" {
+		t.Fatalf("expected empty next_needed_evidence fallback, got %q", result.NextEvidenceJSON)
+	}
+	if strings.TrimSpace(result.FinalOutcome) != "unknown" {
+		t.Fatalf("expected unknown final_outcome fallback, got %q", result.FinalOutcome)
+	}
+}
+
+func TestGeminiStageClassifierDoesNotCoerceNonTrackerStatePayload(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"status\":\"discovering\"}"}]}
+                    }]
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	_, err = classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "detector",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt: prompts.PromptVersion{
+			ID:        "prompt-detector",
+			Stage:     "detector",
+			Template:  "Detect scene",
+			Model:     "gemini",
+			MaxTokens: 128,
+			TimeoutMS: 1000,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), ErrGeminiEmptyResponse.Error()) {
+		t.Fatalf("expected empty response error for non-tracker stage, got %v", err)
+	}
+}
+
 func TestGeminiStageClassifierReportsEmptyResponseDiagnostics(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.mp4")


### PR DESCRIPTION
### Motivation
- Handle cases where Gemini returns a legacy tracker-style JSON object (tracker state fields at top-level) instead of the expected stage response schema for tracker stages.

### Description
- Changed `parseGeminiStageResponse` to accept the `stage` parameter and attempt coercion when the parsed JSON doesn't match the expected response schema.
- Added `coerceTrackerStateObjectResponse` which detects legacy tracker payloads, marshals the payload into `UpdatedState`, and fills fallback fields (`Label`="state_updated", `Delta`/`NextNeededEvidence`/`HardConflicts`=`[]`, `FinalOutcome`="unknown").
- Added helper functions `looksLikeTrackerStatePayload` and `confidenceFromGeneric` to detect tracker payload keys and extract numeric/string confidence values respectively.
- Updated the caller to pass the stage into `parseGeminiStageResponse` and keep existing behavior for non-tracker stages.
- Added unit tests covering coercion for `Start` tracker payloads and ensuring non-tracker stages are not coerced.

### Testing
- Ran unit tests in the media package including `TestGeminiStageClassifierCoercesStartStatePayloadToUpdatedState` and `TestGeminiStageClassifierDoesNotCoerceNonTrackerStatePayload` with `go test ./internal/media`, and they passed.
- Ran the existing `TestGeminiStageClassifierBackfillsTrackerStartPayloadWithNullFinalOutcome` which still passes to confirm null `final_outcome` normalization remains intact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b628d1d4832c93da55b2f3165cf4)