### PR TITLE
streamlink: add capture duration arg, HLS fallback, and shutdown grace period

### DIFF
--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -40,6 +41,7 @@ var streamlinkEndedMarkers = []string{
 
 const defaultPreferredStreamQuality = "1080p60,1080p,720p60,720p,936p60,936p,648p60,648p,480p,best"
 const minimumStreamlinkCaptureTimeout = 25 * time.Second
+const streamlinkCaptureShutdownGracePeriod = 5 * time.Second
 
 type StreamlinkChannelResolver interface {
 	ResolveStreamlinkChannel(ctx context.Context, streamerID string) (string, error)
@@ -159,15 +161,27 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 	}
 	defer file.Close() //nolint:errcheck
 
-	captureCtx, cancel := context.WithTimeout(ctx, a.cfg.CaptureTimeout)
+	captureCtx, cancel := context.WithTimeout(ctx, a.cfg.CaptureTimeout+streamlinkCaptureShutdownGracePeriod)
 	defer cancel()
 
 	streamURL := fmt.Sprintf(a.cfg.URLTemplate, channel)
-	args := []string{"--stdout", streamURL, a.cfg.Quality}
+	args := []string{"--stdout", "--stream-segmented-duration", formatStreamlinkDurationArg(a.cfg.CaptureTimeout), streamURL, a.cfg.Quality}
 
 	var stderr strings.Builder
 	logger.Info("executing streamlink capture", zap.String("streamerID", id), zap.String("binaryPath", a.cfg.BinaryPath), zap.String("streamURL", streamURL), zap.String("quality", a.cfg.Quality), zap.String("chunkPath", chunkPath))
 	runErr := a.runner.Run(captureCtx, file, &stderr, a.cfg.BinaryPath, args...)
+	if runErr != nil && isStreamlinkUnknownOption(stderr.String(), "--stream-segmented-duration") {
+		logger.Info("streamlink does not support --stream-segmented-duration; retrying with --hls-duration", zap.String("streamerID", id), zap.String("binaryPath", a.cfg.BinaryPath))
+		if err := file.Truncate(0); err != nil {
+			return ChunkRef{}, err
+		}
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			return ChunkRef{}, err
+		}
+		stderr.Reset()
+		args = []string{"--stdout", "--hls-duration", formatStreamlinkDurationArg(a.cfg.CaptureTimeout), streamURL, a.cfg.Quality}
+		runErr = a.runner.Run(captureCtx, file, &stderr, a.cfg.BinaryPath, args...)
+	}
 
 	stat, err := file.Stat()
 	if err != nil {
@@ -216,6 +230,28 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 		logger.Info("stream chunk normalized", zap.String("streamerID", id), zap.String("sourceChunkPath", chunk.Reference), zap.String("normalizedChunkPath", normalized.Reference))
 	}
 	return normalized, nil
+}
+
+func formatStreamlinkDurationArg(value time.Duration) string {
+	seconds := int(value.Round(time.Second) / time.Second)
+	if seconds <= 0 {
+		seconds = int(minimumStreamlinkCaptureTimeout / time.Second)
+	}
+	return strconv.Itoa(seconds)
+}
+
+func isStreamlinkUnknownOption(stderr, option string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(stderr))
+	if normalized == "" {
+		return false
+	}
+	needle := strings.ToLower(strings.TrimSpace(option))
+	if needle == "" || !strings.Contains(normalized, needle) {
+		return false
+	}
+	return strings.Contains(normalized, "unrecognized arguments") ||
+		strings.Contains(normalized, "unknown option") ||
+		strings.Contains(normalized, "no such option")
 }
 
 func sanitizeToken(value string) string {

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -102,6 +102,9 @@ func TestStreamlinkCaptureAdapterCaptureSuccess(t *testing.T) {
 	if !strings.Contains(joined, "https://twitch.tv/shroud") {
 		t.Fatalf("expected resolved channel in args, got %q", joined)
 	}
+	if !strings.Contains(joined, "--stream-segmented-duration 25") {
+		t.Fatalf("expected --stream-segmented-duration argument, got %q", joined)
+	}
 
 	data, err := os.ReadFile(chunk.Reference)
 	if err != nil {
@@ -115,6 +118,61 @@ func TestStreamlinkCaptureAdapterCaptureSuccess(t *testing.T) {
 	}
 	if filepath.Ext(chunk.Reference) != ".mp4" {
 		t.Fatalf("expected normalized mp4 chunk, got %q", chunk.Reference)
+	}
+}
+
+func TestStreamlinkCaptureAdapterFallsBackToHLSDurationWhenStreamSegmentedUnsupported(t *testing.T) {
+	outDir := t.TempDir()
+	attempt := 0
+	runner := &fakeCommandRunner{
+		runWithIOFn: func(stdout io.Writer, stderr io.Writer, name string, args ...string) error {
+			if strings.Contains(name, "ffprobe") {
+				_, _ = io.WriteString(stdout, `{"streams":[{"codec_name":"h264","width":1920,"height":1080}]}`)
+				return nil
+			}
+			if strings.Contains(name, "ffmpeg") && len(args) > 0 {
+				outputPath := args[len(args)-1]
+				inputPath := ""
+				for i := 0; i < len(args)-1; i++ {
+					if args[i] == "-i" && i+1 < len(args) {
+						inputPath = args[i+1]
+						break
+					}
+				}
+				data, err := os.ReadFile(inputPath)
+				if err != nil {
+					return err
+				}
+				return os.WriteFile(outputPath, data, 0o644)
+			}
+			attempt++
+			if attempt == 1 {
+				_, _ = io.WriteString(stderr, "error: unrecognized arguments: --stream-segmented-duration")
+				return errors.New("exit status 2")
+			}
+			_, _ = stdout.Write([]byte("chunk-bytes"))
+			return nil
+		},
+	}
+	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{OutputDir: outDir}, nil, runner)
+
+	chunk, err := adapter.Capture(context.Background(), "str_fallback")
+	if err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	if chunk.Reference == "" {
+		t.Fatal("expected chunk reference")
+	}
+	if len(runner.argsHistory) < 3 {
+		t.Fatalf("argsHistory length = %d, want at least 3 (streamlink retry + ffprobe + ffmpeg)", len(runner.argsHistory))
+	}
+	first := strings.Join(runner.argsHistory[0], " ")
+	second := strings.Join(runner.argsHistory[1], " ")
+	if !strings.Contains(first, "--stream-segmented-duration 25") {
+		t.Fatalf("first streamlink invocation = %q, want --stream-segmented-duration", first)
+	}
+	if !strings.Contains(second, "--hls-duration 25") {
+		t.Fatalf("second streamlink invocation = %q, want --hls-duration", second)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Ensure Streamlink captures run for the configured duration and give the binary a short shutdown grace period to flush output. 
- Support older Streamlink versions that do not recognize `--stream-segmented-duration` by falling back to `--hls-duration` when appropriate. 
- Expose a stable integer seconds value for duration arguments to avoid fractional durations being passed to Streamlink.

### Description
- Add `streamlinkCaptureShutdownGracePeriod` and extend the capture context timeout by that grace period when calling Streamlink. 
- Pass `--stream-segmented-duration <seconds>` to Streamlink using a new helper `formatStreamlinkDurationArg`, falling back to `--hls-duration <seconds>` when stderr indicates an unknown option. 
- Add helper `isStreamlinkUnknownOption` to heuristically detect Streamlink unknown-option errors from stderr. 
- Add `strconv` import and new unit tests, and update existing tests to assert the new arguments are used.

### Testing
- Ran unit tests for the media package including `TestStreamlinkCaptureAdapterCaptureSuccess`, `TestStreamlinkCaptureAdapterFallsBackToHLSDurationWhenStreamSegmentedUnsupported`, `TestStreamlinkCaptureAdapterAcceptsTimeoutWhenChunkCaptured`, and `TestNewStreamlinkCaptureAdapterEnforcesMinimumCaptureTimeout`; all tests passed. 
- Executed `go test ./internal/media` to verify behavior of the new helpers and fallback logic, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c53d280490832cb362dffb25a703db)