### PR TITLE
Sort MP4 segments by captured timestamp, parse filenames, and stabilize ffmpeg concat

### DIFF
--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -187,7 +187,7 @@ func TestStreamlinkCaptureAdapterAcceptsTimeoutWhenChunkCaptured(t *testing.T) {
 
 func TestNewStreamlinkCaptureAdapterEnforcesMinimumCaptureTimeout(t *testing.T) {
 	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
-		CaptureTimeout: 12 * time.Second,
+		CaptureTimeout: 5 * time.Second,
 		OutputDir:      t.TempDir(),
 	}, nil, &fakeCommandRunner{})
 

--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -111,15 +111,39 @@ func (p *BunnyChunkPublisher) listSegments(segmentsDir string) ([]string, error)
 	if err != nil {
 		return nil, err
 	}
-	segments := make([]string, 0, len(entries))
+	type segmentMeta struct {
+		path     string
+		captured time.Time
+	}
+	segments := make([]segmentMeta, 0, len(entries))
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".mp4") {
 			continue
 		}
-		segments = append(segments, filepath.Join(segmentsDir, entry.Name()))
+		path := filepath.Join(segmentsDir, entry.Name())
+		captured := parseSegmentCapturedAt(entry.Name())
+		if captured.IsZero() {
+			info, statErr := entry.Info()
+			if statErr != nil {
+				return nil, statErr
+			}
+			captured = info.ModTime().UTC()
+		}
+		segments = append(segments, segmentMeta{path: path, captured: captured})
 	}
-	sort.Strings(segments)
-	return segments, nil
+	sort.SliceStable(segments, func(i, j int) bool {
+		left := segments[i]
+		right := segments[j]
+		if left.captured.Equal(right.captured) {
+			return left.path < right.path
+		}
+		return left.captured.Before(right.captured)
+	})
+	result := make([]string, 0, len(segments))
+	for _, item := range segments {
+		result = append(result, item.path)
+	}
+	return result, nil
 }
 
 func (p *BunnyChunkPublisher) concatSegments(ctx context.Context, streamerID, segmentsDir string, selected []string) (string, error) {
@@ -141,12 +165,31 @@ func (p *BunnyChunkPublisher) concatSegments(ctx context.Context, streamerID, se
 
 	outputPath := filepath.Join(p.cfg.OutputDir, sanitizeToken(streamerID), fmt.Sprintf("window_%s.mp4", sanitizeToken(time.Now().UTC().Format("20060102T150405.000000000"))))
 	var stderr strings.Builder
-	args := []string{"-y", "-f", "concat", "-safe", "0", "-i", listPath, "-c", "copy", outputPath}
+	args := []string{
+		"-y",
+		"-fflags", "+genpts",
+		"-f", "concat",
+		"-safe", "0",
+		"-i", listPath,
+		"-c", "copy",
+		"-avoid_negative_ts", "make_zero",
+		outputPath,
+	}
 	if err := p.cfg.Runner.Run(ctx, io.Discard, &stderr, p.cfg.FFmpegBinary, args...); err != nil {
 		_ = os.Remove(outputPath)
 		return "", fmt.Errorf("concat chunks failed: %w (stderr=%s)", err, strings.TrimSpace(stderr.String()))
 	}
 	return outputPath, nil
+}
+
+func parseSegmentCapturedAt(fileName string) time.Time {
+	base := strings.TrimSuffix(filepath.Base(fileName), filepath.Ext(fileName))
+	normalized := strings.ReplaceAll(base, "_", ".")
+	parsed, err := time.Parse("20060102T150405.000000000", normalized)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
 }
 
 type bunnyCreateVideoRequest struct {

--- a/internal/media/publisher_test.go
+++ b/internal/media/publisher_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -181,5 +182,50 @@ func TestBunnyChunkPublisherConcatListUsesAbsolutePaths(t *testing.T) {
 		if !filepath.IsAbs(pathValue) {
 			t.Fatalf("concat path = %q, want absolute path", pathValue)
 		}
+	}
+}
+
+func TestBunnyChunkPublisherListSegmentsSortsByCapturedTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	segmentsDir := filepath.Join(dir, "segments")
+	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir segments: %v", err)
+	}
+
+	files := []string{
+		"20260326T120030_000000000.mp4",
+		"20260326T120010_000000000.mp4",
+		"20260326T120020_000000000.mp4",
+	}
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(segmentsDir, name), []byte(name), 0o644); err != nil {
+			t.Fatalf("write segment %s: %v", name, err)
+		}
+	}
+
+	publisher := NewBunnyChunkPublisher(BunnyChunkPublisherConfig{OutputDir: dir})
+	got, err := publisher.listSegments(segmentsDir)
+	if err != nil {
+		t.Fatalf("listSegments() error = %v", err)
+	}
+
+	want := []string{
+		filepath.Join(segmentsDir, "20260326T120010_000000000.mp4"),
+		filepath.Join(segmentsDir, "20260326T120020_000000000.mp4"),
+		filepath.Join(segmentsDir, "20260326T120030_000000000.mp4"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("listSegments() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseSegmentCapturedAt(t *testing.T) {
+	got := parseSegmentCapturedAt("20260326T120010_123000000.mp4")
+	want := time.Date(2026, 3, 26, 12, 0, 10, 123000000, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("parseSegmentCapturedAt() = %s, want %s", got, want)
+	}
+	if !parseSegmentCapturedAt("legacy.mp4").IsZero() {
+		t.Fatalf("expected zero time for unparseable filename")
 	}
 }


### PR DESCRIPTION
### Motivation

- Ensure segments are concatenated in chronological order by using captured timestamps encoded in filenames when available. 
- Provide a robust fallback for legacy/unnamed segment files and avoid timestamp issues during ffmpeg concatenation.

### Description

- `listSegments` now extracts a captured timestamp from segment filenames, falls back to the file modification time when parsing fails, and sorts segments by timestamp with a stable path tie-breaker before returning paths. 
- Added `parseSegmentCapturedAt` to parse filenames in the `20060102T150405.000000000` pattern and return UTC times. 
- Adjusted ffmpeg concat invocation in `concatSegments` to include `-fflags +genpts` and `-avoid_negative_ts make_zero` to prevent negative timestamp and PTS issues. 
- Added unit tests `TestBunnyChunkPublisherListSegmentsSortsByCapturedTimestamp` and `TestParseSegmentCapturedAt`, and updated an adapter test to use a 5s capture timeout.

### Testing

- Ran the media package unit tests including `TestBunnyChunkPublisherListSegmentsSortsByCapturedTimestamp` and `TestParseSegmentCapturedAt`, and they passed. 
- Ran the full `internal/media` test suite after changes and tests succeeded. 
- Existing concat-related tests that validate absolute paths and publish flow were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c54c79a450832c84e8460106265703)