### PR TITLE
Align scheduler interval and worker lock TTL with Streamlink capture timeout

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -128,10 +128,10 @@ func main() {
 		&media.InMemoryRunStore{},
 		streamersService,
 		media.NewInMemoryLocker(),
-		media.WorkerConfig{LockTTL: 15 * time.Second, MinConfidence: 0.5},
+		media.WorkerConfig{LockTTL: streamWorkerLockTTL(cfg), MinConfidence: 0.5},
 	)
 	streamWorker.SetLogger(logger.Named("stream_worker"))
-	streamScheduler := media.NewScheduler(streamWorker, 10*time.Second)
+	streamScheduler := media.NewScheduler(streamWorker, streamProcessInterval(cfg))
 	streamScheduler.SetLogger(logger.Named("stream_scheduler"))
 	streamScheduler.SetLifecycleHooks(streamersService.MarkAnalysisActive, streamersService.MarkAnalysisInactive)
 	streamersService.SetSubmissionHook(func(_ context.Context, streamerID string) error {
@@ -243,6 +243,19 @@ func buildStageClassifier(logger *zap.Logger, cfg config.Config) media.StageClas
 	}
 
 	return classifier
+}
+
+func streamProcessInterval(cfg config.Config) time.Duration {
+	if cfg.Streamlink.CaptureTimeout > 0 {
+		return cfg.Streamlink.CaptureTimeout
+	}
+	return 25 * time.Second
+}
+
+func streamWorkerLockTTL(cfg config.Config) time.Duration {
+	interval := streamProcessInterval(cfg)
+	// Keep lock slightly longer than capture interval to prevent overlapping cycles.
+	return interval + 5*time.Second
 }
 
 func newLogger(level string) (*zap.Logger, error) {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -91,6 +91,36 @@ func TestSetupRefreshSessionStoreNoopWhenRefreshDisabled(t *testing.T) {
 	}
 }
 
+func TestStreamProcessIntervalUsesCaptureTimeout(t *testing.T) {
+	cfg := config.Config{
+		Streamlink: config.StreamlinkConfig{
+			CaptureTimeout: 25 * time.Second,
+		},
+	}
+
+	if got := streamProcessInterval(cfg); got != 25*time.Second {
+		t.Fatalf("streamProcessInterval() = %s, want %s", got, 25*time.Second)
+	}
+}
+
+func TestStreamProcessIntervalFallback(t *testing.T) {
+	if got := streamProcessInterval(config.Config{}); got != 25*time.Second {
+		t.Fatalf("streamProcessInterval() = %s, want %s", got, 25*time.Second)
+	}
+}
+
+func TestStreamWorkerLockTTLIncludesBuffer(t *testing.T) {
+	cfg := config.Config{
+		Streamlink: config.StreamlinkConfig{
+			CaptureTimeout: 25 * time.Second,
+		},
+	}
+
+	if got := streamWorkerLockTTL(cfg); got != 30*time.Second {
+		t.Fatalf("streamWorkerLockTTL() = %s, want %s", got, 30*time.Second)
+	}
+}
+
 func buildAuthServiceForSetupStore(t *testing.T) *auth.Service {
 	t.Helper()
 	repo := users.NewInMemoryRepository()

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -83,6 +83,10 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 > `FUNPOT_STREAMLINK_FFMPEG_BINARY` must point to a working `ffmpeg` binary
 > when Streamlink capture is enabled.
 
+> Scheduler cycle interval is aligned with `FUNPOT_STREAMLINK_CAPTURE_TIMEOUT`
+> (for example, `25s` timeout means one capture/LLM cycle every ~25 seconds).
+> This keeps chunk duration and LLM cadence consistent.
+
 > Set `FUNPOT_GEMINI_API_KEY` to enable real Gemini stage classification. When
 > it is unset, the server falls back to the deterministic placeholder
 > classifier used in early development.


### PR DESCRIPTION
### Motivation

- Make the stream processing cadence configurable and tied to the Streamlink capture timeout so capture/LLM cycles do not overlap or drift relative to chunk duration.
- Avoid a hardcoded scheduler interval and worker lock TTL that could cause overlapping processing when `FUNPOT_STREAMLINK_CAPTURE_TIMEOUT` is changed.

### Description

- Added `streamProcessInterval(cfg)` which returns `cfg.Streamlink.CaptureTimeout` or a 25s default when unset, and used it to replace the hardcoded scheduler interval.
- Added `streamWorkerLockTTL(cfg)` that derives the lock TTL from `streamProcessInterval(cfg)` and adds a 5s buffer to prevent overlapping cycles, and wired it into the media worker config.
- Updated `cmd/server/main_test.go` with unit tests for `streamProcessInterval` and `streamWorkerLockTTL` to verify the capture timeout is honored and the TTL includes the buffer.
- Updated `docs/local_setup.md` to document that the scheduler cycle interval is aligned with `FUNPOT_STREAMLINK_CAPTURE_TIMEOUT`.

### Testing

- Ran the server package unit tests including the newly added tests via `go test ./cmd/server`, and the tests passed.
- Existing tests in `cmd/server` continue to pass after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40b4a1ed4832caf5b74068cf8c80c)