### PR TITLE
Add initialStateJson to state schemas and handle stream-end tracker close

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1398,7 +1398,10 @@ components:
           type: boolean
     StateSchemaCreateRequest:
       type: object
-      required: [gameSlug, name, fields]
+      required: [gameSlug, name]
+      description: >
+        Admin-managed tracker schema definition. At least one of `fields` or
+        `initialStateJson` must be provided.
       properties:
         gameSlug:
           type: string
@@ -1410,6 +1413,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StateFieldDefinition'
+        initialStateJson:
+          type: string
+          description: >
+            Full JSON object (stringified) used as bootstrap state for tracker
+            sessions when no persisted previous state exists.
+      anyOf:
+        - required: [fields]
+        - required: [initialStateJson]
     StateSchemaVersion:
       allOf:
         - $ref: '#/components/schemas/StateSchemaCreateRequest'

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -70,7 +70,7 @@ func stateSchemaRequestToCreateRequest(req stateSchemaCreateRequest, actorID str
 			FinalOnly:          field.FinalOnly,
 		})
 	}
-	return prompts.StateSchemaCreateRequest{GameSlug: req.GameSlug, Name: req.Name, Description: req.Description, Fields: fields, ActorID: actorID}
+	return prompts.StateSchemaCreateRequest{GameSlug: req.GameSlug, Name: req.Name, Description: req.Description, Fields: fields, InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), ActorID: actorID}
 }
 
 func ruleSetRequestToCreateRequest(req ruleSetCreateRequest, actorID string) prompts.RuleSetCreateRequest {
@@ -153,10 +153,11 @@ type stateFieldRequest struct {
 }
 
 type stateSchemaCreateRequest struct {
-	GameSlug    string              `json:"gameSlug"`
-	Name        string              `json:"name"`
-	Description string              `json:"description"`
-	Fields      []stateFieldRequest `json:"fields"`
+	GameSlug         string              `json:"gameSlug"`
+	Name             string              `json:"name"`
+	Description      string              `json:"description"`
+	Fields           []stateFieldRequest `json:"fields"`
+	InitialStateJSON string              `json:"initialStateJson"`
 }
 
 type ruleItemRequest struct {

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -44,6 +44,18 @@ func TestAdminLLMStateSchemaAndRuleSetRoutes(t *testing.T) {
 	if stateRes.Code != http.StatusCreated {
 		t.Fatalf("state schema create status = %d body=%s", stateRes.Code, stateRes.Body.String())
 	}
+	stateSchemaBodyWithInitialState, _ := json.Marshal(map[string]any{
+		"gameSlug": "cs2",
+		"name":     "CS2 tracker with initial state",
+		"initialStateJson": `{"session_type":"single_match_single_chat","game":"cs2","session_status":{"value":"unknown"}}`,
+	})
+	stateInitialReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/state-schemas", bytes.NewReader(stateSchemaBodyWithInitialState))
+	stateInitialReq.Header.Set("Authorization", "Bearer "+adminToken)
+	stateInitialRes := httptest.NewRecorder()
+	handler.ServeHTTP(stateInitialRes, stateInitialReq)
+	if stateInitialRes.Code != http.StatusCreated {
+		t.Fatalf("state schema with initial state create status = %d body=%s", stateInitialRes.Code, stateInitialRes.Body.String())
+	}
 
 	ruleBody, _ := json.Marshal(map[string]any{
 		"gameSlug":          "cs2",

--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -156,21 +156,27 @@ func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest
 
 func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest, forceBootstrap bool) (StageClassification, error) {
 	chunkRef := strings.TrimSpace(input.Chunk.Reference)
-	if chunkRef == "" {
+	hasChunk := chunkRef != ""
+	var (
+		data     []byte
+		mimeType string
+		err      error
+	)
+	if hasChunk {
+		data, mimeType, err = loadGeminiChunk(chunkRef, c.maxInlineBytes)
+		if err != nil {
+			return StageClassification{}, err
+		}
+		if err := validateGeminiMIMEType(mimeType); err != nil {
+			return StageClassification{}, err
+		}
+	} else if !allowsEmptyChunk(input.Stage) {
 		return StageClassification{}, ErrGeminiChunkRequired
-	}
-	data, mimeType, err := loadGeminiChunk(chunkRef, c.maxInlineBytes)
-	if err != nil {
-		return StageClassification{}, err
-	}
-
-	if err := validateGeminiMIMEType(mimeType); err != nil {
-		return StageClassification{}, err
 	}
 
 	sessionKey := geminiSessionKey(input)
 	promptFingerprint := geminiPromptFingerprint(input)
-	contents := c.prepareSessionContents(sessionKey, promptFingerprint, input, mimeType, data, forceBootstrap)
+	contents := c.prepareSessionContents(sessionKey, promptFingerprint, input, mimeType, data, forceBootstrap, hasChunk)
 
 	requestBody := geminiGenerateContentRequest{
 		Contents: contents,
@@ -290,12 +296,10 @@ func geminiPromptFingerprint(input StageRequest) string {
 	}, "|")
 }
 
-func (c *GeminiStageClassifier) prepareSessionContents(sessionKey, promptFingerprint string, input StageRequest, mimeType string, chunk []byte, forceBootstrap bool) []geminiContent {
-	userTurn := geminiContent{
-		Role: "user",
-		Parts: []geminiPart{
-			{InlineData: &geminiInlineData{MimeType: mimeType, Data: base64.StdEncoding.EncodeToString(chunk)}},
-		},
+func (c *GeminiStageClassifier) prepareSessionContents(sessionKey, promptFingerprint string, input StageRequest, mimeType string, chunk []byte, forceBootstrap bool, hasChunk bool) []geminiContent {
+	userTurn := geminiContent{Role: "user"}
+	if hasChunk {
+		userTurn.Parts = append(userTurn.Parts, geminiPart{InlineData: &geminiInlineData{MimeType: mimeType, Data: base64.StdEncoding.EncodeToString(chunk)}})
 	}
 	c.sessionsMu.Lock()
 	session, hasSession := c.sessions[sessionKey]
@@ -351,7 +355,7 @@ Active rule set:
 Return ONLY valid JSON with keys: label, confidence, summary.
 - label: short snake_case decision for this stage.
 - confidence: number between 0 and 1.
-- summary: short rationale.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.RuleSet)))
+- summary: short rationale.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.RuleSet)))
 	}
 	return strings.TrimSpace(fmt.Sprintf(base+`
 Previous persisted tracker state JSON:
@@ -389,7 +393,7 @@ Mandatory rules:
 5. If chunk stream appears cut during active gameplay, prefer session_status=likely_truncated.
 6. Preserve previously confirmed evidence unless clearly contradicted.
 7. Store contradictions in hard_conflicts instead of silently overwriting facts.
-8. Never emit narrative commentary outside JSON.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.RuleSet), previousState))
+8. Never emit narrative commentary outside JSON.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.RuleSet), previousState))
 }
 
 func buildGeminiContinuationInstruction(input StageRequest) string {
@@ -404,7 +408,30 @@ Chunk captured at: %s
 Chunk reference: %s
 Previous persisted tracker state JSON:
 %s
-Return ONLY valid JSON using the same schema as before.`, input.Stage, strings.TrimSpace(input.StreamerID), input.Chunk.CapturedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(input.Chunk.Reference), previousState))
+Return ONLY valid JSON using the same schema as before.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), previousState))
+}
+
+func allowsEmptyChunk(stage string) bool {
+	switch strings.TrimSpace(strings.ToLower(stage)) {
+	case trackerStageClose, trackerStageFinalize:
+		return true
+	default:
+		return false
+	}
+}
+
+func formatChunkReference(ref string) string {
+	if strings.TrimSpace(ref) == "" {
+		return "n/a"
+	}
+	return strings.TrimSpace(ref)
+}
+
+func formatChunkCapturedAt(ts time.Time) string {
+	if ts.IsZero() {
+		return "n/a"
+	}
+	return ts.UTC().Format(time.RFC3339Nano)
 }
 
 func loadGeminiChunk(path string, maxBytes int64) ([]byte, string, error) {

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -183,8 +183,15 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 		}
 		if errors.Is(err, ErrStreamlinkStreamEnded) {
 			logger.Info("stream chunk capture skipped because stream has ended or is unavailable", zap.String("streamerID", id), zap.Error(err))
+			decision, closeErr := w.processCloseCurrentSession(ctx, id)
+			if closeErr != nil {
+				logger.Error("close_current_session processing failed", zap.String("streamerID", id), zap.Error(closeErr))
+				w.metrics.recordFailure(ctx, id, trackerStageClose)
+				w.metrics.recordCycle(ctx, id, "failed")
+				return streamers.LLMDecision{}, closeErr
+			}
 			w.metrics.recordCycle(ctx, id, "stream_unavailable")
-			return streamers.LLMDecision{}, nil
+			return decision, nil
 		}
 		logger.Error("stream chunk capture failed", zap.String("streamerID", id), zap.Error(err))
 		w.metrics.recordFailure(ctx, id, "capture")
@@ -212,6 +219,25 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 	w.metrics.recordCycle(ctx, id, "completed")
 	logger.Info("streamer processing cycle completed", zap.String("streamerID", id), zap.String("runID", runID), zap.String("finalStage", lastDecision.Stage), zap.String("finalLabel", lastDecision.Label), zap.Float64("finalConfidence", lastDecision.Confidence))
 	return lastDecision, nil
+}
+
+func (w *Worker) processCloseCurrentSession(ctx context.Context, streamerID string) (streamers.LLMDecision, error) {
+	activePrompts := filterTrackerPrompts(w.prompts.ListActive(ctx))
+	var closePrompt prompts.PromptVersion
+	for _, item := range activePrompts {
+		if strings.EqualFold(strings.TrimSpace(item.Stage), trackerStageClose) {
+			closePrompt = item
+			break
+		}
+	}
+	if strings.TrimSpace(closePrompt.Stage) == "" {
+		return streamers.LLMDecision{}, nil
+	}
+	runID, err := w.runs.CreateRun(ctx, streamerID)
+	if err != nil {
+		return streamers.LLMDecision{}, err
+	}
+	return w.processStage(ctx, runID, streamerID, ChunkRef{CapturedAt: time.Now().UTC()}, closePrompt)
 }
 
 func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID string, chunk ChunkRef) (streamers.LLMDecision, error) {
@@ -361,7 +387,22 @@ func (w *Worker) resolvePreviousState(ctx context.Context, streamerID string) st
 			return state
 		}
 	}
+	if initial := strings.TrimSpace(w.resolveInitialTrackerState(ctx)); initial != "" {
+		return initial
+	}
 	return defaultTrackerState()
+}
+
+func (w *Worker) resolveInitialTrackerState(ctx context.Context) string {
+	const gameSlug = "cs2"
+	if resolver, ok := w.prompts.(activeStateSchemaResolver); ok {
+		if item, err := resolver.GetActiveStateSchema(ctx, gameSlug); err == nil {
+			if state := strings.TrimSpace(item.InitialStateJSON); state != "" && state != "{}" {
+				return state
+			}
+		}
+	}
+	return ""
 }
 
 func normalizeDecisionLabel(result StageClassification, updatedStateJSON string) string {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -40,12 +40,23 @@ func (f fakeClassifier) Classify(_ context.Context, input StageRequest) (StageCl
 	return StageClassification{}, nil
 }
 
-type fakePromptResolver struct{ prompts []prompts.PromptVersion }
+type fakePromptResolver struct {
+	prompts      []prompts.PromptVersion
+	activeSchema prompts.StateSchemaVersion
+	schemaErr    error
+}
 
 func (f fakePromptResolver) ListActive(_ context.Context) []prompts.PromptVersion {
 	out := make([]prompts.PromptVersion, len(f.prompts))
 	copy(out, f.prompts)
 	return out
+}
+
+func (f fakePromptResolver) GetActiveStateSchema(_ context.Context, _ string) (prompts.StateSchemaVersion, error) {
+	if f.schemaErr != nil {
+		return prompts.StateSchemaVersion{}, f.schemaErr
+	}
+	return f.activeSchema, nil
 }
 
 type fakeDecisionStore struct {
@@ -303,6 +314,30 @@ func TestWorkerProcessStreamerSkipsEndedStreamWithoutFailingCycle(t *testing.T) 
 	}
 }
 
+func TestWorkerProcessStreamerRunsCloseCurrentSessionWhenStreamEnds(t *testing.T) {
+	decisions := &fakeDecisionStore{}
+	worker := NewWorker(
+		fakeCapture{err: ErrStreamlinkStreamEnded},
+		fakeClassifier{results: map[string]StageClassification{"close_current_session": {Label: "closure_evaluated", Confidence: 0.95, UpdatedStateJSON: `{"session_status":{"value":"likely_truncated"}}`}}},
+		fakePromptResolver{prompts: []prompts.PromptVersion{{ID: "close-1", Stage: "close_current_session", Position: 1, IsActive: true, Template: "close session state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}}},
+		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
+	)
+
+	got, err := worker.ProcessStreamer(context.Background(), "str-ended")
+	if err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got.Stage != "close_current_session" {
+		t.Fatalf("stage = %q, want close_current_session", got.Stage)
+	}
+	if len(decisions.items) != 1 {
+		t.Fatalf("recorded %d decisions, want 1", len(decisions.items))
+	}
+	if decisions.items[0].ChunkRef != "" {
+		t.Fatalf("chunkRef = %q, want empty for close_current_session", decisions.items[0].ChunkRef)
+	}
+}
+
 func TestWorkerProcessStreamerStillRunsWithoutLegacyScenarioResolver(t *testing.T) {
 	decisions := &fakeDecisionStore{}
 	worker := NewWorker(
@@ -345,6 +380,29 @@ func TestWorkerProcessStreamerPassesPersistedPreviousStateToTrackerStages(t *tes
 	}
 	if !strings.Contains(decisions.items[1].PreviousStateJSON, `"score":{"ct":8,"t":5}`) {
 		t.Fatalf("previous state = %q", decisions.items[1].PreviousStateJSON)
+	}
+}
+
+func TestWorkerProcessStreamerUsesAdminProvidedInitialState(t *testing.T) {
+	decisions := &fakeDecisionStore{}
+	classifier := &flakyClassifier{result: StageClassification{Label: "state_updated", Confidence: 0.95, UpdatedStateJSON: `{"score_state":{"ct_score":1,"t_score":0}}`}}
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		classifier,
+		fakePromptResolver{
+			prompts:      []prompts.PromptVersion{{ID: "tracker-1", Stage: "match_update", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}},
+			activeSchema: prompts.StateSchemaVersion{InitialStateJSON: `{"session_status":{"value":"in_progress"},"score_state":{"ct_score":0,"t_score":0}}`},
+		},
+		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
+	)
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if len(decisions.items) != 1 {
+		t.Fatalf("recorded %d decisions, want 1", len(decisions.items))
+	}
+	if !strings.Contains(decisions.items[0].PreviousStateJSON, `"session_status":{"value":"in_progress"}`) {
+		t.Fatalf("previous state = %q", decisions.items[0].PreviousStateJSON)
 	}
 }
 

--- a/internal/prompts/postgres_service.go
+++ b/internal/prompts/postgres_service.go
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS llm_state_schema_versions (
     description TEXT NOT NULL DEFAULT '',
     version INTEGER NOT NULL,
     fields_json JSONB NOT NULL,
+    initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb,
     is_active BOOLEAN NOT NULL DEFAULT FALSE,
     created_by TEXT NOT NULL,
     activated_by TEXT NOT NULL DEFAULT '',
@@ -101,6 +102,9 @@ func (s *Service) ensureSchema(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, trackerConfigDDL); err != nil {
 		return fmt.Errorf("ensure tracker config schema: %w", err)
 	}
+	if _, err := s.db.ExecContext(ctx, `ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`); err != nil {
+		return fmt.Errorf("ensure llm_state_schema_versions.initial_state_json: %w", err)
+	}
 	s.schemaReady = true
 	return nil
 }
@@ -141,13 +145,15 @@ func scanPrompt(row scanner) (PromptVersion, error) {
 func scanStateSchema(row scanner) (StateSchemaVersion, error) {
 	var item StateSchemaVersion
 	var fields []byte
+	var initialState []byte
 	var activatedAt sql.NullTime
-	if err := row.Scan(&item.ID, &item.GameSlug, &item.Name, &item.Description, &item.Version, &fields, &item.IsActive, &item.CreatedBy, &item.ActivatedBy, &item.CreatedAt, &activatedAt); err != nil {
+	if err := row.Scan(&item.ID, &item.GameSlug, &item.Name, &item.Description, &item.Version, &fields, &initialState, &item.IsActive, &item.CreatedBy, &item.ActivatedBy, &item.CreatedAt, &activatedAt); err != nil {
 		return StateSchemaVersion{}, err
 	}
 	if err := json.Unmarshal(fields, &item.Fields); err != nil {
 		return StateSchemaVersion{}, err
 	}
+	item.InitialStateJSON = strings.TrimSpace(string(initialState))
 	if activatedAt.Valid {
 		item.ActivatedAt = activatedAt.Time
 	}
@@ -329,7 +335,7 @@ func (s *Service) listStateSchemasDB(ctx context.Context) ([]StateSchemaVersion,
 	if err := s.ensureSchema(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -370,13 +376,17 @@ func (s *Service) createStateSchemaDB(ctx context.Context, req StateSchemaCreate
 		return StateSchemaVersion{}, err
 	}
 	now := time.Now().UTC()
-	item := StateSchemaVersion{ID: "state-schema-" + uuid.NewString(), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: version, Fields: append([]StateFieldDefinition(nil), req.Fields...), IsActive: existing == 0, CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	item := StateSchemaVersion{ID: "state-schema-" + uuid.NewString(), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: version, Fields: append([]StateFieldDefinition(nil), req.Fields...), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), IsActive: existing == 0, CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
 	if item.IsActive {
 		item.ActivatedBy = item.CreatedBy
 		item.ActivatedAt = now
 	}
-	_, err = tx.ExecContext(ctx, `INSERT INTO llm_state_schema_versions (id, game_slug, name, description, version, fields_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
-		item.ID, item.GameSlug, item.Name, item.Description, item.Version, fieldsJSON, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt))
+	initialStateRaw := strings.TrimSpace(req.InitialStateJSON)
+	if initialStateRaw == "" {
+		initialStateRaw = "{}"
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO llm_state_schema_versions (id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9,$10,$11,$12)`,
+		item.ID, item.GameSlug, item.Name, item.Description, item.Version, fieldsJSON, initialStateRaw, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt))
 	if err != nil {
 		return StateSchemaVersion{}, err
 	}
@@ -390,7 +400,7 @@ func (s *Service) getStateSchemaDB(ctx context.Context, id string) (StateSchemaV
 	if err := s.ensureSchema(ctx); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE id = $1`, strings.TrimSpace(id)))
+	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE id = $1`, strings.TrimSpace(id)))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return StateSchemaVersion{}, ErrStateSchemaNotFound
@@ -411,8 +421,12 @@ func (s *Service) updateStateSchemaDB(ctx context.Context, id string, req StateS
 	if err != nil {
 		return StateSchemaVersion{}, err
 	}
-	row := s.db.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET game_slug = $2, name = $3, description = $4, fields_json = $5 WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, is_active, created_by, activated_by, created_at, activated_at`,
-		strings.TrimSpace(id), strings.TrimSpace(req.GameSlug), strings.TrimSpace(req.Name), strings.TrimSpace(req.Description), fieldsJSON)
+	initialStateRaw := strings.TrimSpace(req.InitialStateJSON)
+	if initialStateRaw == "" {
+		initialStateRaw = "{}"
+	}
+	row := s.db.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET game_slug = $2, name = $3, description = $4, fields_json = $5, initial_state_json = $6::jsonb WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
+		strings.TrimSpace(id), strings.TrimSpace(req.GameSlug), strings.TrimSpace(req.Name), strings.TrimSpace(req.Description), fieldsJSON, initialStateRaw)
 	item, err := scanStateSchema(row)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -470,7 +484,7 @@ func (s *Service) activateStateSchemaDB(ctx context.Context, id, actorID string)
 	if _, err := tx.ExecContext(ctx, `UPDATE llm_state_schema_versions SET is_active = FALSE WHERE game_slug = $1`, gameSlug); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(tx.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, is_active, created_by, activated_by, created_at, activated_at`,
+	item, err := scanStateSchema(tx.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
 		strings.TrimSpace(id), strings.TrimSpace(actorID), time.Now().UTC()))
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -488,7 +502,7 @@ func (s *Service) getActiveStateSchemaDB(ctx context.Context, gameSlug string) (
 	if err := s.ensureSchema(ctx); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, strings.TrimSpace(gameSlug)))
+	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, strings.TrimSpace(gameSlug)))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return StateSchemaVersion{}, ErrStateSchemaNotFound

--- a/internal/prompts/postgres_service_test.go
+++ b/internal/prompts/postgres_service_test.go
@@ -18,6 +18,7 @@ func TestPostgresServiceCreatePrompt(t *testing.T) {
 
 	svc := NewPostgresService(db)
 	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectBegin()
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(version), 0) + 1 FROM llm_prompt_versions WHERE stage = $1`)).
 		WithArgs("match_update").
@@ -64,9 +65,10 @@ func TestPostgresServiceListStateSchemas(t *testing.T) {
 	svc := NewPostgresService(db)
 	now := time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)
 	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, fields_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "fields_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
-			AddRow("state-schema-1", "cs2", "Schema", "", 1, `[{"key":"score.ct","type":"number"}]`, true, "admin-1", "admin-1", now, now))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "fields_json", "initial_state_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
+			AddRow("state-schema-1", "cs2", "Schema", "", 1, `[{"key":"score.ct","type":"number"}]`, `{"session_status":{"value":"unknown"}}`, true, "admin-1", "admin-1", now, now))
 
 	items := svc.ListStateSchemas(context.Background())
 	if len(items) != 1 || items[0].GameSlug != "cs2" {
@@ -87,6 +89,7 @@ func TestPostgresServiceGetActiveRuleSet(t *testing.T) {
 	svc := NewPostgresService(db)
 	now := time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)
 	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, rule_items_json, finalization_rules_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_rule_set_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`)).
 		WithArgs("cs2").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "rule_items_json", "finalization_rules_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).

--- a/internal/prompts/tracker_config.go
+++ b/internal/prompts/tracker_config.go
@@ -2,6 +2,7 @@ package prompts
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -15,6 +16,7 @@ var (
 	ErrInvalidStateSchemaName    = errors.New("state schema name must not be empty")
 	ErrInvalidStateFieldKey      = errors.New("state field key must not be empty")
 	ErrInvalidStateFieldType     = errors.New("state field type must not be empty")
+	ErrInvalidInitialStateJSON   = errors.New("initialStateJson must be a valid JSON object")
 	ErrStateSchemaNotFound       = errors.New("state schema not found")
 	ErrInvalidRuleSetName        = errors.New("rule set name must not be empty")
 	ErrInvalidRuleFieldKey       = errors.New("rule item fieldKey must not be empty")
@@ -38,25 +40,27 @@ type StateFieldDefinition struct {
 }
 
 type StateSchemaCreateRequest struct {
-	GameSlug    string
-	Name        string
-	Description string
-	Fields      []StateFieldDefinition
-	ActorID     string
+	GameSlug         string
+	Name             string
+	Description      string
+	Fields           []StateFieldDefinition
+	InitialStateJSON string
+	ActorID          string
 }
 
 type StateSchemaVersion struct {
-	ID          string                 `json:"id"`
-	GameSlug    string                 `json:"gameSlug"`
-	Name        string                 `json:"name"`
-	Description string                 `json:"description,omitempty"`
-	Version     int                    `json:"version"`
-	Fields      []StateFieldDefinition `json:"fields"`
-	IsActive    bool                   `json:"isActive"`
-	CreatedBy   string                 `json:"createdBy"`
-	ActivatedBy string                 `json:"activatedBy,omitempty"`
-	CreatedAt   time.Time              `json:"createdAt"`
-	ActivatedAt time.Time              `json:"activatedAt,omitempty"`
+	ID               string                 `json:"id"`
+	GameSlug         string                 `json:"gameSlug"`
+	Name             string                 `json:"name"`
+	Description      string                 `json:"description,omitempty"`
+	Version          int                    `json:"version"`
+	Fields           []StateFieldDefinition `json:"fields"`
+	InitialStateJSON string                 `json:"initialStateJson,omitempty"`
+	IsActive         bool                   `json:"isActive"`
+	CreatedBy        string                 `json:"createdBy"`
+	ActivatedBy      string                 `json:"activatedBy,omitempty"`
+	CreatedAt        time.Time              `json:"createdAt"`
+	ActivatedAt      time.Time              `json:"activatedAt,omitempty"`
 }
 
 type RuleItem struct {
@@ -107,7 +111,7 @@ func ValidateStateSchemaCreateRequest(req StateSchemaCreateRequest) error {
 	if strings.TrimSpace(req.Name) == "" {
 		return ErrInvalidStateSchemaName
 	}
-	if len(req.Fields) == 0 {
+	if len(req.Fields) == 0 && strings.TrimSpace(req.InitialStateJSON) == "" {
 		return ErrInvalidStateFieldKey
 	}
 	seen := map[string]struct{}{}
@@ -123,6 +127,12 @@ func ValidateStateSchemaCreateRequest(req StateSchemaCreateRequest) error {
 			return fmt.Errorf("duplicate state field key: %s", key)
 		}
 		seen[key] = struct{}{}
+	}
+	if raw := strings.TrimSpace(req.InitialStateJSON); raw != "" {
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+			return ErrInvalidInitialStateJSON
+		}
 	}
 	return nil
 }
@@ -207,7 +217,7 @@ func (s *Service) CreateStateSchema(ctx context.Context, req StateSchemaCreateRe
 	gameSlug := strings.TrimSpace(req.GameSlug)
 	now := time.Now().UTC()
 	s.counter++
-	item := StateSchemaVersion{ID: fmt.Sprintf("state-schema-%d", s.counter), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: len(s.stateSchemas[gameSlug]) + 1, Fields: append([]StateFieldDefinition(nil), req.Fields...), CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	item := StateSchemaVersion{ID: fmt.Sprintf("state-schema-%d", s.counter), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: len(s.stateSchemas[gameSlug]) + 1, Fields: append([]StateFieldDefinition(nil), req.Fields...), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
 	if len(s.stateSchemas[gameSlug]) == 0 {
 		item.IsActive = true
 		item.ActivatedBy = strings.TrimSpace(req.ActorID)
@@ -254,6 +264,7 @@ func (s *Service) UpdateStateSchema(ctx context.Context, id string, req StateSch
 			updated.Name = strings.TrimSpace(req.Name)
 			updated.Description = strings.TrimSpace(req.Description)
 			updated.Fields = append([]StateFieldDefinition(nil), req.Fields...)
+			updated.InitialStateJSON = strings.TrimSpace(req.InitialStateJSON)
 			if updated.GameSlug != gameSlug {
 				s.stateSchemas[gameSlug] = append(versions[:i], versions[i+1:]...)
 				s.stateSchemas[updated.GameSlug] = append(s.stateSchemas[updated.GameSlug], updated)

--- a/internal/prompts/tracker_config_test.go
+++ b/internal/prompts/tracker_config_test.go
@@ -2,6 +2,7 @@ package prompts
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -37,6 +38,28 @@ func TestServiceStateSchemaLifecycle(t *testing.T) {
 	}
 	if active.ID != created.ID {
 		t.Fatalf("active id = %q, want %q", active.ID, created.ID)
+	}
+}
+
+func TestValidateStateSchemaCreateRequestAllowsInitialStateJSONWithoutFields(t *testing.T) {
+	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
+		GameSlug:         "cs2",
+		Name:             "CS2 full state",
+		InitialStateJSON: `{"session_status":{"value":"unknown"}}`,
+	})
+	if err != nil {
+		t.Fatalf("ValidateStateSchemaCreateRequest() error = %v", err)
+	}
+}
+
+func TestValidateStateSchemaCreateRequestRejectsInvalidInitialStateJSON(t *testing.T) {
+	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
+		GameSlug:         "cs2",
+		Name:             "CS2 full state",
+		InitialStateJSON: `[]`,
+	})
+	if !errors.Is(err, ErrInvalidInitialStateJSON) {
+		t.Fatalf("error = %v, want %v", err, ErrInvalidInitialStateJSON)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Allow admins to provide a bootstrap JSON state for tracker sessions so tracker prompts can start from a known state when no previous persisted state exists.
- Persist and expose the `initialStateJson` in the tracker state schema storage and API so DB-backed and in-memory resolvers can return it.
- Make the media/Gemini classifier tolerate empty chunk references for specific tracker stages and present clearer chunk metadata in prompts.
- When a stream capture reports the stream ended, run the tracker `close_current_session` stage so the tracker can emit a final closure decision even with no media chunk.

### Description
- API: updated `docs/openapi.yaml` for `StateSchemaCreateRequest` to require at least one of `fields` or `initialStateJson` and added `initialStateJson` property.
- Router/service: threaded `InitialStateJSON` through `stateSchemaCreateRequest` and `stateSchemaRequestToCreateRequest` (trimmed) and added tests in `router_admin_llm_test.go` to create schemas with `initialStateJson`.
- Prompts service: added `InitialStateJSON` to `StateSchemaCreateRequest` and `StateSchemaVersion`, validate JSON object in `ValidateStateSchemaCreateRequest`, accept schemas without `fields` when `initialStateJson` is present, and added in-memory and DB plumbing for `initial_state_json` including DDL & `ensureSchema` migration, scan/insert/update/select changes in `postgres_service.go` and tests in `postgres_service_test.go`.
- Worker/media: when capture reports `ErrStreamlinkStreamEnded`, call new `processCloseCurrentSession` to run an active `close_current_session` prompt; resolve previous state now falls back to an active schema `InitialStateJSON` via `resolveInitialTrackerState`; updated Gemini classifier to allow empty chunk for close/finalize stages, format chunk reference/timestamp with `formatChunkReference`/`formatChunkCapturedAt`, and only include inline data when a chunk is present; added `allowsEmptyChunk` helper.
- Tests: added and updated unit tests for schema lifecycle and validation (`internal/prompts/*_test.go`), worker behavior on ended streams and initial state (`internal/media/worker_test.go`), and DB-level expectations (`internal/prompts/postgres_service_test.go`).

### Testing
- Ran unit tests with `go test ./...` including `TestValidateStateSchemaCreateRequestAllowsInitialStateJSONWithoutFields`, `TestValidateStateSchemaCreateRequestRejectsInvalidInitialStateJSON`, `TestWorkerProcessStreamerRunsCloseCurrentSessionWhenStreamEnds`, and `TestWorkerProcessStreamerUsesAdminProvidedInitialState`, and they passed.
- Database-related tests in `internal/prompts/postgres_service_test.go` that assert DDL and query shapes ran successfully with `sqlmock`.
- Integration-style tests exercising admin routes in `internal/app/router_admin_llm_test.go` ran and returned `HTTP 201` for created schemas including the one with `initialStateJson`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d62894ac832cbe5c6aeb119874b4)