### PR TITLE
Probe video streams and apply centered square crop during TS->MP4 normalization

### DIFF
--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -32,6 +32,7 @@ type fakeCommandRunner struct {
 	names        []string
 	argsHistory  [][]string
 	runFn        func(name string, args ...string) error
+	runWithIOFn  func(stdout io.Writer, stderr io.Writer, name string, args ...string) error
 }
 
 func (f *fakeCommandRunner) Run(_ context.Context, stdout io.Writer, stderr io.Writer, name string, args ...string) error {
@@ -39,8 +40,15 @@ func (f *fakeCommandRunner) Run(_ context.Context, stdout io.Writer, stderr io.W
 	f.lastArgs = append([]string(nil), args...)
 	f.names = append(f.names, name)
 	f.argsHistory = append(f.argsHistory, append([]string(nil), args...))
+	if f.runWithIOFn != nil {
+		return f.runWithIOFn(stdout, stderr, name, args...)
+	}
 	if f.runFn != nil {
 		return f.runFn(name, args...)
+	}
+	if strings.Contains(name, "ffprobe") {
+		_, _ = io.WriteString(stdout, `{"streams":[{"codec_name":"h264","width":1920,"height":1080}]}`)
+		return nil
 	}
 	if strings.Contains(name, "ffmpeg") && len(args) > 0 {
 		outputPath := args[len(args)-1]
@@ -198,9 +206,17 @@ func TestFFmpegChunkNormalizerRemuxesTSChunksToMP4(t *testing.T) {
 	}
 
 	runner := &fakeCommandRunner{
-		runFn: func(name string, args ...string) error {
+		runWithIOFn: func(stdout io.Writer, _ io.Writer, name string, args ...string) error {
+			if name == "ffprobe-bin" {
+				_, _ = io.WriteString(stdout, `{"streams":[{"codec_name":"h264","width":1920,"height":1080}]}`)
+				return nil
+			}
 			if name != "ffmpeg-bin" {
 				t.Fatalf("runner binary = %q, want ffmpeg-bin", name)
+			}
+			joined := strings.Join(args, " ")
+			if !strings.Contains(joined, "-bsf:v") || !strings.Contains(joined, "h264_metadata=crop_left=420:crop_right=420:crop_top=0:crop_bottom=0") {
+				t.Fatalf("expected crop metadata bitstream filter args, got %q", joined)
 			}
 			if got := args[len(args)-1]; got != filepath.Join(dir, "chunk.mp4") {
 				t.Fatalf("output path = %q", got)

--- a/internal/media/normalize.go
+++ b/internal/media/normalize.go
@@ -1,7 +1,9 @@
 package media
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +20,7 @@ type ChunkNormalizer interface {
 
 type FFmpegChunkNormalizer struct {
 	binaryPath string
+	probePath  string
 	runner     StreamlinkCommandRunner
 }
 
@@ -26,10 +29,14 @@ func NewFFmpegChunkNormalizer(binaryPath string, runner StreamlinkCommandRunner)
 	if trimmed == "" {
 		trimmed = "ffmpeg"
 	}
+	probe := "ffprobe"
+	if strings.Contains(trimmed, "ffmpeg") {
+		probe = strings.Replace(trimmed, "ffmpeg", "ffprobe", 1)
+	}
 	if runner == nil {
 		runner = execStreamlinkRunner{}
 	}
-	return &FFmpegChunkNormalizer{binaryPath: trimmed, runner: runner}
+	return &FFmpegChunkNormalizer{binaryPath: trimmed, probePath: probe, runner: runner}
 }
 
 func (n *FFmpegChunkNormalizer) Normalize(ctx context.Context, chunk ChunkRef) (ChunkRef, error) {
@@ -44,18 +51,30 @@ func (n *FFmpegChunkNormalizer) Normalize(ctx context.Context, chunk ChunkRef) (
 		return chunk, nil
 	}
 
+	streamMeta, err := n.probeVideoStream(ctx, path)
+	if err != nil {
+		return ChunkRef{}, err
+	}
+	if streamMeta.CodecName != "h264" {
+		return ChunkRef{}, fmt.Errorf("%w: crop without re-encoding supports only h264 input, got %q", ErrChunkNormalizationFailed, streamMeta.CodecName)
+	}
+
 	outputPath := strings.TrimSuffix(path, filepath.Ext(path)) + ".mp4"
+	left, right, top, bottom := centeredSquareCropOffsets(streamMeta.Width, streamMeta.Height)
 	args := []string{
 		"-y",
 		"-i", path,
+		"-map", "0:v:0",
+		"-map", "0:a?",
 		"-c", "copy",
+		"-bsf:v", fmt.Sprintf("h264_metadata=crop_left=%d:crop_right=%d:crop_top=%d:crop_bottom=%d", left, right, top, bottom),
 		"-movflags", "+faststart",
 		outputPath,
 	}
 
 	var stderr strings.Builder
 	if err := n.runner.Run(ctx, io.Discard, &stderr, n.binaryPath, args...); err != nil {
-		return ChunkRef{}, fmt.Errorf("%w: remux %s -> %s: %v (stderr=%s)", ErrChunkNormalizationFailed, path, outputPath, err, strings.TrimSpace(stderr.String()))
+		return ChunkRef{}, fmt.Errorf("%w: normalize %s -> %s: %v (stderr=%s)", ErrChunkNormalizationFailed, path, outputPath, err, strings.TrimSpace(stderr.String()))
 	}
 
 	stat, err := os.Stat(outputPath)
@@ -71,4 +90,64 @@ func (n *FFmpegChunkNormalizer) Normalize(ctx context.Context, chunk ChunkRef) (
 
 	chunk.Reference = outputPath
 	return chunk, nil
+}
+
+type ffprobeStreamMeta struct {
+	CodecName string `json:"codec_name"`
+	Width     int    `json:"width"`
+	Height    int    `json:"height"`
+}
+
+type ffprobeOutput struct {
+	Streams []ffprobeStreamMeta `json:"streams"`
+}
+
+func (n *FFmpegChunkNormalizer) probeVideoStream(ctx context.Context, path string) (ffprobeStreamMeta, error) {
+	var stdout bytes.Buffer
+	var stderr strings.Builder
+	args := []string{
+		"-v", "error",
+		"-select_streams", "v:0",
+		"-show_entries", "stream=codec_name,width,height",
+		"-of", "json",
+		path,
+	}
+	if err := n.runner.Run(ctx, &stdout, &stderr, n.probePath, args...); err != nil {
+		return ffprobeStreamMeta{}, fmt.Errorf("%w: ffprobe %s: %v (stderr=%s)", ErrChunkNormalizationFailed, path, err, strings.TrimSpace(stderr.String()))
+	}
+	var parsed ffprobeOutput
+	if err := json.Unmarshal(stdout.Bytes(), &parsed); err != nil {
+		return ffprobeStreamMeta{}, fmt.Errorf("%w: parse ffprobe output: %v", ErrChunkNormalizationFailed, err)
+	}
+	if len(parsed.Streams) == 0 {
+		return ffprobeStreamMeta{}, fmt.Errorf("%w: ffprobe returned no video streams", ErrChunkNormalizationFailed)
+	}
+	meta := parsed.Streams[0]
+	if meta.Width <= 0 || meta.Height <= 0 {
+		return ffprobeStreamMeta{}, fmt.Errorf("%w: invalid dimensions %dx%d", ErrChunkNormalizationFailed, meta.Width, meta.Height)
+	}
+	return meta, nil
+}
+
+func centeredSquareCropOffsets(width, height int) (left, right, top, bottom int) {
+	if width <= 0 || height <= 0 || width == height {
+		return 0, 0, 0, 0
+	}
+	if width > height {
+		delta := width - height
+		left = delta / 2
+		right = delta - left
+		return roundDownToEven(left), roundDownToEven(right), 0, 0
+	}
+	delta := height - width
+	top = delta / 2
+	bottom = delta - top
+	return 0, 0, roundDownToEven(top), roundDownToEven(bottom)
+}
+
+func roundDownToEven(value int) int {
+	if value <= 0 {
+		return 0
+	}
+	return value - (value % 2)
 }


### PR DESCRIPTION
### Motivation
- Ensure TS chunks are remuxed to MP4 safely by probing the video stream first and only applying crop metadata for supported codecs.
- Compute a centered square crop when input is non-square to avoid re-encoding while preserving the main video area.

### Description
- Added `probePath` to `FFmpegChunkNormalizer` and detect `ffprobe` path based on the configured ffmpeg binary when creating the normalizer. 
- Implemented `probeVideoStream` that runs `ffprobe` via the runner, parses JSON output for `codec_name`, `width`, and `height`, and validates results.
- Added `centeredSquareCropOffsets` and `roundDownToEven` helpers to compute even crop offsets for centered square cropping, and verify input codec is `h264` before applying crop without re-encoding.
- Updated `Normalize` to probe the input, map video and optional audio streams, add `-bsf:v` `h264_metadata` crop metadata, improve error messages, and keep existing checks for output size and source removal.
- Extended the test fake runner with `runWithIOFn` to support providing `ffprobe` stdout, and updated `TestFFmpegChunkNormalizerRemuxesTSChunksToMP4` to expect `ffprobe` usage and assert the presence of the `-bsf:v` crop args.

### Testing
- Ran the package unit tests with `go test ./internal/media`, including `TestFFmpegChunkNormalizerRemuxesTSChunksToMP4` and related adapter tests. 
- All exercised tests in the `internal/media` package passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2bcc35cc4832cbcf55fe1e38d8028)