### PR TITLE
Support legacy tracker delta payloads in Gemini stage responses

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -611,6 +611,9 @@ func parseGeminiStageResponse(raw string, stage string) (geminiStageResponse, er
 	parsed.HardConflicts = rawMessageFromGenericValue(generic["hard_conflicts"])
 	parsed.FinalOutcome = strings.TrimSpace(stringValue(generic["final_outcome"]))
 	if !hasGeminiResponsePayload(parsed) {
+		if coerced, ok := coerceTrackerLegacyDeltaResponse(stage, generic); ok {
+			return coerced, nil
+		}
 		if coerced, ok := coerceTrackerStateObjectResponse(stage, generic); ok {
 			return coerced, nil
 		}
@@ -674,6 +677,48 @@ func coerceTrackerStateObjectResponse(stage string, payload map[string]any) (gem
 		NextNeededEvidence: json.RawMessage("[]"),
 		HardConflicts:      json.RawMessage("[]"),
 		FinalOutcome:       "unknown",
+	}, true
+}
+
+func coerceTrackerLegacyDeltaResponse(stage string, payload map[string]any) (geminiStageResponse, bool) {
+	if !isTrackerStage(stage) || len(payload) == 0 {
+		return geminiStageResponse{}, false
+	}
+	stateChanges, hasStateChanges := payload["state_changes"]
+	newEvidence, hasNewEvidence := payload["new_evidence"]
+	if !hasStateChanges && !hasNewEvidence {
+		return geminiStageResponse{}, false
+	}
+
+	updatedState := rawMessageFromGenericValue(stateChanges)
+	if len(updatedState) == 0 || strings.TrimSpace(string(updatedState)) == "null" {
+		updatedState = json.RawMessage("{}")
+	}
+	delta := rawMessageFromGenericValue(newEvidence)
+	if len(delta) == 0 || strings.TrimSpace(string(delta)) == "null" {
+		delta = json.RawMessage("[]")
+	}
+	nextNeededEvidence := rawMessageFromGenericValue(payload["next_needed_evidence"])
+	if len(nextNeededEvidence) == 0 || strings.TrimSpace(string(nextNeededEvidence)) == "null" {
+		nextNeededEvidence = json.RawMessage("[]")
+	}
+	hardConflicts := rawMessageFromGenericValue(payload["hard_conflicts"])
+	if len(hardConflicts) == 0 || strings.TrimSpace(string(hardConflicts)) == "null" {
+		hardConflicts = json.RawMessage("[]")
+	}
+	finalOutcome := strings.TrimSpace(stringValue(payload["final_outcome"]))
+	if finalOutcome == "" {
+		finalOutcome = "unknown"
+	}
+
+	return geminiStageResponse{
+		Label:              "state_updated",
+		Confidence:         confidenceFromGeneric(payload["confidence"]),
+		UpdatedState:       updatedState,
+		Delta:              delta,
+		NextNeededEvidence: nextNeededEvidence,
+		HardConflicts:      hardConflicts,
+		FinalOutcome:       finalOutcome,
 	}, true
 }
 

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -794,6 +794,59 @@ func TestGeminiStageClassifierCoercesStartStatePayloadToUpdatedState(t *testing.
 	}
 }
 
+func TestGeminiStageClassifierCoercesLegacyTrackerDeltaPayload(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+	                    "candidates": [{
+	                        "content": {"parts": [{"text": "{\"chunk_time_range\":\"00:00-00:07\",\"new_evidence\":[{\"type\":\"score_update\",\"text\":\"5-6\",\"confidence\":1.0}],\"state_changes\":{\"t_score\":6,\"ct_score\":5,\"session_status\":\"in_progress\"}}"}]}
+	                    }],
+	                    "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
+	                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	result, err := classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "Start",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt:     prompts.PromptVersion{Stage: "Start", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+	})
+	if err != nil {
+		t.Fatalf("expected legacy tracker payload coercion, got error %v", err)
+	}
+	if strings.TrimSpace(result.Label) != "state_updated" {
+		t.Fatalf("expected state_updated label, got %q", result.Label)
+	}
+	if strings.TrimSpace(result.UpdatedStateJSON) != `{"ct_score":5,"session_status":"in_progress","t_score":6}` {
+		t.Fatalf("unexpected updated_state mapping, got %q", result.UpdatedStateJSON)
+	}
+	if strings.TrimSpace(result.EvidenceDeltaJSON) != `[{"confidence":1,"text":"5-6","type":"score_update"}]` {
+		t.Fatalf("unexpected delta mapping, got %q", result.EvidenceDeltaJSON)
+	}
+	if strings.TrimSpace(result.NextEvidenceJSON) != "[]" {
+		t.Fatalf("expected empty next_needed_evidence fallback, got %q", result.NextEvidenceJSON)
+	}
+	if strings.TrimSpace(result.FinalOutcome) != "unknown" {
+		t.Fatalf("expected unknown final_outcome fallback, got %q", result.FinalOutcome)
+	}
+}
+
 func TestGeminiStageClassifierDoesNotCoerceNonTrackerStatePayload(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.mp4")


### PR DESCRIPTION
### Motivation
- Accept legacy Gemini tracker responses that use `state_changes`/`new_evidence` instead of the newer `updated_state`/`delta` fields so stage classification remains backward-compatible.

### Description
- Add `coerceTrackerLegacyDeltaResponse` which detects legacy payload shapes and coerces them into `geminiStageResponse` with normalized JSON fields and confidence via `confidenceFromGeneric`.
- Invoke the new coercion from `parseGeminiStageResponse` as a fallback when a parsed response has no explicit payload.
- Ensure missing or null legacy fields are normalized to defaults (`{}`, `[]`, and `"unknown"`) and preserve mapped values for `UpdatedState`, `Delta`, `NextNeededEvidence`, `HardConflicts`, and `FinalOutcome`.
- Add `TestGeminiStageClassifierCoercesLegacyTrackerDeltaPayload` to validate parsing of a mocked legacy Gemini response and the resulting JSON mappings.

### Testing
- Ran `go test ./internal/media -run TestGeminiStageClassifierCoercesLegacyTrackerDeltaPayload` and the new test passed.
- Ran `go test ./...` to verify the package suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52a41d850832cbc60a93d6528f581)