### PR TITLE
Sanitize Gemini generation config and improve request handling

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"net/http"
 	"os"
@@ -26,6 +27,8 @@ var (
 	ErrGeminiInvalidConfidence = errors.New("gemini confidence must be between 0 and 1")
 	ErrGeminiUnsupportedMIME   = errors.New("gemini does not support the chunk mime type")
 )
+
+const geminiMaxOutputTokensLimit = 8192
 
 type GeminiClassifierConfig struct {
 	APIKey         string
@@ -100,7 +103,6 @@ type geminiGenerationConfig struct {
 	Temperature      float64 `json:"temperature,omitempty"`
 	MaxOutputTokens  int     `json:"maxOutputTokens,omitempty"`
 	ResponseMIMEType string  `json:"responseMimeType,omitempty"`
-	MediaResolution  string  `json:"mediaResolution,omitempty"`
 }
 
 type geminiGenerateContentResponse struct {
@@ -179,13 +181,8 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 	contents := c.prepareSessionContents(sessionKey, promptFingerprint, input, mimeType, data, forceBootstrap, hasChunk)
 
 	requestBody := geminiGenerateContentRequest{
-		Contents: contents,
-		GenerationConfig: geminiGenerationConfig{
-			Temperature:      input.Prompt.Temperature,
-			MaxOutputTokens:  input.Prompt.MaxTokens,
-			ResponseMIMEType: "application/json",
-			MediaResolution:  "MEDIA_RESOLUTION_LOW",
-		},
+		Contents:         contents,
+		GenerationConfig: sanitizeGeminiGenerationConfig(input.Prompt.Temperature, input.Prompt.MaxTokens),
 	}
 
 	bodyBytes, err := json.Marshal(requestBody)
@@ -221,7 +218,16 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 		return StageClassification{}, err
 	}
 	if resp.StatusCode >= 400 {
-		return StageClassification{}, fmt.Errorf("gemini generateContent failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(responseBody)))
+		return StageClassification{}, fmt.Errorf("gemini generateContent failed: status=%d stage=%s model=%s mime=%s has_chunk=%t max_output_tokens=%d temperature=%.3f body=%s",
+			resp.StatusCode,
+			strings.TrimSpace(input.Stage),
+			model,
+			mimeType,
+			hasChunk,
+			requestBody.GenerationConfig.MaxOutputTokens,
+			requestBody.GenerationConfig.Temperature,
+			strings.TrimSpace(string(responseBody)),
+		)
 	}
 
 	var payload geminiGenerateContentResponse
@@ -277,6 +283,19 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 		ConflictsJSON:     marshalRawMessage(parsed.HardConflicts),
 		FinalOutcome:      strings.TrimSpace(parsed.FinalOutcome),
 	}, nil
+}
+
+func sanitizeGeminiGenerationConfig(temperature float64, maxTokens int) geminiGenerationConfig {
+	cfg := geminiGenerationConfig{
+		ResponseMIMEType: "application/json",
+	}
+	if !math.IsNaN(temperature) && !math.IsInf(temperature, 0) && temperature >= 0 && temperature <= 2 {
+		cfg.Temperature = temperature
+	}
+	if maxTokens > 0 && maxTokens <= geminiMaxOutputTokensLimit {
+		cfg.MaxOutputTokens = maxTokens
+	}
+	return cfg
 }
 
 func geminiSessionKey(input StageRequest) string {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -90,9 +90,6 @@ func TestGeminiStageClassifierClassify(t *testing.T) {
 	if !strings.Contains(gotBody, `"mimeType":"video/mp4"`) {
 		t.Fatalf("expected transport stream mime type in request body: %s", gotBody)
 	}
-	if !strings.Contains(gotBody, `"mediaResolution":"MEDIA_RESOLUTION_LOW"`) {
-		t.Fatalf("expected low media resolution in generation config: %s", gotBody)
-	}
 	if !strings.Contains(gotBody, "Detect the game being played") {
 		t.Fatalf("expected prompt template in request body: %s", gotBody)
 	}
@@ -164,6 +161,63 @@ func TestGeminiStageClassifierReusesChatSessionWithoutResendingPrompt(t *testing
 	}
 	if strings.Contains(requestBodies[1], "Previous persisted tracker state JSON:") {
 		t.Fatalf("expected second request to avoid re-sending full state, got %s", requestBodies[1])
+	}
+}
+
+func TestGeminiStageClassifierSanitizesGenerationConfig(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	var gotBody string
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			gotBody = string(body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"label\":\"cs_detected\",\"confidence\":0.93,\"summary\":\"Counter-Strike HUD visible\"}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 10}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	_, err = classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "detector",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt: prompts.PromptVersion{
+			Stage:       "detector",
+			Template:    "Detect the game being played",
+			Model:       "gemini",
+			Temperature: -1,
+			MaxTokens:   geminiMaxOutputTokensLimit + 1,
+			TimeoutMS:   1000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+	if strings.Contains(gotBody, `"temperature":`) {
+		t.Fatalf("expected invalid temperature to be omitted from generation config: %s", gotBody)
+	}
+	if strings.Contains(gotBody, `"maxOutputTokens":`) {
+		t.Fatalf("expected oversized maxOutputTokens to be omitted from generation config: %s", gotBody)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Prevent sending invalid or oversized generation parameters to Gemini and avoid relying on a removed `mediaResolution` flag.
- Improve error diagnostics when Gemini returns non-2xx responses.
- Add unit coverage to assert generation config sanitization.

### Description

- Added `geminiMaxOutputTokensLimit = 8192` and removed the `MediaResolution` field from `geminiGenerationConfig`.
- Replaced inline construction of generation config with a new `sanitizeGeminiGenerationConfig` helper that omits invalid `temperature` values and caps `maxOutputTokens` to `geminiMaxOutputTokensLimit`.
- Enhanced the Gemini error message on non-2xx responses to include `stage`, `model`, `mime`, `has_chunk`, `max_output_tokens`, and `temperature` for better debugging.
- Updated tests to stop expecting the removed `mediaResolution` field and added `TestGeminiStageClassifierSanitizesGenerationConfig` to verify invalid `temperature` and oversized `MaxTokens` are omitted from the request body.

### Testing

- Ran unit tests in `internal/media/gemini_test.go`, including `TestGeminiStageClassifierClassify`, `TestGeminiStageClassifierReusesChatSessionWithoutResendingPrompt`, `TestGeminiStageClassifierSanitizesGenerationConfig`, and `TestGeminiStageClassifierRotatesChatWhenTokenBudgetReached`, and they all passed.
- The new test `TestGeminiStageClassifierSanitizesGenerationConfig` asserts that invalid `temperature` and oversized `maxOutputTokens` are not included in the generated request body and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3ef574aa8832c810e042506034432)