### PR TITLE
Coerce Gemini array responses for tracker stages and add unit test

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -585,6 +585,12 @@ func parseGeminiStageResponse(raw string, stage string) (geminiStageResponse, er
 
 	var generic map[string]any
 	if err := json.Unmarshal([]byte(cleaned), &generic); err != nil {
+		var arrayPayload []any
+		if arrayErr := json.Unmarshal([]byte(cleaned), &arrayPayload); arrayErr == nil {
+			if coerced, ok := coerceTrackerArrayResponse(stage, arrayPayload); ok {
+				return coerced, nil
+			}
+		}
 		return geminiStageResponse{}, fmt.Errorf("parse gemini stage response: %w", err)
 	}
 	parsed.Label = strings.TrimSpace(stringValue(generic["label"]))
@@ -611,6 +617,29 @@ func parseGeminiStageResponse(raw string, stage string) (geminiStageResponse, er
 		return geminiStageResponse{}, ErrGeminiEmptyResponse
 	}
 	return parsed, nil
+}
+
+func coerceTrackerArrayResponse(stage string, payload []any) (geminiStageResponse, bool) {
+	if !isTrackerStage(stage) {
+		return geminiStageResponse{}, false
+	}
+	delta, err := json.Marshal(payload)
+	if err != nil {
+		return geminiStageResponse{}, false
+	}
+	updatedState := json.RawMessage("{}")
+	if isTrackerStartStage(stage) {
+		updatedState = json.RawMessage(defaultTrackerState())
+	}
+	return geminiStageResponse{
+		Label:              "state_updated",
+		Confidence:         0,
+		UpdatedState:       updatedState,
+		Delta:              json.RawMessage(delta),
+		NextNeededEvidence: json.RawMessage("[]"),
+		HardConflicts:      json.RawMessage("[]"),
+		FinalOutcome:       "unknown",
+	}, true
 }
 
 func trimForLog(value string, max int) string {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -688,6 +688,59 @@ func TestGeminiStageClassifierBackfillsTrackerStartPayloadWithNullFinalOutcome(t
 	}
 }
 
+func TestGeminiStageClassifierCoercesTrackerArrayResponse(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "[{\"field\":\"score_state.ct_score\",\"value\":1}]"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	result, err := classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "match_update",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt:     prompts.PromptVersion{Stage: "match_update", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+	})
+	if err != nil {
+		t.Fatalf("expected tracker array payload coercion, got error %v", err)
+	}
+	if strings.TrimSpace(result.Label) != "state_updated" {
+		t.Fatalf("expected state_updated label, got %q", result.Label)
+	}
+	if strings.TrimSpace(result.UpdatedStateJSON) != "{}" {
+		t.Fatalf("expected empty object updated_state placeholder, got %q", result.UpdatedStateJSON)
+	}
+	if strings.TrimSpace(result.EvidenceDeltaJSON) != `[{"field":"score_state.ct_score","value":1}]` {
+		t.Fatalf("expected array payload in delta, got %q", result.EvidenceDeltaJSON)
+	}
+	if strings.TrimSpace(result.NextEvidenceJSON) != "[]" {
+		t.Fatalf("expected empty next_needed_evidence fallback, got %q", result.NextEvidenceJSON)
+	}
+	if strings.TrimSpace(result.FinalOutcome) != "unknown" {
+		t.Fatalf("expected unknown final_outcome fallback, got %q", result.FinalOutcome)
+	}
+}
+
 func TestGeminiStageClassifierCoercesStartStatePayloadToUpdatedState(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.mp4")


### PR DESCRIPTION
### Motivation
- Gemini sometimes returns a JSON array payload for tracker stages instead of the expected object shape, which breaks downstream state handling and classification.
- The classifier needs a deterministic `geminiStageResponse` shape for tracker stages (including `updated_state`, `delta`, and `final_outcome`) so tracking logic can proceed.

### Description
- Updated `parseGeminiStageResponse` to attempt unmarshaling the raw response as an array and call a new coercion helper when appropriate.
- Added `coerceTrackerArrayResponse` which recognizes tracker stages and converts an array payload into a `geminiStageResponse` with `Label: "state_updated"`, `Delta` set to the marshaled array, `UpdatedState` set to `{}` or the default tracker start state, `NextNeededEvidence`/`HardConflicts` set to `[]`, and `FinalOutcome` set to `"unknown"`.
- Kept existing object coercion logic in `coerceTrackerStateObjectResponse` and the general parsing fallback behavior.
- Added unit test `TestGeminiStageClassifierCoercesTrackerArrayResponse` that simulates a Gemini response containing an array and asserts the coerced label, updated state placeholder, delta payload, next evidence placeholder, and unknown final outcome.

### Testing
- Ran the new unit test with `go test ./internal/media -run TestGeminiStageClassifierCoercesTrackerArrayResponse -v`, and it passed.
- Ran the related Gemini stage classifier tests in `./internal/media`, and they all passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43ea7a344832cb2c39ced84a02cf6)