### PR TITLE
Lower Streamlink archive aggregate default to 5 (≈2-minute archives)

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -46,7 +46,7 @@ FUNPOT_STREAMLINK_QUALITY=1080p60,1080p,720p60,720p,936p60,936p,648p60,648p,480p
 FUNPOT_STREAMLINK_CAPTURE_TIMEOUT=25s
 FUNPOT_STREAMLINK_OUTPUT_DIR=tmp/stream_chunks
 FUNPOT_STREAMLINK_URL_TEMPLATE=https://twitch.tv/%s
-FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT=24
+FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT=5
 FUNPOT_STREAMLINK_BUNNY_BASE_URL=https://video.bunnycdn.com
 FUNPOT_STREAMLINK_BUNNY_LIBRARY_ID=
 FUNPOT_STREAMLINK_BUNNY_API_KEY=
@@ -92,7 +92,7 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 >
 > Each ~25s chunk is analyzed immediately by the worker.
 > In parallel, chunks are accumulated and merged via `ffmpeg -c copy` (no re-encoding)
-> into ~10-minute windows (`FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT` controls batch size),
+> into ~2-minute windows (`FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT` controls batch size),
 > then uploaded to Bunny Stream when Bunny credentials are configured.
 
 > Set `FUNPOT_GEMINI_API_KEY` to enable real Gemini stage classification. When

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -308,7 +308,7 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	streamlinkAggregateCount, err := getInt("FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT", 24)
+	streamlinkAggregateCount, err := getInt("FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT", 5)
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	defaultBunnyBaseURL          = "https://video.bunnycdn.com"
-	defaultChunkPublishBatchSize = 24
+	defaultChunkPublishBatchSize = 5
 )
 
 type BunnyChunkPublisherConfig struct {


### PR DESCRIPTION
### Motivation

- Reduce the default Streamlink archive batch size to create smaller (~2-minute) aggregated uploads for faster processing, uploads, and analysis while keeping documentation and code in sync.

### Description

- Updated the default `FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT` from `24` to `5` in `docs/local_setup.md`, `internal/config/config.go`, and `internal/media/publisher.go`, and adjusted the docs text to reference ~2-minute windows instead of ~10-minute windows.

### Testing

- Ran `go test ./...` and basic build checks, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5330e93a4832ca4a7eef51a7cc4a0)