### PR TITLE
Fix formatting in admin LLM router test

### DIFF
--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -45,8 +45,8 @@ func TestAdminLLMStateSchemaAndRuleSetRoutes(t *testing.T) {
 		t.Fatalf("state schema create status = %d body=%s", stateRes.Code, stateRes.Body.String())
 	}
 	stateSchemaBodyWithInitialState, _ := json.Marshal(map[string]any{
-		"gameSlug": "cs2",
-		"name":     "CS2 tracker with initial state",
+		"gameSlug":         "cs2",
+		"name":             "CS2 tracker with initial state",
 		"initialStateJson": `{"session_type":"single_match_single_chat","game":"cs2","session_status":{"value":"unknown"}}`,
 	})
 	stateInitialReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/state-schemas", bytes.NewReader(stateSchemaBodyWithInitialState))


### PR DESCRIPTION
### Motivation
- Fix CI formatting failure caused by an unformatted test file `internal/app/router_admin_llm_test.go` so the build stops failing.

### Description
- Run `gofmt -w internal/app/router_admin_llm_test.go` to normalize formatting and commit the change; there are no functional code changes.

### Testing
- Ran `gofmt -l internal/app/router_admin_llm_test.go` which returned no output and resolved the formatter check in CI.

Checklist (aligned with `docs/implementation_plan.md` M2.1):
- [ ] After streamer is added, connect/start worker job automatically.
- [ ] Download/capture stream chunks every 10 seconds.
- [ ] Send each chunk to LLM with the active admin-created prompt.
- [ ] Persist decisions and publish live status updates.
- [x] CI formatting issue resolved for this iteration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2da257e2c832cbc9250302d4e0743)