### PR TITLE
Normalize enum-like admin initialStateJson templates and document behavior

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -175,6 +175,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `PUT /api/admin/games/{gameId}` – admin-only endpoint updating a game definition.
 - `DELETE /api/admin/games/{gameId}` – admin-only endpoint deleting a game definition.
 - `GET /api/admin/llm/state-schemas` / `POST /api/admin/llm/state-schemas` – admin CRUD for versioned match state schemas.
+  - `initialStateJson` can be used as a tracker bootstrap template: enum-like string placeholders such as `"competitive | faceit | unknown"` are normalized by runtime logic to a concrete value (`unknown` when present, otherwise the first option).
 - `GET /api/admin/llm/rule-sets` / `POST /api/admin/llm/rule-sets` – admin CRUD for update/finalization rules used by the tracker.
 - `GET /api/admin/llm/prompts` / `POST /api/admin/llm/prompts` – admin CRUD for match update/finalization prompt templates.
 - When PostgreSQL is enabled, admin-managed tracker configuration (`/api/admin/llm/state-schemas`, `/api/admin/llm/rule-sets`, `/api/admin/prompts`) is persisted in dedicated versioned tables and survives service restarts.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1417,7 +1417,10 @@ components:
           description: >
             Bootstrap state for tracker sessions when no persisted previous
             state exists. Can be passed either as a JSON object or as a
-            stringified JSON object.
+            stringified JSON object. Admin templates with enum-like strings
+            (for example `"ct | t | unknown"`) are accepted; runtime
+            normalization resolves them to a concrete value (prefers
+            `unknown`, otherwise the first option).
           oneOf:
             - type: string
             - type: object

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -398,11 +398,71 @@ func (w *Worker) resolveInitialTrackerState(ctx context.Context) string {
 	if resolver, ok := w.prompts.(activeStateSchemaResolver); ok {
 		if item, err := resolver.GetActiveStateSchema(ctx, gameSlug); err == nil {
 			if state := strings.TrimSpace(item.InitialStateJSON); state != "" && state != "{}" {
-				return state
+				return normalizeInitialStateTemplateJSON(state)
 			}
 		}
 	}
 	return ""
+}
+
+func normalizeInitialStateTemplateJSON(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		return trimmed
+	}
+	normalized := normalizeTemplateValue(parsed)
+	body, err := json.Marshal(normalized)
+	if err != nil {
+		return trimmed
+	}
+	return strings.TrimSpace(string(body))
+}
+
+func normalizeTemplateValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			out[key] = normalizeTemplateValue(nested)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, normalizeTemplateValue(item))
+		}
+		return out
+	case string:
+		return resolveTemplateEnumString(typed)
+	default:
+		return value
+	}
+}
+
+func resolveTemplateEnumString(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if !strings.Contains(trimmed, "|") {
+		return trimmed
+	}
+	parts := strings.Split(trimmed, "|")
+	candidate := ""
+	for _, part := range parts {
+		token := strings.TrimSpace(part)
+		if token == "" {
+			continue
+		}
+		if strings.EqualFold(token, "unknown") {
+			return "unknown"
+		}
+		if candidate == "" {
+			candidate = token
+		}
+	}
+	return candidate
 }
 
 func normalizeDecisionLabel(result StageClassification, updatedStateJSON string) string {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -406,6 +406,42 @@ func TestWorkerProcessStreamerUsesAdminProvidedInitialState(t *testing.T) {
 	}
 }
 
+func TestWorkerProcessStreamerNormalizesAdminInitialStateTemplate(t *testing.T) {
+	decisions := &fakeDecisionStore{}
+	classifier := &flakyClassifier{result: StageClassification{Label: "state_updated", Confidence: 0.95, UpdatedStateJSON: `{"score_state":{"ct_score":1,"t_score":0}}`}}
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		classifier,
+		fakePromptResolver{
+			prompts: []prompts.PromptVersion{{ID: "tracker-1", Stage: "match_update", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}},
+			activeSchema: prompts.StateSchemaVersion{InitialStateJSON: `{
+				"mode": "competitive | faceit | wingman | unknown",
+				"session_status": {
+					"value": "in_progress | likely_finished | confirmed_finished | likely_truncated | unknown"
+				},
+				"winner_state": {"winner_side":"CT | T | draw | unknown"}
+			}`},
+		},
+		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
+	)
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if len(decisions.items) != 1 {
+		t.Fatalf("recorded %d decisions, want 1", len(decisions.items))
+	}
+	previous := decisions.items[0].PreviousStateJSON
+	if !strings.Contains(previous, `"mode":"unknown"`) {
+		t.Fatalf("previous state mode was not normalized: %q", previous)
+	}
+	if !strings.Contains(previous, `"value":"unknown"`) {
+		t.Fatalf("previous state session_status was not normalized: %q", previous)
+	}
+	if !strings.Contains(previous, `"winner_side":"unknown"`) {
+		t.Fatalf("previous state winner_side was not normalized: %q", previous)
+	}
+}
+
 func TestWorkerProcessStreamerNormalizesLegacyStatePayloads(t *testing.T) {
 	decisions := &fakeDecisionStore{}
 	worker := NewWorker(


### PR DESCRIPTION
### Motivation
- Accept admin-provided `initialStateJson` templates that contain enum-like pipe-delimited strings and normalize them to concrete values for consistent tracker bootstrap behavior.
- Make runtime behavior explicit in the docs and OpenAPI so operators know that templates like `"ct | t | unknown"` are resolved automatically.

### Description
- Added `normalizeInitialStateTemplateJSON`, `normalizeTemplateValue`, and `resolveTemplateEnumString` helpers to normalize JSON templates and prefer `unknown` when present. 
- Updated `resolveInitialTrackerState` to return the normalized template via `normalizeInitialStateTemplateJSON` when an admin-managed schema provides an `InitialStateJSON` payload. 
- Added `TestWorkerProcessStreamerNormalizesAdminInitialStateTemplate` to verify normalization of nested enum-like strings in admin templates. 
- Documented the normalization behavior in `docs/local_setup.md` and in the `initialStateJson` description in `docs/openapi.yaml`.

### Testing
- Ran the unit tests in the media package with `go test ./internal/media` and the new `TestWorkerProcessStreamerNormalizesAdminInitialStateTemplate` which passed. 
- Ran the project test suite with `go test ./...` and confirmed no failures in the changed packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3c7f81fe0832cbdef385361f0e21a)