### PR TITLE
Support admin-defined JSON Schema for LLM tracker state contracts

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -175,6 +175,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `PUT /api/admin/games/{gameId}` – admin-only endpoint updating a game definition.
 - `DELETE /api/admin/games/{gameId}` – admin-only endpoint deleting a game definition.
 - `GET /api/admin/llm/state-schemas` / `POST /api/admin/llm/state-schemas` – admin CRUD for versioned match state schemas.
+  - `stateSchemaJson` accepts a JSON Schema object that is passed to the tracker prompt as the strict expected LLM response contract.
   - `initialStateJson` can be used as a tracker bootstrap template: enum-like string placeholders such as `"competitive | faceit | unknown"` are normalized by runtime logic to a concrete value (`unknown` when present, otherwise the first option).
 - `GET /api/admin/llm/rule-sets` / `POST /api/admin/llm/rule-sets` – admin CRUD for update/finalization rules used by the tracker.
 - `GET /api/admin/llm/prompts` / `POST /api/admin/llm/prompts` – admin CRUD for match update/finalization prompt templates.

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -70,7 +70,15 @@ func stateSchemaRequestToCreateRequest(req stateSchemaCreateRequest, actorID str
 			FinalOnly:          field.FinalOnly,
 		})
 	}
-	return prompts.StateSchemaCreateRequest{GameSlug: req.GameSlug, Name: req.Name, Description: req.Description, Fields: fields, InitialStateJSON: normalizeInitialStateJSON(req.InitialStateJSON), ActorID: actorID}
+	return prompts.StateSchemaCreateRequest{
+		GameSlug:         req.GameSlug,
+		Name:             req.Name,
+		Description:      req.Description,
+		Fields:           fields,
+		StateSchemaJSON:  normalizeInitialStateJSON(req.StateSchemaJSON),
+		InitialStateJSON: normalizeInitialStateJSON(req.InitialStateJSON),
+		ActorID:          actorID,
+	}
 }
 
 func normalizeInitialStateJSON(raw json.RawMessage) string {
@@ -172,6 +180,7 @@ type stateSchemaCreateRequest struct {
 	Name             string              `json:"name"`
 	Description      string              `json:"description"`
 	Fields           []stateFieldRequest `json:"fields"`
+	StateSchemaJSON  json.RawMessage     `json:"stateSchemaJson"`
 	InitialStateJSON json.RawMessage     `json:"initialStateJson"`
 }
 

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -59,6 +59,13 @@ func TestAdminLLMStateSchemaAndRuleSetRoutes(t *testing.T) {
 	stateSchemaBodyWithInitialStateObject, _ := json.Marshal(map[string]any{
 		"gameSlug": "cs2",
 		"name":     "CS2 tracker with object initial state",
+		"stateSchemaJson": map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"session_type": map[string]any{"type": "string"},
+			},
+		},
 		"initialStateJson": map[string]any{
 			"session_type": "single_match_single_chat",
 			"game":         "cs2",

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -778,7 +778,11 @@ func (w *Worker) resolveTrackerConfig(ctx context.Context) (string, string) {
 	var stateSchema string
 	if resolver, ok := w.prompts.(activeStateSchemaResolver); ok {
 		if item, err := resolver.GetActiveStateSchema(ctx, gameSlug); err == nil {
-			stateSchema = fmt.Sprintf("state_schema[%s v%d]: %s", item.Name, item.Version, compactJSON(item.Fields))
+			schemaPayload := strings.TrimSpace(item.StateSchemaJSON)
+			if schemaPayload == "" || schemaPayload == "{}" {
+				schemaPayload = compactJSON(item.Fields)
+			}
+			stateSchema = fmt.Sprintf("state_schema[%s v%d]: %s", item.Name, item.Version, schemaPayload)
 		}
 	}
 	var ruleSet string

--- a/internal/prompts/postgres_service.go
+++ b/internal/prompts/postgres_service.go
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS llm_state_schema_versions (
     description TEXT NOT NULL DEFAULT '',
     version INTEGER NOT NULL,
     fields_json JSONB NOT NULL,
+    state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb,
     initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb,
     is_active BOOLEAN NOT NULL DEFAULT FALSE,
     created_by TEXT NOT NULL,
@@ -105,6 +106,9 @@ func (s *Service) ensureSchema(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, `ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`); err != nil {
 		return fmt.Errorf("ensure llm_state_schema_versions.initial_state_json: %w", err)
 	}
+	if _, err := s.db.ExecContext(ctx, `ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`); err != nil {
+		return fmt.Errorf("ensure llm_state_schema_versions.state_schema_json: %w", err)
+	}
 	s.schemaReady = true
 	return nil
 }
@@ -145,14 +149,16 @@ func scanPrompt(row scanner) (PromptVersion, error) {
 func scanStateSchema(row scanner) (StateSchemaVersion, error) {
 	var item StateSchemaVersion
 	var fields []byte
+	var schemaJSON []byte
 	var initialState []byte
 	var activatedAt sql.NullTime
-	if err := row.Scan(&item.ID, &item.GameSlug, &item.Name, &item.Description, &item.Version, &fields, &initialState, &item.IsActive, &item.CreatedBy, &item.ActivatedBy, &item.CreatedAt, &activatedAt); err != nil {
+	if err := row.Scan(&item.ID, &item.GameSlug, &item.Name, &item.Description, &item.Version, &fields, &schemaJSON, &initialState, &item.IsActive, &item.CreatedBy, &item.ActivatedBy, &item.CreatedAt, &activatedAt); err != nil {
 		return StateSchemaVersion{}, err
 	}
 	if err := json.Unmarshal(fields, &item.Fields); err != nil {
 		return StateSchemaVersion{}, err
 	}
+	item.StateSchemaJSON = strings.TrimSpace(string(schemaJSON))
 	item.InitialStateJSON = strings.TrimSpace(string(initialState))
 	if activatedAt.Valid {
 		item.ActivatedAt = activatedAt.Time
@@ -335,7 +341,7 @@ func (s *Service) listStateSchemasDB(ctx context.Context) ([]StateSchemaVersion,
 	if err := s.ensureSchema(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -362,6 +368,10 @@ func (s *Service) createStateSchemaDB(ctx context.Context, req StateSchemaCreate
 	if err != nil {
 		return StateSchemaVersion{}, err
 	}
+	schemaJSONRaw := strings.TrimSpace(req.StateSchemaJSON)
+	if schemaJSONRaw == "" {
+		schemaJSONRaw = "{}"
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return StateSchemaVersion{}, err
@@ -376,7 +386,7 @@ func (s *Service) createStateSchemaDB(ctx context.Context, req StateSchemaCreate
 		return StateSchemaVersion{}, err
 	}
 	now := time.Now().UTC()
-	item := StateSchemaVersion{ID: "state-schema-" + uuid.NewString(), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: version, Fields: append([]StateFieldDefinition(nil), req.Fields...), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), IsActive: existing == 0, CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	item := StateSchemaVersion{ID: "state-schema-" + uuid.NewString(), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: version, Fields: append([]StateFieldDefinition(nil), req.Fields...), StateSchemaJSON: strings.TrimSpace(req.StateSchemaJSON), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), IsActive: existing == 0, CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
 	if item.IsActive {
 		item.ActivatedBy = item.CreatedBy
 		item.ActivatedAt = now
@@ -385,8 +395,8 @@ func (s *Service) createStateSchemaDB(ctx context.Context, req StateSchemaCreate
 	if initialStateRaw == "" {
 		initialStateRaw = "{}"
 	}
-	_, err = tx.ExecContext(ctx, `INSERT INTO llm_state_schema_versions (id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9,$10,$11,$12)`,
-		item.ID, item.GameSlug, item.Name, item.Description, item.Version, fieldsJSON, initialStateRaw, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt))
+	_, err = tx.ExecContext(ctx, `INSERT INTO llm_state_schema_versions (id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8::jsonb,$9,$10,$11,$12,$13)`,
+		item.ID, item.GameSlug, item.Name, item.Description, item.Version, fieldsJSON, schemaJSONRaw, initialStateRaw, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt))
 	if err != nil {
 		return StateSchemaVersion{}, err
 	}
@@ -400,7 +410,7 @@ func (s *Service) getStateSchemaDB(ctx context.Context, id string) (StateSchemaV
 	if err := s.ensureSchema(ctx); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE id = $1`, strings.TrimSpace(id)))
+	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE id = $1`, strings.TrimSpace(id)))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return StateSchemaVersion{}, ErrStateSchemaNotFound
@@ -425,8 +435,12 @@ func (s *Service) updateStateSchemaDB(ctx context.Context, id string, req StateS
 	if initialStateRaw == "" {
 		initialStateRaw = "{}"
 	}
-	row := s.db.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET game_slug = $2, name = $3, description = $4, fields_json = $5, initial_state_json = $6::jsonb WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
-		strings.TrimSpace(id), strings.TrimSpace(req.GameSlug), strings.TrimSpace(req.Name), strings.TrimSpace(req.Description), fieldsJSON, initialStateRaw)
+	schemaJSONRaw := strings.TrimSpace(req.StateSchemaJSON)
+	if schemaJSONRaw == "" {
+		schemaJSONRaw = "{}"
+	}
+	row := s.db.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET game_slug = $2, name = $3, description = $4, fields_json = $5, state_schema_json = $6::jsonb, initial_state_json = $7::jsonb WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
+		strings.TrimSpace(id), strings.TrimSpace(req.GameSlug), strings.TrimSpace(req.Name), strings.TrimSpace(req.Description), fieldsJSON, schemaJSONRaw, initialStateRaw)
 	item, err := scanStateSchema(row)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -484,7 +498,7 @@ func (s *Service) activateStateSchemaDB(ctx context.Context, id, actorID string)
 	if _, err := tx.ExecContext(ctx, `UPDATE llm_state_schema_versions SET is_active = FALSE WHERE game_slug = $1`, gameSlug); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(tx.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
+	item, err := scanStateSchema(tx.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
 		strings.TrimSpace(id), strings.TrimSpace(actorID), time.Now().UTC()))
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -502,7 +516,7 @@ func (s *Service) getActiveStateSchemaDB(ctx context.Context, gameSlug string) (
 	if err := s.ensureSchema(ctx); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, strings.TrimSpace(gameSlug)))
+	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, strings.TrimSpace(gameSlug)))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return StateSchemaVersion{}, ErrStateSchemaNotFound

--- a/internal/prompts/postgres_service_test.go
+++ b/internal/prompts/postgres_service_test.go
@@ -19,6 +19,7 @@ func TestPostgresServiceCreatePrompt(t *testing.T) {
 	svc := NewPostgresService(db)
 	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectBegin()
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(version), 0) + 1 FROM llm_prompt_versions WHERE stage = $1`)).
 		WithArgs("match_update").
@@ -66,13 +67,17 @@ func TestPostgresServiceListStateSchemas(t *testing.T) {
 	now := time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)
 	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "fields_json", "initial_state_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
-			AddRow("state-schema-1", "cs2", "Schema", "", 1, `[{"key":"score.ct","type":"number"}]`, `{"session_status":{"value":"unknown"}}`, true, "admin-1", "admin-1", now, now))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "fields_json", "state_schema_json", "initial_state_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
+			AddRow("state-schema-1", "cs2", "Schema", "", 1, `[{"key":"score.ct","type":"number"}]`, `{"type":"object"}`, `{"session_status":{"value":"unknown"}}`, true, "admin-1", "admin-1", now, now))
 
 	items := svc.ListStateSchemas(context.Background())
 	if len(items) != 1 || items[0].GameSlug != "cs2" {
 		t.Fatalf("ListStateSchemas() = %#v", items)
+	}
+	if items[0].StateSchemaJSON == "" {
+		t.Fatalf("expected state schema json to be set: %#v", items[0])
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet() error = %v", err)
@@ -90,6 +95,7 @@ func TestPostgresServiceGetActiveRuleSet(t *testing.T) {
 	now := time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)
 	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, rule_items_json, finalization_rules_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_rule_set_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`)).
 		WithArgs("cs2").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "rule_items_json", "finalization_rules_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).

--- a/internal/prompts/tracker_config.go
+++ b/internal/prompts/tracker_config.go
@@ -16,6 +16,7 @@ var (
 	ErrInvalidStateSchemaName    = errors.New("state schema name must not be empty")
 	ErrInvalidStateFieldKey      = errors.New("state field key must not be empty")
 	ErrInvalidStateFieldType     = errors.New("state field type must not be empty")
+	ErrInvalidStateSchemaJSON    = errors.New("stateSchemaJson must be a valid JSON object")
 	ErrInvalidInitialStateJSON   = errors.New("initialStateJson must be a valid JSON object")
 	ErrStateSchemaNotFound       = errors.New("state schema not found")
 	ErrInvalidRuleSetName        = errors.New("rule set name must not be empty")
@@ -44,6 +45,7 @@ type StateSchemaCreateRequest struct {
 	Name             string
 	Description      string
 	Fields           []StateFieldDefinition
+	StateSchemaJSON  string
 	InitialStateJSON string
 	ActorID          string
 }
@@ -55,6 +57,7 @@ type StateSchemaVersion struct {
 	Description      string                 `json:"description,omitempty"`
 	Version          int                    `json:"version"`
 	Fields           []StateFieldDefinition `json:"fields"`
+	StateSchemaJSON  string                 `json:"stateSchemaJson,omitempty"`
 	InitialStateJSON string                 `json:"initialStateJson,omitempty"`
 	IsActive         bool                   `json:"isActive"`
 	CreatedBy        string                 `json:"createdBy"`
@@ -111,7 +114,7 @@ func ValidateStateSchemaCreateRequest(req StateSchemaCreateRequest) error {
 	if strings.TrimSpace(req.Name) == "" {
 		return ErrInvalidStateSchemaName
 	}
-	if len(req.Fields) == 0 && strings.TrimSpace(req.InitialStateJSON) == "" {
+	if len(req.Fields) == 0 && strings.TrimSpace(req.InitialStateJSON) == "" && strings.TrimSpace(req.StateSchemaJSON) == "" {
 		return ErrInvalidStateFieldKey
 	}
 	seen := map[string]struct{}{}
@@ -132,6 +135,12 @@ func ValidateStateSchemaCreateRequest(req StateSchemaCreateRequest) error {
 		var decoded map[string]any
 		if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
 			return ErrInvalidInitialStateJSON
+		}
+	}
+	if raw := strings.TrimSpace(req.StateSchemaJSON); raw != "" {
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+			return ErrInvalidStateSchemaJSON
 		}
 	}
 	return nil
@@ -217,7 +226,7 @@ func (s *Service) CreateStateSchema(ctx context.Context, req StateSchemaCreateRe
 	gameSlug := strings.TrimSpace(req.GameSlug)
 	now := time.Now().UTC()
 	s.counter++
-	item := StateSchemaVersion{ID: fmt.Sprintf("state-schema-%d", s.counter), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: len(s.stateSchemas[gameSlug]) + 1, Fields: append([]StateFieldDefinition(nil), req.Fields...), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	item := StateSchemaVersion{ID: fmt.Sprintf("state-schema-%d", s.counter), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: len(s.stateSchemas[gameSlug]) + 1, Fields: append([]StateFieldDefinition(nil), req.Fields...), StateSchemaJSON: strings.TrimSpace(req.StateSchemaJSON), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
 	if len(s.stateSchemas[gameSlug]) == 0 {
 		item.IsActive = true
 		item.ActivatedBy = strings.TrimSpace(req.ActorID)
@@ -264,6 +273,7 @@ func (s *Service) UpdateStateSchema(ctx context.Context, id string, req StateSch
 			updated.Name = strings.TrimSpace(req.Name)
 			updated.Description = strings.TrimSpace(req.Description)
 			updated.Fields = append([]StateFieldDefinition(nil), req.Fields...)
+			updated.StateSchemaJSON = strings.TrimSpace(req.StateSchemaJSON)
 			updated.InitialStateJSON = strings.TrimSpace(req.InitialStateJSON)
 			if updated.GameSlug != gameSlug {
 				s.stateSchemas[gameSlug] = append(versions[:i], versions[i+1:]...)

--- a/internal/prompts/tracker_config_test.go
+++ b/internal/prompts/tracker_config_test.go
@@ -63,6 +63,28 @@ func TestValidateStateSchemaCreateRequestRejectsInvalidInitialStateJSON(t *testi
 	}
 }
 
+func TestValidateStateSchemaCreateRequestAllowsJSONSchemaWithoutFields(t *testing.T) {
+	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
+		GameSlug:        "cs2",
+		Name:            "CS2 full schema",
+		StateSchemaJSON: `{"type":"object","properties":{"score":{"type":"number"}}}`,
+	})
+	if err != nil {
+		t.Fatalf("ValidateStateSchemaCreateRequest() error = %v", err)
+	}
+}
+
+func TestValidateStateSchemaCreateRequestRejectsInvalidStateSchemaJSON(t *testing.T) {
+	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
+		GameSlug:        "cs2",
+		Name:            "CS2 full schema",
+		StateSchemaJSON: `[]`,
+	})
+	if !errors.Is(err, ErrInvalidStateSchemaJSON) {
+		t.Fatalf("error = %v, want %v", err, ErrInvalidStateSchemaJSON)
+	}
+}
+
 func TestServiceRuleSetLifecycle(t *testing.T) {
 	svc := NewService()
 	created, err := svc.CreateRuleSet(context.Background(), RuleSetCreateRequest{


### PR DESCRIPTION
### Motivation
- Allow admins to declare a strict JSON Schema contract for the LLM tracker responses so the tracker prompt can require and validate structured JSON output.
- Keep backwards compatibility with existing `fields`-based schemas while enabling stricter, versioned admin control required by the M2.1 state-tracker design.

### Description
- Added `StateSchemaJSON` to the admin API payload mapping and to the `prompts` service models so `/api/admin/llm/state-schemas` accepts `stateSchemaJson` and stores it in memory and Postgres (files changed: `internal/app/router.go`, `internal/prompts/tracker_config.go`).
- Validated `stateSchemaJson` as a JSON object and allowed creating a state schema using `stateSchemaJson` even when legacy `fields` are empty; added `ErrInvalidStateSchemaJSON` and new unit tests (files changed: `internal/prompts/tracker_config.go`, `internal/prompts/tracker_config_test.go`).
- Persisted `state_schema_json` in the Postgres-backed tracker config with schema bootstrapping and `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` support so no separate migration file is required (files changed: `internal/prompts/postgres_service.go`, `internal/prompts/postgres_service_test.go`).
- Updated worker prompt resolution to prefer the active `stateSchemaJson` and fall back to legacy `fields` when `stateSchemaJson` is empty so the LLM receives the admin-defined contract (file changed: `internal/media/worker.go`).
- Documentation and tests updated to reflect the API change (file changed: `docs/local_setup.md` and `internal/app/router_admin_llm_test.go`).
- Checklist aligned with M2.1 implementation plan: [x] admin CRUD accepts JSON Schema, [x] service persists JSON Schema, [x] worker injects active JSON Schema into prompts, [ ] finalization orchestration & observability, [ ] auto-start/10s capture loop orchestration and end-to-end live publishing.

### Testing
- Ran unit and package tests with `go test ./internal/prompts ./internal/app ./internal/media` which passed successfully.
- Ran full test suite with `go test ./...` which completed successfully.
- New and updated tests that exercised the change include `TestValidateStateSchemaCreateRequestAllowsJSONSchemaWithoutFields`, Postgres sqlmock tests for `state_schema_json`, and API handler tests that post `stateSchemaJson`, all of which passed under CI-local test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3f9b96e1c832cbbe15fd299480363)