### PR TITLE
Accept object or string for `initialStateJson` and normalize input

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1414,10 +1414,13 @@ components:
           items:
             $ref: '#/components/schemas/StateFieldDefinition'
         initialStateJson:
-          type: string
           description: >
-            Full JSON object (stringified) used as bootstrap state for tracker
-            sessions when no persisted previous state exists.
+            Bootstrap state for tracker sessions when no persisted previous
+            state exists. Can be passed either as a JSON object or as a
+            stringified JSON object.
+          oneOf:
+            - type: string
+            - type: object
       anyOf:
         - required: [fields]
         - required: [initialStateJson]

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -70,7 +70,22 @@ func stateSchemaRequestToCreateRequest(req stateSchemaCreateRequest, actorID str
 			FinalOnly:          field.FinalOnly,
 		})
 	}
-	return prompts.StateSchemaCreateRequest{GameSlug: req.GameSlug, Name: req.Name, Description: req.Description, Fields: fields, InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), ActorID: actorID}
+	return prompts.StateSchemaCreateRequest{GameSlug: req.GameSlug, Name: req.Name, Description: req.Description, Fields: fields, InitialStateJSON: normalizeInitialStateJSON(req.InitialStateJSON), ActorID: actorID}
+}
+
+func normalizeInitialStateJSON(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || strings.EqualFold(trimmed, "null") {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "\"") {
+		var decoded string
+		if err := json.Unmarshal(raw, &decoded); err == nil {
+			return strings.TrimSpace(decoded)
+		}
+		return ""
+	}
+	return trimmed
 }
 
 func ruleSetRequestToCreateRequest(req ruleSetCreateRequest, actorID string) prompts.RuleSetCreateRequest {
@@ -157,7 +172,7 @@ type stateSchemaCreateRequest struct {
 	Name             string              `json:"name"`
 	Description      string              `json:"description"`
 	Fields           []stateFieldRequest `json:"fields"`
-	InitialStateJSON string              `json:"initialStateJson"`
+	InitialStateJSON json.RawMessage     `json:"initialStateJson"`
 }
 
 type ruleItemRequest struct {

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -56,6 +56,24 @@ func TestAdminLLMStateSchemaAndRuleSetRoutes(t *testing.T) {
 	if stateInitialRes.Code != http.StatusCreated {
 		t.Fatalf("state schema with initial state create status = %d body=%s", stateInitialRes.Code, stateInitialRes.Body.String())
 	}
+	stateSchemaBodyWithInitialStateObject, _ := json.Marshal(map[string]any{
+		"gameSlug": "cs2",
+		"name":     "CS2 tracker with object initial state",
+		"initialStateJson": map[string]any{
+			"session_type": "single_match_single_chat",
+			"game":         "cs2",
+			"session_status": map[string]any{
+				"value": "unknown",
+			},
+		},
+	})
+	stateInitialObjectReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/state-schemas", bytes.NewReader(stateSchemaBodyWithInitialStateObject))
+	stateInitialObjectReq.Header.Set("Authorization", "Bearer "+adminToken)
+	stateInitialObjectRes := httptest.NewRecorder()
+	handler.ServeHTTP(stateInitialObjectRes, stateInitialObjectReq)
+	if stateInitialObjectRes.Code != http.StatusCreated {
+		t.Fatalf("state schema with object initial state create status = %d body=%s", stateInitialObjectRes.Code, stateInitialObjectRes.Body.String())
+	}
 
 	ruleBody, _ := json.Marshal(map[string]any{
 		"gameSlug":          "cs2",


### PR DESCRIPTION
### Motivation
- Make the admin LLM state schema endpoint accept `initialStateJson` either as a JSON object or as a string so clients can send bootstrap state in either form.
- Normalize incoming payloads into the existing internal string representation expected by prompts to avoid breaking consumers.

### Description
- Updated `docs/openapi.yaml` to document `initialStateJson` as `oneOf` string or object and clarified the field description.
- Changed the API request model `stateSchemaCreateRequest.InitialStateJSON` from `string` to `json.RawMessage` so raw JSON or quoted strings can be received.
- Added `normalizeInitialStateJSON` which trims input, treats empty or `null` as empty, and unmarshals quoted JSON strings into their inner string form, and wired it into `stateSchemaRequestToCreateRequest` to produce the normalized `InitialStateJSON` passed to `prompts.StateSchemaCreateRequest`.
- Extended `TestAdminLLMStateSchemaAndRuleSetRoutes` to include a POST using an object for `initialStateJson` and verify creation succeeds.

### Testing
- Ran the updated unit test `TestAdminLLMStateSchemaAndRuleSetRoutes` which exercises creating state schemas with no initial state, a string `initialStateJson`, and an object `initialStateJson`, and it passed.
- Executed package tests after the change (`go test ./...`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2dea23a64832c96a1f1c333471c46)