### PR TITLE
Add Bunny Stream chunk publisher and integrate with worker

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -128,7 +128,7 @@ func main() {
 		&media.InMemoryRunStore{},
 		streamersService,
 		media.NewInMemoryLocker(),
-		media.WorkerConfig{LockTTL: streamWorkerLockTTL(cfg), MinConfidence: 0.5},
+		media.WorkerConfig{LockTTL: streamWorkerLockTTL(cfg), MinConfidence: 0.5, ChunkPublisher: buildChunkPublisher(cfg)},
 	)
 	streamWorker.SetLogger(logger.Named("stream_worker"))
 	streamScheduler := media.NewScheduler(streamWorker, streamProcessInterval(cfg))
@@ -256,6 +256,20 @@ func streamWorkerLockTTL(cfg config.Config) time.Duration {
 	interval := streamProcessInterval(cfg)
 	// Keep lock slightly longer than capture interval to prevent overlapping cycles.
 	return interval + 5*time.Second
+}
+
+func buildChunkPublisher(cfg config.Config) media.ChunkPublisher {
+	if cfg.Streamlink.BunnyLibraryID == "" || cfg.Streamlink.BunnyAPIKey == "" {
+		return nil
+	}
+	return media.NewBunnyChunkPublisher(media.BunnyChunkPublisherConfig{
+		OutputDir:      cfg.Streamlink.OutputDir,
+		FFmpegBinary:   cfg.Streamlink.FFmpegBinary,
+		AggregateCount: cfg.Streamlink.AggregateCount,
+		BaseURL:        cfg.Streamlink.BunnyBaseURL,
+		LibraryID:      cfg.Streamlink.BunnyLibraryID,
+		APIKey:         cfg.Streamlink.BunnyAPIKey,
+	})
 }
 
 func newLogger(level string) (*zap.Logger, error) {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -121,6 +121,28 @@ func TestStreamWorkerLockTTLIncludesBuffer(t *testing.T) {
 	}
 }
 
+func TestBuildChunkPublisherReturnsNilWhenBunnyNotConfigured(t *testing.T) {
+	if got := buildChunkPublisher(config.Config{}); got != nil {
+		t.Fatal("expected nil publisher")
+	}
+}
+
+func TestBuildChunkPublisherReturnsPublisherWhenConfigured(t *testing.T) {
+	cfg := config.Config{
+		Streamlink: config.StreamlinkConfig{
+			OutputDir:      "tmp/stream_chunks",
+			FFmpegBinary:   "ffmpeg",
+			AggregateCount: 24,
+			BunnyBaseURL:   "https://video.bunnycdn.com",
+			BunnyLibraryID: "lib-id",
+			BunnyAPIKey:    "api-key",
+		},
+	}
+	if got := buildChunkPublisher(cfg); got == nil {
+		t.Fatal("expected publisher")
+	}
+}
+
 func buildAuthServiceForSetupStore(t *testing.T) *auth.Service {
 	t.Helper()
 	repo := users.NewInMemoryRepository()

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -46,6 +46,10 @@ FUNPOT_STREAMLINK_QUALITY=1080p60,1080p,720p60,720p,936p60,936p,648p60,648p,480p
 FUNPOT_STREAMLINK_CAPTURE_TIMEOUT=25s
 FUNPOT_STREAMLINK_OUTPUT_DIR=tmp/stream_chunks
 FUNPOT_STREAMLINK_URL_TEMPLATE=https://twitch.tv/%s
+FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT=24
+FUNPOT_STREAMLINK_BUNNY_BASE_URL=https://video.bunnycdn.com
+FUNPOT_STREAMLINK_BUNNY_LIBRARY_ID=
+FUNPOT_STREAMLINK_BUNNY_API_KEY=
 FUNPOT_GEMINI_API_KEY=<google_ai_studio_api_key>
 FUNPOT_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 FUNPOT_GEMINI_MAX_INLINE_BYTES=19922944
@@ -85,7 +89,11 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 
 > Scheduler cycle interval is aligned with `FUNPOT_STREAMLINK_CAPTURE_TIMEOUT`
 > (for example, `25s` timeout means one capture/LLM cycle every ~25 seconds).
-> This keeps chunk duration and LLM cadence consistent.
+>
+> Each ~25s chunk is analyzed immediately by the worker.
+> In parallel, chunks are accumulated and merged via `ffmpeg -c copy` (no re-encoding)
+> into ~10-minute windows (`FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT` controls batch size),
+> then uploaded to Bunny Stream when Bunny credentials are configured.
 
 > Set `FUNPOT_GEMINI_API_KEY` to enable real Gemini stage classification. When
 > it is unset, the server falls back to the deterministic placeholder

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,10 @@ type StreamlinkConfig struct {
 	CaptureTimeout time.Duration
 	OutputDir      string
 	URLTemplate    string
+	AggregateCount int
+	BunnyBaseURL   string
+	BunnyLibraryID string
+	BunnyAPIKey    string
 }
 
 // GeminiConfig controls outbound Gemini API integration for stage classification.
@@ -304,6 +308,10 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	streamlinkAggregateCount, err := getInt("FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT", 24)
+	if err != nil {
+		return Config{}, err
+	}
 
 	geminiMaxInlineBytes, err := getInt64("FUNPOT_GEMINI_MAX_INLINE_BYTES", 19*1024*1024)
 	if err != nil {
@@ -431,6 +439,10 @@ func Load() (Config, error) {
 			CaptureTimeout: streamlinkCaptureTimeout,
 			OutputDir:      getString("FUNPOT_STREAMLINK_OUTPUT_DIR", "tmp/stream_chunks"),
 			URLTemplate:    getString("FUNPOT_STREAMLINK_URL_TEMPLATE", "https://twitch.tv/%s"),
+			AggregateCount: streamlinkAggregateCount,
+			BunnyBaseURL:   getString("FUNPOT_STREAMLINK_BUNNY_BASE_URL", "https://video.bunnycdn.com"),
+			BunnyLibraryID: strings.TrimSpace(os.Getenv("FUNPOT_STREAMLINK_BUNNY_LIBRARY_ID")),
+			BunnyAPIKey:    strings.TrimSpace(os.Getenv("FUNPOT_STREAMLINK_BUNNY_API_KEY")),
 		},
 		Gemini: GeminiConfig{
 			APIKey:         os.Getenv("FUNPOT_GEMINI_API_KEY"),
@@ -492,6 +504,15 @@ func Load() (Config, error) {
 		}
 		if strings.TrimSpace(cfg.Streamlink.URLTemplate) == "" || !strings.Contains(cfg.Streamlink.URLTemplate, "%s") {
 			return Config{}, fmt.Errorf("FUNPOT_STREAMLINK_URL_TEMPLATE must include %%s placeholder")
+		}
+		if cfg.Streamlink.AggregateCount <= 0 {
+			return Config{}, fmt.Errorf("FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT must be > 0")
+		}
+		if cfg.Streamlink.BunnyLibraryID != "" && cfg.Streamlink.BunnyAPIKey == "" {
+			return Config{}, fmt.Errorf("FUNPOT_STREAMLINK_BUNNY_API_KEY must be set when FUNPOT_STREAMLINK_BUNNY_LIBRARY_ID is configured")
+		}
+		if cfg.Streamlink.BunnyAPIKey != "" && cfg.Streamlink.BunnyLibraryID == "" {
+			return Config{}, fmt.Errorf("FUNPOT_STREAMLINK_BUNNY_LIBRARY_ID must be set when FUNPOT_STREAMLINK_BUNNY_API_KEY is configured")
 		}
 	}
 

--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -1,0 +1,213 @@
+package media
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBunnyBaseURL          = "https://video.bunnycdn.com"
+	defaultChunkPublishBatchSize = 24
+)
+
+type BunnyChunkPublisherConfig struct {
+	OutputDir      string
+	FFmpegBinary   string
+	Runner         StreamlinkCommandRunner
+	AggregateCount int
+	BaseURL        string
+	LibraryID      string
+	APIKey         string
+	HTTPTimeout    time.Duration
+}
+
+type BunnyChunkPublisher struct {
+	cfg    BunnyChunkPublisherConfig
+	client *http.Client
+}
+
+func NewBunnyChunkPublisher(cfg BunnyChunkPublisherConfig) *BunnyChunkPublisher {
+	if strings.TrimSpace(cfg.OutputDir) == "" {
+		cfg.OutputDir = "tmp/stream_chunks"
+	}
+	if strings.TrimSpace(cfg.FFmpegBinary) == "" {
+		cfg.FFmpegBinary = "ffmpeg"
+	}
+	if cfg.Runner == nil {
+		cfg.Runner = execStreamlinkRunner{}
+	}
+	if cfg.AggregateCount <= 0 {
+		cfg.AggregateCount = defaultChunkPublishBatchSize
+	}
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		cfg.BaseURL = defaultBunnyBaseURL
+	}
+	if cfg.HTTPTimeout <= 0 {
+		cfg.HTTPTimeout = 2 * time.Minute
+	}
+	return &BunnyChunkPublisher{cfg: cfg, client: &http.Client{Timeout: cfg.HTTPTimeout}}
+}
+
+func (p *BunnyChunkPublisher) Publish(ctx context.Context, streamerID string, chunk ChunkRef) error {
+	if p == nil {
+		return nil
+	}
+	if strings.TrimSpace(p.cfg.LibraryID) == "" || strings.TrimSpace(p.cfg.APIKey) == "" {
+		return nil
+	}
+	chunkPath := strings.TrimSpace(chunk.Reference)
+	if chunkPath == "" {
+		return fmt.Errorf("publish chunk: empty chunk reference")
+	}
+
+	segmentsDir := filepath.Join(p.cfg.OutputDir, sanitizeToken(streamerID), "segments")
+	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
+		return err
+	}
+	segmentPath := filepath.Join(segmentsDir, filepath.Base(chunkPath))
+	if err := os.Rename(chunkPath, segmentPath); err != nil {
+		return err
+	}
+
+	segments, err := p.listSegments(segmentsDir)
+	if err != nil {
+		return err
+	}
+	if len(segments) < p.cfg.AggregateCount {
+		return nil
+	}
+
+	selected := segments[:p.cfg.AggregateCount]
+	windowPath, err := p.concatSegments(ctx, streamerID, segmentsDir, selected)
+	if err != nil {
+		return err
+	}
+	for _, segment := range selected {
+		_ = os.Remove(segment)
+	}
+	defer os.Remove(windowPath) //nolint:errcheck
+
+	videoID, err := p.createVideo(ctx, streamerID, chunk.CapturedAt)
+	if err != nil {
+		return err
+	}
+	if err := p.uploadVideo(ctx, videoID, windowPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *BunnyChunkPublisher) listSegments(segmentsDir string) ([]string, error) {
+	entries, err := os.ReadDir(segmentsDir)
+	if err != nil {
+		return nil, err
+	}
+	segments := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".mp4") {
+			continue
+		}
+		segments = append(segments, filepath.Join(segmentsDir, entry.Name()))
+	}
+	sort.Strings(segments)
+	return segments, nil
+}
+
+func (p *BunnyChunkPublisher) concatSegments(ctx context.Context, streamerID, segmentsDir string, selected []string) (string, error) {
+	listPath := filepath.Join(segmentsDir, fmt.Sprintf("concat_%s.txt", sanitizeToken(time.Now().UTC().Format(time.RFC3339Nano))))
+	var body strings.Builder
+	for _, segment := range selected {
+		body.WriteString("file '")
+		body.WriteString(strings.ReplaceAll(segment, "'", "'\\''"))
+		body.WriteString("'\n")
+	}
+	if err := os.WriteFile(listPath, []byte(body.String()), 0o644); err != nil {
+		return "", err
+	}
+	defer os.Remove(listPath) //nolint:errcheck
+
+	outputPath := filepath.Join(p.cfg.OutputDir, sanitizeToken(streamerID), fmt.Sprintf("window_%s.mp4", sanitizeToken(time.Now().UTC().Format("20060102T150405.000000000"))))
+	var stderr strings.Builder
+	args := []string{"-y", "-f", "concat", "-safe", "0", "-i", listPath, "-c", "copy", outputPath}
+	if err := p.cfg.Runner.Run(ctx, io.Discard, &stderr, p.cfg.FFmpegBinary, args...); err != nil {
+		_ = os.Remove(outputPath)
+		return "", fmt.Errorf("concat chunks failed: %w (stderr=%s)", err, strings.TrimSpace(stderr.String()))
+	}
+	return outputPath, nil
+}
+
+type bunnyCreateVideoRequest struct {
+	Title string `json:"title"`
+}
+
+type bunnyCreateVideoResponse struct {
+	GUID string `json:"guid"`
+}
+
+func (p *BunnyChunkPublisher) createVideo(ctx context.Context, streamerID string, capturedAt time.Time) (string, error) {
+	title := fmt.Sprintf("%s-%s", sanitizeToken(streamerID), sanitizeToken(capturedAt.UTC().Format(time.RFC3339Nano)))
+	payload, err := json.Marshal(bunnyCreateVideoRequest{Title: title})
+	if err != nil {
+		return "", err
+	}
+	endpoint := strings.TrimRight(p.cfg.BaseURL, "/") + "/library/" + p.cfg.LibraryID + "/videos"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("AccessKey", p.cfg.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return "", fmt.Errorf("create bunny video failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(msg)))
+	}
+	var decoded bunnyCreateVideoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(decoded.GUID) == "" {
+		return "", fmt.Errorf("create bunny video: empty guid")
+	}
+	return decoded.GUID, nil
+}
+
+func (p *BunnyChunkPublisher) uploadVideo(ctx context.Context, videoID, videoPath string) error {
+	file, err := os.Open(filepath.Clean(videoPath))
+	if err != nil {
+		return err
+	}
+	defer file.Close() //nolint:errcheck
+
+	endpoint := strings.TrimRight(p.cfg.BaseURL, "/") + "/library/" + p.cfg.LibraryID + "/videos/" + videoID
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, file)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("AccessKey", p.cfg.APIKey)
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("upload bunny video failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(msg)))
+	}
+	return nil
+}

--- a/internal/media/publisher_test.go
+++ b/internal/media/publisher_test.go
@@ -1,0 +1,104 @@
+package media
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakePublishRunner struct {
+	names []string
+	args  [][]string
+}
+
+func (f *fakePublishRunner) Run(_ context.Context, _ io.Writer, _ io.Writer, name string, args ...string) error {
+	f.names = append(f.names, name)
+	f.args = append(f.args, append([]string(nil), args...))
+	if strings.Contains(name, "ffmpeg") {
+		outputPath := args[len(args)-1]
+		listPath := ""
+		for i := 0; i < len(args)-1; i++ {
+			if args[i] == "-i" && i+1 < len(args) {
+				listPath = args[i+1]
+				break
+			}
+		}
+		listData, err := os.ReadFile(listPath)
+		if err != nil {
+			return err
+		}
+		var merged strings.Builder
+		for _, line := range strings.Split(string(listData), "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "file '") || !strings.HasSuffix(line, "'") {
+				continue
+			}
+			segmentPath := strings.TrimSuffix(strings.TrimPrefix(line, "file '"), "'")
+			payload, readErr := os.ReadFile(segmentPath)
+			if readErr != nil {
+				return readErr
+			}
+			merged.Write(payload)
+		}
+		return os.WriteFile(outputPath, []byte(merged.String()), 0o644)
+	}
+	return nil
+}
+
+func TestBunnyChunkPublisherAggregatesAndUploadsWhenBatchReady(t *testing.T) {
+	uploadCalls := 0
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/videos"):
+			_, _ = w.Write([]byte(`{"guid":"video-1"}`))
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/videos/video-1"):
+			uploadCalls++
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer api.Close()
+
+	runner := &fakePublishRunner{}
+	dir := t.TempDir()
+	publisher := NewBunnyChunkPublisher(BunnyChunkPublisherConfig{
+		OutputDir:      dir,
+		FFmpegBinary:   "ffmpeg",
+		Runner:         runner,
+		AggregateCount: 2,
+		BaseURL:        api.URL,
+		LibraryID:      "lib-1",
+		APIKey:         "key",
+		HTTPTimeout:    time.Second,
+	})
+
+	chunkA := filepath.Join(dir, "a.mp4")
+	if err := os.WriteFile(chunkA, []byte("A"), 0o644); err != nil {
+		t.Fatalf("write chunkA: %v", err)
+	}
+	if err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkA, CapturedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("publish first chunk: %v", err)
+	}
+	if uploadCalls != 0 {
+		t.Fatalf("uploadCalls = %d, want 0 before batch ready", uploadCalls)
+	}
+
+	chunkB := filepath.Join(dir, "b.mp4")
+	if err := os.WriteFile(chunkB, []byte("B"), 0o644); err != nil {
+		t.Fatalf("write chunkB: %v", err)
+	}
+	if err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkB, CapturedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("publish second chunk: %v", err)
+	}
+	if uploadCalls != 1 {
+		t.Fatalf("uploadCalls = %d, want 1 after batch ready", uploadCalls)
+	}
+}

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -87,6 +87,10 @@ type Locker interface {
 	Unlock(key string)
 }
 
+type ChunkPublisher interface {
+	Publish(ctx context.Context, streamerID string, chunk ChunkRef) error
+}
+
 type Worker struct {
 	logger              *zap.Logger
 	metrics             *workerMetrics
@@ -100,6 +104,7 @@ type Worker struct {
 	minConfidence       float64
 	captureRetryCount   int
 	captureRetryBackoff time.Duration
+	chunkPublisher      ChunkPublisher
 	sleepFn             func(context.Context, time.Duration) error
 }
 
@@ -108,6 +113,7 @@ type WorkerConfig struct {
 	MinConfidence       float64
 	CaptureRetryCount   int
 	CaptureRetryBackoff time.Duration
+	ChunkPublisher      ChunkPublisher
 }
 
 func NewWorker(capture StreamCapture, classifier StageClassifier, promptResolver PromptResolver, runs RunStore, decisions DecisionStore, locker Locker, cfg WorkerConfig) *Worker {
@@ -136,6 +142,7 @@ func NewWorker(capture StreamCapture, classifier StageClassifier, promptResolver
 		minConfidence:       cfg.MinConfidence,
 		captureRetryCount:   cfg.CaptureRetryCount,
 		captureRetryBackoff: cfg.CaptureRetryBackoff,
+		chunkPublisher:      cfg.ChunkPublisher,
 		sleepFn:             sleepContext,
 	}
 }
@@ -216,6 +223,14 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 		w.metrics.recordFailure(ctx, id, "execution_plan")
 		w.metrics.recordCycle(ctx, id, "failed")
 		return streamers.LLMDecision{}, err
+	}
+	if w.chunkPublisher != nil {
+		if err := w.chunkPublisher.Publish(ctx, id, chunk); err != nil {
+			logger.Error("chunk publish failed", zap.String("streamerID", id), zap.String("chunkRef", chunk.Reference), zap.Error(err))
+			w.metrics.recordFailure(ctx, id, "publish_chunk")
+			w.metrics.recordCycle(ctx, id, "failed")
+			return streamers.LLMDecision{}, err
+		}
 	}
 	w.metrics.recordCycle(ctx, id, "completed")
 	logger.Info("streamer processing cycle completed", zap.String("streamerID", id), zap.String("runID", runID), zap.String("finalStage", lastDecision.Stage), zap.String("finalLabel", lastDecision.Label), zap.Float64("finalConfidence", lastDecision.Confidence))

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -87,6 +87,11 @@ type flakyClassifier struct {
 	result   StageClassification
 }
 
+type fakeChunkPublisher struct {
+	err   error
+	calls int
+}
+
 func (f *flakyClassifier) Classify(_ context.Context, input StageRequest) (StageClassification, error) {
 	if f.calls == nil {
 		f.calls = map[string]int{}
@@ -96,6 +101,11 @@ func (f *flakyClassifier) Classify(_ context.Context, input StageRequest) (Stage
 		return StageClassification{}, errors.New("temporary llm failure")
 	}
 	return f.result, nil
+}
+
+func (f *fakeChunkPublisher) Publish(_ context.Context, _ string, _ ChunkRef) error {
+	f.calls++
+	return f.err
 }
 
 func (s *fakeDecisionStore) RecordLLMDecision(_ context.Context, req streamers.RecordDecisionRequest) (streamers.LLMDecision, error) {
@@ -313,6 +323,17 @@ func TestWorkerProcessStreamerRetriesStageClassification(t *testing.T) {
 	}
 	if got := classifier.calls["custom"]; got != 2 {
 		t.Fatalf("classifier calls = %d, want 2", got)
+	}
+}
+
+func TestWorkerProcessStreamerPublishesChunkAfterAnalysis(t *testing.T) {
+	publisher := &fakeChunkPublisher{}
+	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, fakeClassifier{results: map[string]StageClassification{"custom": {Label: "ok", Confidence: 0.9}}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5, ChunkPublisher: publisher})
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if publisher.calls != 1 {
+		t.Fatalf("publisher calls = %d, want 1", publisher.calls)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Enable optional archival of live stream chunks to Bunny Stream by aggregating, concatenating and uploading segments. 
- Provide a configurable, pluggable chunk publisher so the worker can publish archived windows without coupling to upload implementation. 
- Expose necessary configuration and validations to control aggregation and Bunny credentials. 

### Description
- Add `media.BunnyChunkPublisher` to aggregate `.mp4` segments, run `ffmpeg -f concat -c copy` to produce windowed MP4s, create videos via Bunny Library API and upload the merged files. 
- Introduce a `ChunkPublisher` interface and `ChunkPublisher` field on `WorkerConfig`, and wire `ChunkPublisher` into `Worker.ProcessStreamer` to publish after analysis. 
- Add `buildChunkPublisher` in `cmd/server/main.go` and inject it into the worker when Bunny credentials are present. 
- Extend `StreamlinkConfig` with `AggregateCount`, `BunnyBaseURL`, `BunnyLibraryID`, and `BunnyAPIKey`, add environment variables and local docs, and validate config combinations in `internal/config`. 
- Add unit tests for the publisher (`internal/media/publisher_test.go`), worker publish behavior (`internal/media/worker_test.go`), and main helpers (`cmd/server/main_test.go`).

### Testing
- Ran `go test ./...` including `TestBunnyChunkPublisherAggregatesAndUploadsWhenBatchReady`, `TestBuildChunkPublisherReturnsNilWhenBunnyNotConfigured`, `TestBuildChunkPublisherReturnsPublisherWhenConfigured`, and `TestWorkerProcessStreamerPublishesChunkAfterAnalysis`. 
- All unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51feddc98832cbaab07ed5de60e32)