### PR TITLE
Reduce LLM token usage by avoiding full-state resends and skipping unchanged updates

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -397,18 +397,15 @@ Mandatory rules:
 }
 
 func buildGeminiContinuationInstruction(input StageRequest) string {
-	previousState := strings.TrimSpace(input.PreviousState)
-	if previousState == "" {
-		previousState = defaultTrackerState()
-	}
 	return strings.TrimSpace(fmt.Sprintf(`Continue the existing match chat session.
 Stage: %s
 Streamer ID: %s
 Chunk captured at: %s
 Chunk reference: %s
-Previous persisted tracker state JSON:
-%s
-Return ONLY valid JSON using the same schema as before.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), previousState))
+Do not repeat full state snapshots from earlier turns.
+Return ONLY concrete changes discovered in this chunk and keep delta minimal.
+If there are no concrete changes, return updated_state with the current known state and an empty delta.
+Return ONLY valid JSON using the same schema as before.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference)))
 }
 
 func allowsEmptyChunk(stage string) bool {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -162,6 +162,9 @@ func TestGeminiStageClassifierReusesChatSessionWithoutResendingPrompt(t *testing
 	if !strings.Contains(requestBodies[1], "Continue the existing match chat session.") {
 		t.Fatalf("expected second request to include continuation marker, got %s", requestBodies[1])
 	}
+	if strings.Contains(requestBodies[1], "Previous persisted tracker state JSON:") {
+		t.Fatalf("expected second request to avoid re-sending full state, got %s", requestBodies[1])
+	}
 }
 
 func TestGeminiStageClassifierRotatesChatWhenTokenBudgetReached(t *testing.T) {

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -332,6 +332,20 @@ func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chu
 
 func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.PromptVersion, result StageClassification, chunk ChunkRef, runID, streamerID, previousState string) (streamers.LLMDecision, error) {
 	updatedStateJSON := normalizeStateSnapshot(previousState, result)
+	evidenceDelta := firstNonEmpty(strings.TrimSpace(result.EvidenceDeltaJSON), strings.TrimSpace(result.NextEvidenceJSON))
+	conflicts := strings.TrimSpace(result.ConflictsJSON)
+	finalOutcome := strings.TrimSpace(result.FinalOutcome)
+	if strings.EqualFold(strings.TrimSpace(activePrompt.Stage), trackerStageUpdate) &&
+		!hasConcreteTrackerChange(previousState, updatedStateJSON, evidenceDelta, conflicts, finalOutcome) {
+		return streamers.LLMDecision{
+			RunID:            runID,
+			StreamerID:       streamerID,
+			Stage:            activePrompt.Stage,
+			Label:            "awaiting_changes",
+			Confidence:       result.Confidence,
+			UpdatedStateJSON: updatedStateJSON,
+		}, nil
+	}
 	label := normalizeDecisionLabel(result, updatedStateJSON)
 	if label == "" || result.Confidence < effectiveConfidenceThreshold(w.minConfidence, activePrompt.MinConfidence) {
 		label = "uncertain"
@@ -365,9 +379,9 @@ func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.Pr
 		TransitionOutcome: transitionOutcome,
 		PreviousStateJSON: previousState,
 		UpdatedStateJSON:  updatedStateJSON,
-		EvidenceDeltaJSON: firstNonEmpty(strings.TrimSpace(result.EvidenceDeltaJSON), strings.TrimSpace(result.NextEvidenceJSON)),
-		ConflictsJSON:     strings.TrimSpace(result.ConflictsJSON),
-		FinalOutcome:      strings.TrimSpace(result.FinalOutcome),
+		EvidenceDeltaJSON: evidenceDelta,
+		ConflictsJSON:     conflicts,
+		FinalOutcome:      finalOutcome,
 	}
 	decision, err := w.decisions.RecordLLMDecision(ctx, recordReq)
 	if err != nil {
@@ -375,6 +389,20 @@ func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.Pr
 		return streamers.LLMDecision{}, err
 	}
 	return decision, nil
+}
+
+func hasConcreteTrackerChange(previousState, updatedState, evidenceDelta, conflicts, finalOutcome string) bool {
+	if normalizeStateJSON(previousState) != normalizeStateJSON(updatedState) {
+		return true
+	}
+	if normalized := normalizeStateJSON(evidenceDelta); normalized != "" && normalized != "[]" {
+		return true
+	}
+	if normalized := normalizeStateJSON(conflicts); normalized != "" && normalized != "[]" {
+		return true
+	}
+	outcome := strings.TrimSpace(strings.ToLower(finalOutcome))
+	return outcome != "" && outcome != "unknown"
 }
 
 func (w *Worker) resolvePreviousState(ctx context.Context, streamerID string) string {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -158,6 +158,53 @@ func TestWorkerProcessStreamerPrefersTrackerPromptsOverLegacyStages(t *testing.T
 	}
 }
 
+func TestWorkerProcessStageSkipsHistoryWhenStateDidNotChange(t *testing.T) {
+	decisions := &fakeDecisionStore{
+		items: []streamers.RecordDecisionRequest{
+			{
+				RunID:            "run-0",
+				StreamerID:       "str-1",
+				Stage:            "match_update",
+				Label:            "state_updated",
+				Confidence:       0.9,
+				UpdatedStateJSON: `{"session_status":{"value":"in_progress"}}`,
+			},
+		},
+	}
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		fakeClassifier{results: map[string]StageClassification{
+			"match_update": {
+				Label:             "state_updated",
+				Confidence:        0.9,
+				UpdatedStateJSON:  `{"session_status":{"value":"in_progress"}}`,
+				EvidenceDeltaJSON: `[]`,
+				NextEvidenceJSON:  `[]`,
+				FinalOutcome:      "unknown",
+			},
+		}},
+		fakePromptResolver{prompts: []prompts.PromptVersion{
+			{ID: "tracker-1", Stage: "match_update", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000},
+		}},
+		&InMemoryRunStore{},
+		decisions,
+		NewInMemoryLocker(),
+		WorkerConfig{MinConfidence: 0.5},
+	)
+	decision, err := worker.processStage(context.Background(), "run-1", "str-1", ChunkRef{Reference: "chunk-1"}, prompts.PromptVersion{
+		ID: "tracker-1", Stage: "match_update", IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000,
+	})
+	if err != nil {
+		t.Fatalf("processStage() error = %v", err)
+	}
+	if decision.Label != "awaiting_changes" {
+		t.Fatalf("decision.Label = %q, want awaiting_changes", decision.Label)
+	}
+	if len(decisions.items) != 1 {
+		t.Fatalf("recorded %d decisions, want 1 (only seed state)", len(decisions.items))
+	}
+}
+
 func TestWorkerResolvePreviousStateDefaultsToTrackerBootstrap(t *testing.T) {
 	worker := NewWorker(fakeCapture{}, fakeClassifier{}, fakePromptResolver{}, &InMemoryRunStore{}, nil, NewInMemoryLocker(), WorkerConfig{})
 	if got := worker.resolvePreviousState(context.Background(), "str-1"); got != defaultTrackerState() {
@@ -372,14 +419,15 @@ func TestWorkerProcessStreamerPassesPersistedPreviousStateToTrackerStages(t *tes
 	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
 		t.Fatalf("first ProcessStreamer() error = %v", err)
 	}
-	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+	second, err := worker.ProcessStreamer(context.Background(), "str-1")
+	if err != nil {
 		t.Fatalf("second ProcessStreamer() error = %v", err)
 	}
-	if len(decisions.items) != 2 {
-		t.Fatalf("recorded %d decisions, want 2", len(decisions.items))
+	if len(decisions.items) != 1 {
+		t.Fatalf("recorded %d decisions, want 1 (skip unchanged updates)", len(decisions.items))
 	}
-	if !strings.Contains(decisions.items[1].PreviousStateJSON, `"score":{"ct":8,"t":5}`) {
-		t.Fatalf("previous state = %q", decisions.items[1].PreviousStateJSON)
+	if second.Label != "awaiting_changes" {
+		t.Fatalf("second label = %q, want awaiting_changes", second.Label)
 	}
 }
 
@@ -496,10 +544,17 @@ func TestWorkerProcessStreamerPreservesKnownScoreWhenModelReturnsUnknownPlacehol
 		t.Fatalf("first ProcessStreamer() error = %v", err)
 	}
 	decisions.items[0].UpdatedStateJSON = `{"state":{"ct_score":8,"t_score":5,"mode":"competitive"},"final_outcome":"unknown"}`
-	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+	second, err := worker.ProcessStreamer(context.Background(), "str-1")
+	if err != nil {
 		t.Fatalf("second ProcessStreamer() error = %v", err)
 	}
-	if got := decisions.items[1].UpdatedStateJSON; got != `{"final_outcome":"unknown","state":{"ct_score":8,"mode":"competitive","t_score":5}}` {
+	if second.Label != "awaiting_changes" {
+		t.Fatalf("second label = %q, want awaiting_changes", second.Label)
+	}
+	if got := second.UpdatedStateJSON; got != `{"final_outcome":"unknown","state":{"ct_score":8,"mode":"competitive","t_score":5}}` {
 		t.Fatalf("updated state = %q", got)
+	}
+	if len(decisions.items) != 1 {
+		t.Fatalf("recorded %d decisions, want 1 (skip unchanged updates)", len(decisions.items))
 	}
 }


### PR DESCRIPTION
### Motivation
- Reduce token usage and chat size for ongoing Gemini analysis by avoiding re-sending the full `previous_state` on continuation turns and asking the model to return only concrete changes per chunk.  
- Reduce noisy history growth by persisting only meaningful `match_update` records and returning a lightweight `awaiting_changes` decision when nothing changed.  
- Align runtime behavior with the M2.1 state-tracker design (`previous_state + new_chunk -> updated_state`) while optimising token and storage costs.

### Description
- Tighten continuation prompt in `buildGeminiContinuationInstruction` so continuation turns do not include the full `previous_state` and instead instruct the model to return only concrete changes and minimal delta (`internal/media/gemini.go`).
- Add change-detection logic in `processStageResult`: compute a minimal `evidenceDelta`, `conflicts`, `finalOutcome`, and short-circuit `match_update` stages when nothing changed by returning `awaiting_changes` (no DB write) (`internal/media/worker.go`).
- Introduce helper `hasConcreteTrackerChange` and normalize evidence/conflict/finalOutcome fields before recording decisions, and only persist when there is a concrete change (`internal/media/worker.go`).
- Update unit tests to reflect the new behavior: assert continuation requests avoid re-sending full state and expect `awaiting_changes` / skipped history writes when appropriate (`internal/media/gemini_test.go`, `internal/media/worker_test.go`).

### Testing
- Ran `go test ./internal/media ./internal/config` and the test suites passed successfully.  
- Updated and extended tests in `internal/media/gemini_test.go` and `internal/media/worker_test.go` to cover continuation payload minimization and unchanged-update suppression, and all tests are green.  
- Checklist (aligned to M2.1 priority):  
  - [x] Stop re-sending full `previous_state` on Gemini continuation turns and reuse chat context until rotation.  
  - [x] Suppress persisting `match_update` history when no concrete state/evidence/conflict/final-outcome change occurs.  
  - [ ] Autostart worker immediately after streamer onboarding (end-to-end).  
  - [ ] Ensure production Streamlink capture loop reliably produces 10s chunks and validate end-to-end latency/coverage.  
  - [ ] Publish realtime `LLM_MATCH_STATE_UPDATED` / `LLM_MATCH_FINALIZED` events and provide REST backfill/history e2e.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3e245c974832cb4b3ff956cdab6b5)