### PR TITLE
Refine tracker terminality logic and add close_current_session handling

### DIFF
--- a/docs/llm_stream_orchestration_plan.md
+++ b/docs/llm_stream_orchestration_plan.md
@@ -62,10 +62,14 @@ The LLM must behave as a **finite match state tracker**, not as a commentator.
 ### Canonical session state
 ```json
 {
-  "session_type": "single_match",
+  "session_type": "single_match_single_chat",
   "game": "cs2",
   "mode": "competitive | faceit | wingman | unknown",
-  "match_status": "in_progress | finished | interrupted | unknown",
+  "session_status": {
+    "value": "in_progress | likely_finished | confirmed_finished | likely_truncated | unknown",
+    "confidence": 0.0,
+    "reason": null
+  },
   "focus_player": {
     "name": null,
     "team_side": "CT | T | unknown",
@@ -75,39 +79,48 @@ The LLM must behave as a **finite match state tracker**, not as a commentator.
   "score_state": {
     "ct_score": null,
     "t_score": null,
-    "last_confirmed_from": "hud | scoreboard | endscreen | inferred | unknown",
+    "source": "hud | scoreboard | endscreen | inferred | unknown",
     "confidence": 0.0
   },
   "round_tracking": {
     "observed_round_wins_ct": 0,
     "observed_round_wins_t": 0,
     "observed_round_history": [],
-    "round_history_confidence": 0.0
+    "confidence": 0.0
   },
-  "final_evidence": {
-    "final_banner_seen": false,
-    "final_banner_text": null,
-    "final_scoreboard_seen": false,
-    "final_scoreboard_text": null,
-    "winner_side_confirmed": "CT | T | draw | unknown",
+  "winner_state": {
+    "winner_side": "CT | T | draw | unknown",
     "winner_team_label": "team_1 | team_2 | unknown",
+    "source": "final_banner | final_scoreboard | round_accumulation | unknown",
     "confidence": 0.0
   },
   "player_result": {
     "outcome": "win | loss | draw | unknown",
+    "confidence": 0.0,
     "reason": null,
-    "confidence": 0.0
+    "is_final": false
+  },
+  "terminal_evidence": {
+    "final_banner_seen": false,
+    "final_banner_text": null,
+    "final_scoreboard_seen": false,
+    "final_scoreboard_text": null,
+    "post_match_ui_seen": false,
+    "return_to_lobby_seen": false,
+    "strong_terminal_signals": [],
+    "weak_terminal_signals": []
   },
   "supporting_evidence": [],
   "open_uncertainties": [],
   "hard_conflicts": [],
   "next_needed_evidence": [
-    "final scoreboard",
-    "final banner",
-    "clear player team identification"
+    "clear final screen",
+    "clear final scoreboard",
+    "clear player team confirmation"
   ]
 }
 ```
+
 
 ### Practical runtime shape
 ```json
@@ -146,13 +159,13 @@ The LLM must behave as a **finite match state tracker**, not as a commentator.
 }
 ```
 
-## Update/finalize protocol
+## Update/close protocol
 
-### Update step
+### Update step (`match_update`)
 Each 10-second chunk produces one update request containing:
 - `previous_state`
 - `new_chunk.time_range`
-- structured observations (`observations`, `visible_hud_text`, `scoreboard_text`, `round_result_signals`, `team_identity_signals`, `final_screen_signals`)
+- structured observations (`observations`, `visible_hud_text`, `scoreboard_text`, `round_result_signals`, `team_identity_signals`, `final_screen_signals`, `post_match_signals`, `truncation_signals`)
 - active admin-managed rules and prompt version metadata
 
 Expected response shape:
@@ -163,52 +176,55 @@ Expected response shape:
     "score updated from 7-5 to 8-5"
   ],
   "next_needed_evidence": [
-    "final scoreboard",
-    "final banner"
+    "clear final scoreboard"
   ]
 }
 ```
 
-### Final step
-When the match ends or the stream segment is exhausted, the backend sends the accumulated state to a finalization prompt.
+### Session close step (`close_current_session`)
+When no more chunks are currently available and the reason is unknown, backend triggers `close_current_session`.
 
 Expected response shape:
 ```json
 {
-  "final_outcome": "win",
-  "final_score": {
-    "ct": 13,
-    "t": 10
+  "updated_state": {
+    "session_status": {
+      "value": "likely_truncated",
+      "confidence": 0.86,
+      "reason": "last chunk showed active gameplay without terminal UI"
+    },
+    "player_result": {
+      "outcome": "unknown",
+      "confidence": 0.0,
+      "reason": "match ending not confirmed",
+      "is_final": false
+    }
   },
-  "player_team": {
-    "team_side": "CT",
-    "team_label": "team_1"
-  },
-  "winner_team": {
-    "team_side": "CT",
-    "team_label": "team_1"
-  },
-  "confidence": 0.97,
-  "evidence": [
-    "Final scoreboard shows CT 13 - T 10",
-    "Focus player had been consistently identified as CT"
-  ],
-  "unresolved_issues": []
+  "final_outcome": "unknown"
 }
 ```
 
 ## Evidence-first decision rules
-The finalizer must use a strict priority cascade:
-1. Final banner / end screen.
-2. Final scoreboard.
-3. Clear late-match scoreboard.
-4. Accumulated round outcomes with high confidence.
-5. Otherwise `unknown`.
+Strong terminal signals can set `session_status=confirmed_finished`:
+1. explicit final banner / match end screen;
+2. explicit final scoreboard;
+3. explicit post-match UI / return to lobby after results;
+4. repeated strong terminal indicators across chunks.
+
+Weak signals can suggest `session_status=likely_finished`:
+- long scoreboard without new gameplay,
+- summary/MVP-like screens without explicit final banner,
+- menu transition without explicit winner confirmation.
+
+Truncation signals should prefer `session_status=likely_truncated`:
+- last chunk shows active gameplay,
+- no terminal UI and no post-match transition,
+- data ends abruptly.
 
 Additional hard rules:
 - Never infer `win` because the player "looked stronger".
-- If player side/team is not confirmed, keep `unknown`.
-- If the ending is cut off or interrupted, keep `unknown` unless final evidence was already captured.
+- If player side/team is not confirmed, keep `player_result.outcome=unknown`.
+- `player_result.is_final=true` only when `session_status=confirmed_finished` and winner/player-team evidence is strong.
 - Contradictions must be stored in `hard_conflicts`, not silently overwritten.
 
 ## Admin capabilities (backend requirements)

--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -356,10 +356,23 @@ Return ONLY valid JSON with keys: label, confidence, summary.
 	return strings.TrimSpace(fmt.Sprintf(base+`
 Previous persisted tracker state JSON:
 %s
-Update the tracker using previous_state + new_chunk for this 10-second window.
+
+You are a match state tracker for a single game session.
+
+Critical rule:
+The end of available video data is NOT the same as confirmed end of the match.
+
+Track two independent fields:
+- player_result.outcome = win | loss | draw | unknown
+- session_status.value = in_progress | likely_finished | confirmed_finished | likely_truncated | unknown
+
+Stage-specific behavior:
+- For match_update: update cumulative state using previous_state + new_chunk.
+- For close_current_session or match_finalize: no more chunks are currently available; do NOT assume the match finished and choose closure status only from accumulated evidence.
+
 Return ONLY valid JSON with this exact shape:
 {
-  "label": "state_updated | finalized | unknown",
+  "label": "state_updated | closure_evaluated | unknown",
   "confidence": 0.0,
   "updated_state": {},
   "delta": [],
@@ -367,12 +380,16 @@ Return ONLY valid JSON with this exact shape:
   "hard_conflicts": [],
   "final_outcome": "win | loss | draw | unknown"
 }
-Rules:
-- Treat one chat/session as one match.
-- Always update and return compact state JSON in updated_state.
-- Never emit narrative commentary outside JSON.
-- Keep final_outcome as unknown until direct evidence exists.
-- Store contradictions in hard_conflicts instead of overwriting prior facts.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.RuleSet), previousState))
+
+Mandatory rules:
+1. Never infer match completion only because no more chunks are currently available.
+2. Never infer player victory/defeat from gameplay quality.
+3. Treat final outcome as validated ONLY when strong terminal evidence exists (final banner, final scoreboard, explicit post-match UI, or repeated strong terminal signals).
+4. If completion is not confirmed, keep player_result.is_final=false and final_outcome=unknown.
+5. If chunk stream appears cut during active gameplay, prefer session_status=likely_truncated.
+6. Preserve previously confirmed evidence unless clearly contradicted.
+7. Store contradictions in hard_conflicts instead of silently overwriting facts.
+8. Never emit narrative commentary outside JSON.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.RuleSet), previousState))
 }
 
 func buildGeminiContinuationInstruction(input StageRequest) string {
@@ -595,10 +612,12 @@ func looksLikeTrackerStatePayload(payload map[string]any) bool {
 	for _, key := range []string{
 		"session_type",
 		"status",
+		"session_status",
 		"ct_score",
 		"t_score",
 		"mode",
 		"player_outcome",
+		"player_result",
 		"team_side",
 		"evidence_log",
 		"uncertainties",
@@ -696,7 +715,7 @@ func normalizeGeminiTrackerResponse(input StageRequest, parsed geminiStageRespon
 
 func isTrackerStartStage(stage string) bool {
 	switch strings.TrimSpace(strings.ToLower(stage)) {
-	case trackerStageDiscovery, "start", "discovery":
+	case trackerStageDiscovery, "start", "discovery", "bootstrap", "initialize":
 		return true
 	default:
 		return false

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -40,6 +40,7 @@ const (
 	trackerStageDiscovery = "match_discovery"
 	trackerStageUpdate    = "match_update"
 	trackerStageFinalize  = "match_finalize"
+	trackerStageClose     = "close_current_session"
 )
 
 type StageClassification struct {
@@ -258,7 +259,7 @@ func filterTrackerPrompts(items []prompts.PromptVersion) []prompts.PromptVersion
 
 func isTrackerStage(stage string) bool {
 	switch strings.TrimSpace(strings.ToLower(stage)) {
-	case trackerStageDiscovery, trackerStageUpdate, trackerStageFinalize, "start", "update", "finalize", "finish", "end":
+	case trackerStageDiscovery, trackerStageUpdate, trackerStageFinalize, trackerStageClose, "start", "update", "finalize", "finish", "end", "close":
 		return true
 	default:
 		return false
@@ -266,7 +267,7 @@ func isTrackerStage(stage string) bool {
 }
 
 func defaultTrackerState() string {
-	return `{"session_type":"single_match","status":"discovering","player_outcome":{"value":"unknown","confidence":0},"evidence_log":[],"uncertainties":[],"hard_conflicts":[]}`
+	return `{"session_type":"single_match_single_chat","game":"cs2","mode":"unknown","session_status":{"value":"unknown","confidence":0,"reason":null},"focus_player":{"name":null,"team_side":"unknown","team_label":"unknown","confidence":0},"score_state":{"ct_score":null,"t_score":null,"source":"unknown","confidence":0},"round_tracking":{"observed_round_wins_ct":0,"observed_round_wins_t":0,"observed_round_history":[],"confidence":0},"winner_state":{"winner_side":"unknown","winner_team_label":"unknown","source":"unknown","confidence":0},"player_result":{"outcome":"unknown","confidence":0,"reason":"match ending not confirmed","is_final":false},"terminal_evidence":{"final_banner_seen":false,"final_banner_text":null,"final_scoreboard_seen":false,"final_scoreboard_text":null,"post_match_ui_seen":false,"return_to_lobby_seen":false,"strong_terminal_signals":[],"weak_terminal_signals":[]},"supporting_evidence":[],"open_uncertainties":[],"hard_conflicts":[],"next_needed_evidence":["clear final screen","clear final scoreboard","clear player team confirmation"]}`
 }
 
 func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (ChunkRef, error) {


### PR DESCRIPTION
### Motivation
- Prevent treating the end of available video data as a guaranteed match end and avoid forced final `win|loss` outcomes when terminal evidence is missing.
- Introduce an explicit session-closure step so the worker can evaluate closure of the observation window separately from match finalization.
- Align runtime and prompts with the updated two-axis decision model: independent `session_status` and `player_result` fields.

### Description
- Update tracker bootstrap state via `defaultTrackerState` to the new contract with `session_status`, `player_result.is_final`, `terminal_evidence`, `winner_state` and other cumulative fields (`internal/media/worker.go`).
- Add `close_current_session` as a recognized tracker stage constant and include it in `isTrackerStage` so prompts can run a dedicated closure evaluation (`internal/media/worker.go`).
- Rewrite the Gemini tracker instruction in `buildGeminiInstruction` to enforce the rule "end of data != end of match", to require separate `session_status` handling, and to mandate that `final_outcome` only be considered final with strong terminal evidence (`internal/media/gemini.go`).
- Extend payload heuristics and start-stage aliases to recognize new state keys (`session_status`, `player_result`) and bootstrap variants (`bootstrap`, `initialize`), and update docs to document the `match_update` + `close_current_session` protocol (`internal/media/gemini.go`, `docs/llm_stream_orchestration_plan.md`).

### Testing
- Ran `go test ./internal/media ./internal/prompts ./internal/streamers` and all targeted package tests passed.
- Ran full test suite `go test ./...` and the repository tests passed (status: `ok`).
- No runtime or linter failures were introduced by these changes according to the test output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d1705b64832cb48652d143254ef2)