### PR TITLE
Add support for per-chunk delta schema (deltaSchemaJson) throughout tracker stack

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1401,7 +1401,7 @@ components:
       required: [gameSlug, name]
       description: >
         Admin-managed tracker schema definition. At least one of `fields` or
-        `initialStateJson` must be provided.
+        `stateSchemaJson` or `initialStateJson` must be provided.
       properties:
         gameSlug:
           type: string
@@ -1413,6 +1413,20 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StateFieldDefinition'
+        stateSchemaJson:
+          description: >
+            Full JSON schema for the persisted tracker state object.
+            Can be passed either as a JSON object or as a stringified JSON object.
+          oneOf:
+            - type: string
+            - type: object
+        deltaSchemaJson:
+          description: >
+            Compact JSON schema for per-chunk delta payloads returned by the LLM.
+            Can be passed either as a JSON object or as a stringified JSON object.
+          oneOf:
+            - type: string
+            - type: object
         initialStateJson:
           description: >
             Bootstrap state for tracker sessions when no persisted previous
@@ -1426,6 +1440,7 @@ components:
             - type: object
       anyOf:
         - required: [fields]
+        - required: [stateSchemaJson]
         - required: [initialStateJson]
     StateSchemaVersion:
       allOf:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -76,6 +76,7 @@ func stateSchemaRequestToCreateRequest(req stateSchemaCreateRequest, actorID str
 		Description:      req.Description,
 		Fields:           fields,
 		StateSchemaJSON:  normalizeInitialStateJSON(req.StateSchemaJSON),
+		DeltaSchemaJSON:  normalizeInitialStateJSON(req.DeltaSchemaJSON),
 		InitialStateJSON: normalizeInitialStateJSON(req.InitialStateJSON),
 		ActorID:          actorID,
 	}
@@ -181,6 +182,7 @@ type stateSchemaCreateRequest struct {
 	Description      string              `json:"description"`
 	Fields           []stateFieldRequest `json:"fields"`
 	StateSchemaJSON  json.RawMessage     `json:"stateSchemaJson"`
+	DeltaSchemaJSON  json.RawMessage     `json:"deltaSchemaJson"`
 	InitialStateJSON json.RawMessage     `json:"initialStateJson"`
 }
 

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -66,6 +66,14 @@ func TestAdminLLMStateSchemaAndRuleSetRoutes(t *testing.T) {
 				"session_type": map[string]any{"type": "string"},
 			},
 		},
+		"deltaSchemaJson": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"new_evidence": map[string]any{
+					"type": "array",
+				},
+			},
+		},
 		"initialStateJson": map[string]any{
 			"session_type": "single_match_single_chat",
 			"game":         "cs2",
@@ -102,6 +110,16 @@ func TestAdminLLMStateSchemaAndRuleSetRoutes(t *testing.T) {
 	handler.ServeHTTP(listRes, listReq)
 	if listRes.Code != http.StatusOK {
 		t.Fatalf("state schema list status = %d", listRes.Code)
+	}
+	var schemas []map[string]any
+	if err := json.Unmarshal(listRes.Body.Bytes(), &schemas); err != nil {
+		t.Fatalf("state schema list decode error = %v", err)
+	}
+	if len(schemas) == 0 {
+		t.Fatal("expected non-empty state schema list")
+	}
+	if _, ok := schemas[0]["deltaSchemaJson"]; !ok {
+		t.Fatalf("expected deltaSchemaJson in response: %v", schemas[0])
 	}
 
 	ruleListReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/rule-sets", nil)

--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -311,6 +311,7 @@ func geminiPromptFingerprint(input StageRequest) string {
 		strings.TrimSpace(input.Prompt.ID),
 		strings.TrimSpace(input.Prompt.Template),
 		strings.TrimSpace(input.StateSchema),
+		strings.TrimSpace(input.DeltaSchema),
 		strings.TrimSpace(input.RuleSet),
 	}, "|")
 }
@@ -363,6 +364,8 @@ Use this admin-managed tracker prompt as the source of truth (including the expe
 %s
 Active state schema:
 %s
+Active delta schema (apply on each chunk update):
+%s
 Active rule set:
 %s`
 	previousState := strings.TrimSpace(input.PreviousState)
@@ -376,7 +379,7 @@ For detector stages, the JSON must include keys: label, confidence, summary.
 - label: short snake_case decision for this stage.
 - confidence: number between 0 and 1.
 - summary: short rationale.
-Do not include any keys that are not part of the admin-managed template.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.RuleSet)))
+Do not include any keys that are not part of the admin-managed template.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.DeltaSchema), strings.TrimSpace(input.RuleSet)))
 	}
 	return strings.TrimSpace(fmt.Sprintf(base+`
 Previous persisted tracker state JSON:
@@ -415,7 +418,7 @@ Mandatory rules:
 5. If chunk stream appears cut during active gameplay, prefer session_status=likely_truncated.
 6. Preserve previously confirmed evidence unless clearly contradicted.
 7. Store contradictions in hard_conflicts instead of silently overwriting facts.
-8. Never emit narrative commentary outside JSON.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.RuleSet), previousState))
+8. Never emit narrative commentary outside JSON.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), strings.TrimSpace(input.DeltaSchema), strings.TrimSpace(input.RuleSet), previousState))
 }
 
 func buildGeminiContinuationInstruction(input StageRequest) string {
@@ -425,6 +428,7 @@ Streamer ID: %s
 Chunk captured at: %s
 Chunk reference: %s
 Do not repeat full state snapshots from earlier turns.
+Use only the active admin delta schema for this request and keep payload compact.
 Return ONLY concrete changes discovered in this chunk and keep delta minimal.
 If there are no concrete changes, return updated_state with the current known state and an empty delta.
 Return JSON that matches the admin-managed JSON template and include only changed fields when possible.

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -33,6 +33,7 @@ type StageRequest struct {
 	Prompt        prompts.PromptVersion
 	PreviousState string
 	StateSchema   string
+	DeltaSchema   string
 	RuleSet       string
 }
 
@@ -321,8 +322,8 @@ func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (Chunk
 
 func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptVersion) (streamers.LLMDecision, error) {
 	previousState := w.resolvePreviousState(ctx, streamerID)
-	stateSchema, ruleSet := w.resolveTrackerConfig(ctx)
-	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt, PreviousState: previousState, StateSchema: stateSchema, RuleSet: ruleSet}, activePrompt)
+	stateSchema, deltaSchema, ruleSet := w.resolveTrackerConfig(ctx)
+	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt, PreviousState: previousState, StateSchema: stateSchema, DeltaSchema: deltaSchema, RuleSet: ruleSet}, activePrompt)
 	if err != nil {
 		w.metrics.recordFailure(ctx, streamerID, activePrompt.Stage)
 		return streamers.LLMDecision{}, err
@@ -773,9 +774,10 @@ type activeRuleSetResolver interface {
 	GetActiveRuleSet(ctx context.Context, gameSlug string) (prompts.RuleSetVersion, error)
 }
 
-func (w *Worker) resolveTrackerConfig(ctx context.Context) (string, string) {
+func (w *Worker) resolveTrackerConfig(ctx context.Context) (string, string, string) {
 	const gameSlug = "cs2"
 	var stateSchema string
+	var deltaSchema string
 	if resolver, ok := w.prompts.(activeStateSchemaResolver); ok {
 		if item, err := resolver.GetActiveStateSchema(ctx, gameSlug); err == nil {
 			schemaPayload := strings.TrimSpace(item.StateSchemaJSON)
@@ -783,6 +785,10 @@ func (w *Worker) resolveTrackerConfig(ctx context.Context) (string, string) {
 				schemaPayload = compactJSON(item.Fields)
 			}
 			stateSchema = fmt.Sprintf("state_schema[%s v%d]: %s", item.Name, item.Version, schemaPayload)
+			deltaPayload := strings.TrimSpace(item.DeltaSchemaJSON)
+			if deltaPayload != "" && deltaPayload != "{}" {
+				deltaSchema = fmt.Sprintf("delta_schema[%s v%d]: %s", item.Name, item.Version, deltaPayload)
+			}
 		}
 	}
 	var ruleSet string
@@ -791,7 +797,7 @@ func (w *Worker) resolveTrackerConfig(ctx context.Context) (string, string) {
 			ruleSet = fmt.Sprintf("rule_set[%s v%d]: rule_items=%s finalization_rules=%s", item.Name, item.Version, compactJSON(item.RuleItems), compactJSON(item.FinalizationRules))
 		}
 	}
-	return stateSchema, ruleSet
+	return stateSchema, deltaSchema, ruleSet
 }
 
 func compactJSON(value any) string {

--- a/internal/prompts/postgres_service.go
+++ b/internal/prompts/postgres_service.go
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS llm_state_schema_versions (
     version INTEGER NOT NULL,
     fields_json JSONB NOT NULL,
     state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    delta_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb,
     initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb,
     is_active BOOLEAN NOT NULL DEFAULT FALSE,
     created_by TEXT NOT NULL,
@@ -109,6 +110,9 @@ func (s *Service) ensureSchema(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, `ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`); err != nil {
 		return fmt.Errorf("ensure llm_state_schema_versions.state_schema_json: %w", err)
 	}
+	if _, err := s.db.ExecContext(ctx, `ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS delta_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`); err != nil {
+		return fmt.Errorf("ensure llm_state_schema_versions.delta_schema_json: %w", err)
+	}
 	s.schemaReady = true
 	return nil
 }
@@ -150,15 +154,17 @@ func scanStateSchema(row scanner) (StateSchemaVersion, error) {
 	var item StateSchemaVersion
 	var fields []byte
 	var schemaJSON []byte
+	var deltaJSON []byte
 	var initialState []byte
 	var activatedAt sql.NullTime
-	if err := row.Scan(&item.ID, &item.GameSlug, &item.Name, &item.Description, &item.Version, &fields, &schemaJSON, &initialState, &item.IsActive, &item.CreatedBy, &item.ActivatedBy, &item.CreatedAt, &activatedAt); err != nil {
+	if err := row.Scan(&item.ID, &item.GameSlug, &item.Name, &item.Description, &item.Version, &fields, &schemaJSON, &deltaJSON, &initialState, &item.IsActive, &item.CreatedBy, &item.ActivatedBy, &item.CreatedAt, &activatedAt); err != nil {
 		return StateSchemaVersion{}, err
 	}
 	if err := json.Unmarshal(fields, &item.Fields); err != nil {
 		return StateSchemaVersion{}, err
 	}
 	item.StateSchemaJSON = strings.TrimSpace(string(schemaJSON))
+	item.DeltaSchemaJSON = strings.TrimSpace(string(deltaJSON))
 	item.InitialStateJSON = strings.TrimSpace(string(initialState))
 	if activatedAt.Valid {
 		item.ActivatedAt = activatedAt.Time
@@ -341,7 +347,7 @@ func (s *Service) listStateSchemasDB(ctx context.Context) ([]StateSchemaVersion,
 	if err := s.ensureSchema(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -372,6 +378,10 @@ func (s *Service) createStateSchemaDB(ctx context.Context, req StateSchemaCreate
 	if schemaJSONRaw == "" {
 		schemaJSONRaw = "{}"
 	}
+	deltaSchemaJSONRaw := strings.TrimSpace(req.DeltaSchemaJSON)
+	if deltaSchemaJSONRaw == "" {
+		deltaSchemaJSONRaw = "{}"
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return StateSchemaVersion{}, err
@@ -386,7 +396,7 @@ func (s *Service) createStateSchemaDB(ctx context.Context, req StateSchemaCreate
 		return StateSchemaVersion{}, err
 	}
 	now := time.Now().UTC()
-	item := StateSchemaVersion{ID: "state-schema-" + uuid.NewString(), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: version, Fields: append([]StateFieldDefinition(nil), req.Fields...), StateSchemaJSON: strings.TrimSpace(req.StateSchemaJSON), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), IsActive: existing == 0, CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	item := StateSchemaVersion{ID: "state-schema-" + uuid.NewString(), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: version, Fields: append([]StateFieldDefinition(nil), req.Fields...), StateSchemaJSON: strings.TrimSpace(req.StateSchemaJSON), DeltaSchemaJSON: strings.TrimSpace(req.DeltaSchemaJSON), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), IsActive: existing == 0, CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
 	if item.IsActive {
 		item.ActivatedBy = item.CreatedBy
 		item.ActivatedAt = now
@@ -395,8 +405,8 @@ func (s *Service) createStateSchemaDB(ctx context.Context, req StateSchemaCreate
 	if initialStateRaw == "" {
 		initialStateRaw = "{}"
 	}
-	_, err = tx.ExecContext(ctx, `INSERT INTO llm_state_schema_versions (id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8::jsonb,$9,$10,$11,$12,$13)`,
-		item.ID, item.GameSlug, item.Name, item.Description, item.Version, fieldsJSON, schemaJSONRaw, initialStateRaw, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt))
+	_, err = tx.ExecContext(ctx, `INSERT INTO llm_state_schema_versions (id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8::jsonb,$9::jsonb,$10,$11,$12,$13,$14)`,
+		item.ID, item.GameSlug, item.Name, item.Description, item.Version, fieldsJSON, schemaJSONRaw, deltaSchemaJSONRaw, initialStateRaw, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt))
 	if err != nil {
 		return StateSchemaVersion{}, err
 	}
@@ -410,7 +420,7 @@ func (s *Service) getStateSchemaDB(ctx context.Context, id string) (StateSchemaV
 	if err := s.ensureSchema(ctx); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE id = $1`, strings.TrimSpace(id)))
+	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE id = $1`, strings.TrimSpace(id)))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return StateSchemaVersion{}, ErrStateSchemaNotFound
@@ -439,8 +449,12 @@ func (s *Service) updateStateSchemaDB(ctx context.Context, id string, req StateS
 	if schemaJSONRaw == "" {
 		schemaJSONRaw = "{}"
 	}
-	row := s.db.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET game_slug = $2, name = $3, description = $4, fields_json = $5, state_schema_json = $6::jsonb, initial_state_json = $7::jsonb WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
-		strings.TrimSpace(id), strings.TrimSpace(req.GameSlug), strings.TrimSpace(req.Name), strings.TrimSpace(req.Description), fieldsJSON, schemaJSONRaw, initialStateRaw)
+	deltaSchemaJSONRaw := strings.TrimSpace(req.DeltaSchemaJSON)
+	if deltaSchemaJSONRaw == "" {
+		deltaSchemaJSONRaw = "{}"
+	}
+	row := s.db.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET game_slug = $2, name = $3, description = $4, fields_json = $5, state_schema_json = $6::jsonb, delta_schema_json = $7::jsonb, initial_state_json = $8::jsonb WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
+		strings.TrimSpace(id), strings.TrimSpace(req.GameSlug), strings.TrimSpace(req.Name), strings.TrimSpace(req.Description), fieldsJSON, schemaJSONRaw, deltaSchemaJSONRaw, initialStateRaw)
 	item, err := scanStateSchema(row)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -498,7 +512,7 @@ func (s *Service) activateStateSchemaDB(ctx context.Context, id, actorID string)
 	if _, err := tx.ExecContext(ctx, `UPDATE llm_state_schema_versions SET is_active = FALSE WHERE game_slug = $1`, gameSlug); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(tx.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
+	item, err := scanStateSchema(tx.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
 		strings.TrimSpace(id), strings.TrimSpace(actorID), time.Now().UTC()))
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -516,7 +530,7 @@ func (s *Service) getActiveStateSchemaDB(ctx context.Context, gameSlug string) (
 	if err := s.ensureSchema(ctx); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, strings.TrimSpace(gameSlug)))
+	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, strings.TrimSpace(gameSlug)))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return StateSchemaVersion{}, ErrStateSchemaNotFound

--- a/internal/prompts/postgres_service_test.go
+++ b/internal/prompts/postgres_service_test.go
@@ -20,6 +20,7 @@ func TestPostgresServiceCreatePrompt(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS delta_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectBegin()
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(version), 0) + 1 FROM llm_prompt_versions WHERE stage = $1`)).
 		WithArgs("match_update").
@@ -68,9 +69,10 @@ func TestPostgresServiceListStateSchemas(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, fields_json, state_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "fields_json", "state_schema_json", "initial_state_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
-			AddRow("state-schema-1", "cs2", "Schema", "", 1, `[{"key":"score.ct","type":"number"}]`, `{"type":"object"}`, `{"session_status":{"value":"unknown"}}`, true, "admin-1", "admin-1", now, now))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS delta_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "fields_json", "state_schema_json", "delta_schema_json", "initial_state_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
+			AddRow("state-schema-1", "cs2", "Schema", "", 1, `[{"key":"score.ct","type":"number"}]`, `{"type":"object"}`, `{"type":"object","properties":{"chunk_time_range":{"type":"string"}}}`, `{"session_status":{"value":"unknown"}}`, true, "admin-1", "admin-1", now, now))
 
 	items := svc.ListStateSchemas(context.Background())
 	if len(items) != 1 || items[0].GameSlug != "cs2" {
@@ -96,6 +98,7 @@ func TestPostgresServiceGetActiveRuleSet(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS delta_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, rule_items_json, finalization_rules_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_rule_set_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`)).
 		WithArgs("cs2").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "rule_items_json", "finalization_rules_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).

--- a/internal/prompts/tracker_config.go
+++ b/internal/prompts/tracker_config.go
@@ -17,6 +17,7 @@ var (
 	ErrInvalidStateFieldKey      = errors.New("state field key must not be empty")
 	ErrInvalidStateFieldType     = errors.New("state field type must not be empty")
 	ErrInvalidStateSchemaJSON    = errors.New("stateSchemaJson must be a valid JSON object")
+	ErrInvalidDeltaSchemaJSON    = errors.New("deltaSchemaJson must be a valid JSON object")
 	ErrInvalidInitialStateJSON   = errors.New("initialStateJson must be a valid JSON object")
 	ErrStateSchemaNotFound       = errors.New("state schema not found")
 	ErrInvalidRuleSetName        = errors.New("rule set name must not be empty")
@@ -46,6 +47,7 @@ type StateSchemaCreateRequest struct {
 	Description      string
 	Fields           []StateFieldDefinition
 	StateSchemaJSON  string
+	DeltaSchemaJSON  string
 	InitialStateJSON string
 	ActorID          string
 }
@@ -58,6 +60,7 @@ type StateSchemaVersion struct {
 	Version          int                    `json:"version"`
 	Fields           []StateFieldDefinition `json:"fields"`
 	StateSchemaJSON  string                 `json:"stateSchemaJson,omitempty"`
+	DeltaSchemaJSON  string                 `json:"deltaSchemaJson,omitempty"`
 	InitialStateJSON string                 `json:"initialStateJson,omitempty"`
 	IsActive         bool                   `json:"isActive"`
 	CreatedBy        string                 `json:"createdBy"`
@@ -143,6 +146,12 @@ func ValidateStateSchemaCreateRequest(req StateSchemaCreateRequest) error {
 			return ErrInvalidStateSchemaJSON
 		}
 	}
+	if raw := strings.TrimSpace(req.DeltaSchemaJSON); raw != "" {
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+			return ErrInvalidDeltaSchemaJSON
+		}
+	}
 	return nil
 }
 
@@ -226,7 +235,7 @@ func (s *Service) CreateStateSchema(ctx context.Context, req StateSchemaCreateRe
 	gameSlug := strings.TrimSpace(req.GameSlug)
 	now := time.Now().UTC()
 	s.counter++
-	item := StateSchemaVersion{ID: fmt.Sprintf("state-schema-%d", s.counter), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: len(s.stateSchemas[gameSlug]) + 1, Fields: append([]StateFieldDefinition(nil), req.Fields...), StateSchemaJSON: strings.TrimSpace(req.StateSchemaJSON), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	item := StateSchemaVersion{ID: fmt.Sprintf("state-schema-%d", s.counter), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: len(s.stateSchemas[gameSlug]) + 1, Fields: append([]StateFieldDefinition(nil), req.Fields...), StateSchemaJSON: strings.TrimSpace(req.StateSchemaJSON), DeltaSchemaJSON: strings.TrimSpace(req.DeltaSchemaJSON), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
 	if len(s.stateSchemas[gameSlug]) == 0 {
 		item.IsActive = true
 		item.ActivatedBy = strings.TrimSpace(req.ActorID)
@@ -274,6 +283,7 @@ func (s *Service) UpdateStateSchema(ctx context.Context, id string, req StateSch
 			updated.Description = strings.TrimSpace(req.Description)
 			updated.Fields = append([]StateFieldDefinition(nil), req.Fields...)
 			updated.StateSchemaJSON = strings.TrimSpace(req.StateSchemaJSON)
+			updated.DeltaSchemaJSON = strings.TrimSpace(req.DeltaSchemaJSON)
 			updated.InitialStateJSON = strings.TrimSpace(req.InitialStateJSON)
 			if updated.GameSlug != gameSlug {
 				s.stateSchemas[gameSlug] = append(versions[:i], versions[i+1:]...)

--- a/internal/prompts/tracker_config_test.go
+++ b/internal/prompts/tracker_config_test.go
@@ -68,6 +68,7 @@ func TestValidateStateSchemaCreateRequestAllowsJSONSchemaWithoutFields(t *testin
 		GameSlug:        "cs2",
 		Name:            "CS2 full schema",
 		StateSchemaJSON: `{"type":"object","properties":{"score":{"type":"number"}}}`,
+		DeltaSchemaJSON: `{"type":"object","properties":{"new_evidence":{"type":"array"}}}`,
 	})
 	if err != nil {
 		t.Fatalf("ValidateStateSchemaCreateRequest() error = %v", err)
@@ -82,6 +83,18 @@ func TestValidateStateSchemaCreateRequestRejectsInvalidStateSchemaJSON(t *testin
 	})
 	if !errors.Is(err, ErrInvalidStateSchemaJSON) {
 		t.Fatalf("error = %v, want %v", err, ErrInvalidStateSchemaJSON)
+	}
+}
+
+func TestValidateStateSchemaCreateRequestRejectsInvalidDeltaSchemaJSON(t *testing.T) {
+	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
+		GameSlug:        "cs2",
+		Name:            "CS2 full schema",
+		StateSchemaJSON: `{"type":"object","properties":{"score":{"type":"number"}}}`,
+		DeltaSchemaJSON: `[]`,
+	})
+	if !errors.Is(err, ErrInvalidDeltaSchemaJSON) {
+		t.Fatalf("error = %v, want %v", err, ErrInvalidDeltaSchemaJSON)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Introduce a compact per-chunk delta JSON schema so LLM responses can return minimal, well-typed delta payloads in addition to the full persisted state.
- Propagate the delta schema through the API, storage, prompt construction, and worker flow so it is available to the classifier and included in prompt fingerprinting.

### Description

- API/OpenAPI: updated `StateSchemaCreateRequest` text and added `stateSchemaJson` and `deltaSchemaJson` properties with `oneOf` (`string` or `object`) and adjusted the required `anyOf` to allow `stateSchemaJson` instead of the previous `fields` only path.
- Router: added `DeltaSchemaJSON` to `stateSchemaCreateRequest`, normalized it via `normalizeInitialStateJSON`, and included it in the `prompts.StateSchemaCreateRequest` mapping.
- Worker/media: added `DeltaSchema` to `StageRequest`, included it in prompt fingerprinting (`geminiPromptFingerprint`) and in the built Gemini instructions (`buildGeminiInstruction` / `buildGeminiContinuationInstruction`), and updated `resolveTrackerConfig` to return and format `deltaSchema` alongside `stateSchema` and `ruleSet`.
- Prompts service/DB: added `DeltaSchemaJSON` to `StateSchemaCreateRequest`/`StateSchemaVersion`, introduced `delta_schema_json` DB column and `ALTER TABLE` migration, updated SQL queries/scans for create/list/get/update/activate/delete operations and JSON insert/update payloads, and added `ErrInvalidDeltaSchemaJSON` and validation of `DeltaSchemaJSON` in `ValidateStateSchemaCreateRequest`.
- Tests: updated and added unit test expectations and assertions to include `delta_schema_json`/`deltaSchemaJson` in `postgres_service_test.go`, `tracker_config_test.go`, and `router_admin_llm_test.go`.

### Testing

- Ran unit tests and updated expectations in `internal/prompts` and `internal/app` test files, including `TestPostgresServiceCreatePrompt`, `TestPostgresServiceListStateSchemas`, `TestValidateStateSchemaCreateRequestRejectsInvalidDeltaSchemaJSON`, and `TestAdminLLMStateSchemaAndRuleSetRoutes`, and they passed locally under `go test ./...`.
- SQL mock expectations for the new `ALTER TABLE` and additional `SELECT` columns were added and validated by the updated tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4013e7d04832ca08aa9f5df8c2230)