### PR TITLE
Introduce GeminiGenerateContentError and add retry handling for transient Gemini failures

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -48,6 +48,45 @@ type GeminiStageClassifier struct {
 	sessions       map[string]geminiChatSession
 }
 
+type GeminiGenerateContentError struct {
+	StatusCode      int
+	Stage           string
+	Model           string
+	MIMEType        string
+	HasChunk        bool
+	MaxOutputTokens int
+	Temperature     float64
+	Body            string
+}
+
+func (e *GeminiGenerateContentError) Error() string {
+	if e == nil {
+		return "gemini generateContent failed"
+	}
+	return fmt.Sprintf("gemini generateContent failed: status=%d stage=%s model=%s mime=%s has_chunk=%t max_output_tokens=%d temperature=%.3f body=%s",
+		e.StatusCode,
+		strings.TrimSpace(e.Stage),
+		strings.TrimSpace(e.Model),
+		strings.TrimSpace(e.MIMEType),
+		e.HasChunk,
+		e.MaxOutputTokens,
+		e.Temperature,
+		strings.TrimSpace(e.Body),
+	)
+}
+
+func (e *GeminiGenerateContentError) Retryable() bool {
+	if e == nil {
+		return false
+	}
+	switch e.StatusCode {
+	case http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
 type geminiChatSession struct {
 	TokenCount        int
 	PromptFingerprint string
@@ -218,16 +257,16 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 		return StageClassification{}, err
 	}
 	if resp.StatusCode >= 400 {
-		return StageClassification{}, fmt.Errorf("gemini generateContent failed: status=%d stage=%s model=%s mime=%s has_chunk=%t max_output_tokens=%d temperature=%.3f body=%s",
-			resp.StatusCode,
-			strings.TrimSpace(input.Stage),
-			model,
-			mimeType,
-			hasChunk,
-			requestBody.GenerationConfig.MaxOutputTokens,
-			requestBody.GenerationConfig.Temperature,
-			strings.TrimSpace(string(responseBody)),
-		)
+		return StageClassification{}, &GeminiGenerateContentError{
+			StatusCode:      resp.StatusCode,
+			Stage:           input.Stage,
+			Model:           model,
+			MIMEType:        mimeType,
+			HasChunk:        hasChunk,
+			MaxOutputTokens: requestBody.GenerationConfig.MaxOutputTokens,
+			Temperature:     requestBody.GenerationConfig.Temperature,
+			Body:            string(responseBody),
+		}
 	}
 
 	var payload geminiGenerateContentResponse

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -719,6 +719,10 @@ func (w *Worker) classifyWithRetry(ctx context.Context, input StageRequest, acti
 	if attempts <= 0 {
 		attempts = 1
 	}
+	const (
+		minTransientAttempts    = 3
+		defaultTransientBackoff = 500 * time.Millisecond
+	)
 
 	var lastErr error
 	for attempt := 1; attempt <= attempts; attempt++ {
@@ -727,14 +731,36 @@ func (w *Worker) classifyWithRetry(ctx context.Context, input StageRequest, acti
 			return result, nil
 		}
 		lastErr = err
-		if attempt == attempts {
+		geminiRetryable, isGeminiError := geminiRetryableClassificationError(err)
+		retryable := geminiRetryable || !isGeminiError
+		maxAttempts := attempts
+		if geminiRetryable && maxAttempts < minTransientAttempts {
+			maxAttempts = minTransientAttempts
+		}
+		if !retryable || attempt == maxAttempts {
 			break
 		}
-		if err := w.waitForRetry(ctx, time.Duration(activePrompt.BackoffMS)*time.Millisecond, attempt); err != nil {
+		backoff := time.Duration(activePrompt.BackoffMS) * time.Millisecond
+		if geminiRetryable && backoff <= 0 {
+			backoff = defaultTransientBackoff
+		}
+		if err := w.waitForRetry(ctx, backoff, attempt); err != nil {
 			return StageClassification{}, err
 		}
+		attempts = maxAttempts
 	}
 	return StageClassification{}, lastErr
+}
+
+func geminiRetryableClassificationError(err error) (retryable bool, isGemini bool) {
+	if err == nil {
+		return false, false
+	}
+	var geminiErr *GeminiGenerateContentError
+	if errors.As(err, &geminiErr) {
+		return geminiErr.Retryable(), true
+	}
+	return false, false
 }
 
 func (w *Worker) waitForRetry(ctx context.Context, base time.Duration, attempt int) error {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -3,6 +3,7 @@ package media
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,6 +86,7 @@ type flakyClassifier struct {
 	failures int
 	calls    map[string]int
 	result   StageClassification
+	err      error
 }
 
 type fakeChunkPublisher struct {
@@ -98,6 +100,9 @@ func (f *flakyClassifier) Classify(_ context.Context, input StageRequest) (Stage
 	}
 	f.calls[input.Stage]++
 	if f.calls[input.Stage] <= f.failures {
+		if f.err != nil {
+			return StageClassification{}, f.err
+		}
 		return StageClassification{}, errors.New("temporary llm failure")
 	}
 	return f.result, nil
@@ -347,6 +352,48 @@ func TestWorkerProcessStreamerReturnsErrorAfterRetryExhausted(t *testing.T) {
 	}
 	if got := classifier.calls["custom"]; got != 2 {
 		t.Fatalf("classifier calls = %d, want 2", got)
+	}
+}
+
+func TestWorkerProcessStreamerRetriesTransientGeminiFailuresWithSafetyFloor(t *testing.T) {
+	classifier := &flakyClassifier{
+		failures: 2,
+		result:   StageClassification{Label: "ok", Confidence: 0.9},
+		err: &GeminiGenerateContentError{
+			StatusCode: http.StatusServiceUnavailable,
+			Stage:      "custom",
+			Model:      "gemini",
+		},
+	}
+	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, classifier, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1, RetryCount: 0, BackoffMS: 0}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+	worker.sleepFn = func(context.Context, time.Duration) error { return nil }
+
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got := classifier.calls["custom"]; got != 3 {
+		t.Fatalf("classifier calls = %d, want 3", got)
+	}
+}
+
+func TestWorkerProcessStreamerDoesNotRetryNonTransientGeminiFailures(t *testing.T) {
+	classifier := &flakyClassifier{
+		failures: 2,
+		result:   StageClassification{Label: "ok", Confidence: 0.9},
+		err: &GeminiGenerateContentError{
+			StatusCode: http.StatusBadRequest,
+			Stage:      "custom",
+			Model:      "gemini",
+		},
+	}
+	worker := NewWorker(fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, classifier, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1, RetryCount: 3, BackoffMS: 10}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+	worker.sleepFn = func(context.Context, time.Duration) error { return nil }
+
+	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err == nil {
+		t.Fatal("expected non-transient gemini error")
+	}
+	if got := classifier.calls["custom"]; got != 1 {
+		t.Fatalf("classifier calls = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Provide a typed error for Gemini `generateContent` failures so retry behavior can distinguish transient service errors from permanent ones. 
- Ensure the worker retry loop enforces a safety floor of attempts and a default backoff for transient Gemini outages even when prompt settings are zero.

### Description

- Add `GeminiGenerateContentError` struct with `Error()` and `Retryable()` methods to capture HTTP status, model, MIME, chunk presence, token and temperature info, and response body. 
- Return `*GeminiGenerateContentError` from the Gemini classifier when the `generateContent` HTTP status is >= 400 instead of an unstructured formatted string. 
- Update retry logic in `classifyWithRetry` to detect Gemini retryable errors via `geminiRetryableClassificationError`, apply a `minTransientAttempts` safety floor of 3 attempts, and use `defaultTransientBackoff` when configured backoff is zero. 
- Add helper `geminiRetryableClassificationError` and adjust waiting/backoff behavior and attempts accounting accordingly. 
- Update `flakyClassifier` test helper to accept a synthetic Gemini error and add two unit tests: `TestWorkerProcessStreamerRetriesTransientGeminiFailuresWithSafetyFloor` and `TestWorkerProcessStreamerDoesNotRetryNonTransientGeminiFailures` to validate retry behavior, plus a minor `net/http` import used by tests.

### Testing

- Ran package unit tests for `internal/media` including the new tests for transient and non-transient Gemini failures using `go test ./internal/media`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c539f171d8832c89f90b314257f042)