### PR TITLE
Continuous Streamlink capture, indexed segment publishing, and scheduler timing fix

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -88,7 +88,13 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 > when Streamlink capture is enabled.
 
 > Scheduler cycle interval is aligned with `FUNPOT_STREAMLINK_CAPTURE_TIMEOUT`
-> (for example, `25s` timeout means one capture/LLM cycle every ~25 seconds).
+> (for example, `25s` timeout means one capture/LLM cycle every ~25 seconds)
+> and automatically starts the next cycle without an extra idle pause when
+> the previous capture overruns the window.
+>
+> Stream capture now runs as a long-lived Streamlink→FFmpeg pipeline per streamer
+> and cuts sequential ~25s segments continuously (`%09d.ts`) to minimize boundary
+> loss between chunks.
 >
 > Each ~25s chunk is analyzed immediately by the worker.
 > In parallel, chunks are accumulated and merged via `ffmpeg -c copy` (no re-encoding)

--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -78,6 +79,20 @@ type StreamlinkCaptureAdapter struct {
 	runner     StreamlinkCommandRunner
 	normalizer ChunkNormalizer
 	nowFn      func() time.Time
+	continuous bool
+	mu         sync.Mutex
+	sessions   map[string]*continuousCaptureSession
+}
+
+type continuousCaptureSession struct {
+	streamerID    string
+	channel       string
+	segmentsDir   string
+	nextIndex     int
+	started       bool
+	lastErr       error
+	streamlinkCmd *exec.Cmd
+	ffmpegCmd     *exec.Cmd
 }
 
 func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver StreamlinkChannelResolver, runner StreamlinkCommandRunner) *StreamlinkCaptureAdapter {
@@ -97,8 +112,10 @@ func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver Streamlin
 	if strings.TrimSpace(cfg.URLTemplate) == "" {
 		cfg.URLTemplate = "https://twitch.tv/%s"
 	}
+	continuous := false
 	if runner == nil {
 		runner = execStreamlinkRunner{}
+		continuous = true
 	}
 	return &StreamlinkCaptureAdapter{
 		logger:     zap.NewNop(),
@@ -107,6 +124,8 @@ func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver Streamlin
 		runner:     runner,
 		normalizer: NewFFmpegChunkNormalizer(cfg.FFmpegBinary, runner),
 		nowFn:      time.Now,
+		continuous: continuous,
+		sessions:   make(map[string]*continuousCaptureSession),
 	}
 }
 
@@ -122,6 +141,13 @@ func (a *StreamlinkCaptureAdapter) SetLogger(logger *zap.Logger) {
 }
 
 func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID string) (ChunkRef, error) {
+	if a.continuous {
+		return a.captureContinuous(ctx, streamerID)
+	}
+	return a.captureSingle(ctx, streamerID)
+}
+
+func (a *StreamlinkCaptureAdapter) captureSingle(ctx context.Context, streamerID string) (ChunkRef, error) {
 	logger := a.logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -230,6 +256,160 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 		logger.Info("stream chunk normalized", zap.String("streamerID", id), zap.String("sourceChunkPath", chunk.Reference), zap.String("normalizedChunkPath", normalized.Reference))
 	}
 	return normalized, nil
+}
+
+func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, streamerID string) (ChunkRef, error) {
+	logger := a.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	id := strings.TrimSpace(streamerID)
+	if id == "" {
+		return ChunkRef{}, ErrStreamerIDRequired
+	}
+
+	channel := id
+	if a.resolver != nil {
+		resolved, err := a.resolver.ResolveStreamlinkChannel(ctx, id)
+		if err != nil {
+			return ChunkRef{}, fmt.Errorf("%w: %v", ErrStreamlinkChannelResolve, err)
+		}
+		channel = strings.TrimSpace(resolved)
+	}
+	if channel == "" {
+		return ChunkRef{}, fmt.Errorf("%w: empty channel", ErrStreamlinkChannelResolve)
+	}
+
+	session, err := a.ensureContinuousSession(id, channel)
+	if err != nil {
+		return ChunkRef{}, err
+	}
+	if session.lastErr != nil {
+		return ChunkRef{}, session.lastErr
+	}
+
+	targetIndex := session.nextIndex
+	deadline := time.Now().Add(a.cfg.CaptureTimeout + streamlinkCaptureShutdownGracePeriod)
+	for {
+		select {
+		case <-ctx.Done():
+			return ChunkRef{}, ctx.Err()
+		default:
+		}
+		segmentPath := filepath.Join(session.segmentsDir, fmt.Sprintf("%09d.ts", targetIndex))
+		info, statErr := os.Stat(segmentPath)
+		if statErr == nil && info.Size() > 0 {
+			chunkPath := filepath.Join(filepath.Dir(session.segmentsDir), fmt.Sprintf("%s.ts", sanitizeToken(fmt.Sprintf("%09d", targetIndex))))
+			if err := os.Rename(segmentPath, chunkPath); err != nil {
+				return ChunkRef{}, err
+			}
+			session.nextIndex++
+			chunk := ChunkRef{Reference: chunkPath, CapturedAt: a.nowFn().UTC()}
+			normalized, normErr := a.normalizer.Normalize(ctx, chunk)
+			if normErr != nil {
+				return ChunkRef{}, normErr
+			}
+			return normalized, nil
+		}
+		if time.Now().After(deadline) {
+			return ChunkRef{}, fmt.Errorf("%w: no continuous segment available before deadline", ErrStreamlinkNoData)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+func (a *StreamlinkCaptureAdapter) ensureContinuousSession(streamerID, channel string) (*continuousCaptureSession, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	session, ok := a.sessions[streamerID]
+	if !ok {
+		streamerDir := filepath.Join(a.cfg.OutputDir, sanitizeToken(streamerID))
+		segmentsDir := filepath.Join(streamerDir, "live_segments")
+		session = &continuousCaptureSession{
+			streamerID:  streamerID,
+			channel:     channel,
+			segmentsDir: segmentsDir,
+			nextIndex:   1,
+		}
+		a.sessions[streamerID] = session
+	}
+	if session.started {
+		return session, nil
+	}
+
+	if err := os.MkdirAll(session.segmentsDir, 0o755); err != nil {
+		return nil, err
+	}
+	for _, entry := range []string{"*.ts", "*.mp4"} {
+		matches, _ := filepath.Glob(filepath.Join(session.segmentsDir, entry))
+		for _, m := range matches {
+			_ = os.Remove(m)
+		}
+	}
+	session.started = true
+	session.lastErr = nil
+	go a.runContinuousSession(session)
+	return session, nil
+}
+
+func (a *StreamlinkCaptureAdapter) runContinuousSession(session *continuousCaptureSession) {
+	streamURL := fmt.Sprintf(a.cfg.URLTemplate, session.channel)
+
+	streamlinkArgs := []string{"--stdout", streamURL, a.cfg.Quality}
+	ffmpegOutputPattern := filepath.Join(session.segmentsDir, "%09d.ts")
+	ffmpegArgs := []string{
+		"-y",
+		"-i", "pipe:0",
+		"-c", "copy",
+		"-f", "segment",
+		"-segment_time", formatStreamlinkDurationArg(a.cfg.CaptureTimeout),
+		"-segment_start_number", "1",
+		"-reset_timestamps", "1",
+		ffmpegOutputPattern,
+	}
+
+	streamlinkCmd := exec.Command(a.cfg.BinaryPath, streamlinkArgs...)
+	ffmpegCmd := exec.Command(a.cfg.FFmpegBinary, ffmpegArgs...)
+
+	stdout, err := streamlinkCmd.StdoutPipe()
+	if err != nil {
+		a.setSessionError(session.streamerID, err)
+		return
+	}
+	ffmpegCmd.Stdin = stdout
+	var streamlinkErrBuf, ffmpegErrBuf strings.Builder
+	streamlinkCmd.Stderr = &streamlinkErrBuf
+	ffmpegCmd.Stderr = &ffmpegErrBuf
+
+	if err := ffmpegCmd.Start(); err != nil {
+		a.setSessionError(session.streamerID, err)
+		return
+	}
+	if err := streamlinkCmd.Start(); err != nil {
+		_ = ffmpegCmd.Process.Kill()
+		a.setSessionError(session.streamerID, err)
+		return
+	}
+
+	_ = streamlinkCmd.Wait()
+	_ = ffmpegCmd.Wait()
+	sessionErr := strings.TrimSpace(streamlinkErrBuf.String() + " " + ffmpegErrBuf.String())
+	if sessionErr == "" {
+		sessionErr = "continuous capture session exited"
+	}
+	a.setSessionError(session.streamerID, fmt.Errorf("continuous capture stopped: %s", sessionErr))
+}
+
+func (a *StreamlinkCaptureAdapter) setSessionError(streamerID string, err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	session, ok := a.sessions[streamerID]
+	if !ok {
+		return
+	}
+	session.lastErr = err
+	session.started = false
 }
 
 func formatStreamlinkDurationArg(value time.Duration) string {

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -196,6 +196,24 @@ func TestNewStreamlinkCaptureAdapterEnforcesMinimumCaptureTimeout(t *testing.T) 
 	}
 }
 
+func TestNewStreamlinkCaptureAdapterEnablesContinuousModeForDefaultRunner(t *testing.T) {
+	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
+		OutputDir: t.TempDir(),
+	}, nil, nil)
+	if !adapter.continuous {
+		t.Fatalf("expected continuous mode for default runner")
+	}
+}
+
+func TestNewStreamlinkCaptureAdapterDisablesContinuousModeForCustomRunner(t *testing.T) {
+	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
+		OutputDir: t.TempDir(),
+	}, nil, &fakeCommandRunner{})
+	if adapter.continuous {
+		t.Fatalf("expected non-continuous mode for custom runner")
+	}
+}
+
 func TestStreamlinkCaptureAdapterFailsWithoutBytes(t *testing.T) {
 	runner := &fakeCommandRunner{err: errors.New("streamlink failed")}
 	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{OutputDir: t.TempDir()}, nil, runner)

--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sort"
 	"strings"
 	"time"
@@ -73,7 +74,11 @@ func (p *BunnyChunkPublisher) Publish(ctx context.Context, streamerID string, ch
 	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
 		return err
 	}
-	segmentPath := filepath.Join(segmentsDir, filepath.Base(chunkPath))
+	nextIndex, err := p.nextSegmentIndex(segmentsDir)
+	if err != nil {
+		return err
+	}
+	segmentPath := filepath.Join(segmentsDir, fmt.Sprintf("%09d.mp4", nextIndex))
 	if err := os.Rename(chunkPath, segmentPath); err != nil {
 		return err
 	}
@@ -112,6 +117,7 @@ func (p *BunnyChunkPublisher) listSegments(segmentsDir string) ([]string, error)
 		return nil, err
 	}
 	type segmentMeta struct {
+		index    int
 		path     string
 		captured time.Time
 	}
@@ -121,6 +127,7 @@ func (p *BunnyChunkPublisher) listSegments(segmentsDir string) ([]string, error)
 			continue
 		}
 		path := filepath.Join(segmentsDir, entry.Name())
+		index := parseSegmentIndex(entry.Name())
 		captured := parseSegmentCapturedAt(entry.Name())
 		if captured.IsZero() {
 			info, statErr := entry.Info()
@@ -129,11 +136,14 @@ func (p *BunnyChunkPublisher) listSegments(segmentsDir string) ([]string, error)
 			}
 			captured = info.ModTime().UTC()
 		}
-		segments = append(segments, segmentMeta{path: path, captured: captured})
+		segments = append(segments, segmentMeta{index: index, path: path, captured: captured})
 	}
 	sort.SliceStable(segments, func(i, j int) bool {
 		left := segments[i]
 		right := segments[j]
+		if left.index > 0 && right.index > 0 && left.index != right.index {
+			return left.index < right.index
+		}
 		if left.captured.Equal(right.captured) {
 			return left.path < right.path
 		}
@@ -144,6 +154,24 @@ func (p *BunnyChunkPublisher) listSegments(segmentsDir string) ([]string, error)
 		result = append(result, item.path)
 	}
 	return result, nil
+}
+
+func (p *BunnyChunkPublisher) nextSegmentIndex(segmentsDir string) (int, error) {
+	entries, err := os.ReadDir(segmentsDir)
+	if err != nil {
+		return 0, err
+	}
+	maxIndex := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".mp4") {
+			continue
+		}
+		index := parseSegmentIndex(entry.Name())
+		if index > maxIndex {
+			maxIndex = index
+		}
+	}
+	return maxIndex + 1, nil
 }
 
 func (p *BunnyChunkPublisher) concatSegments(ctx context.Context, streamerID, segmentsDir string, selected []string) (string, error) {
@@ -190,6 +218,15 @@ func parseSegmentCapturedAt(fileName string) time.Time {
 		return time.Time{}
 	}
 	return parsed.UTC()
+}
+
+func parseSegmentIndex(fileName string) int {
+	base := strings.TrimSuffix(filepath.Base(fileName), filepath.Ext(fileName))
+	value, err := strconv.Atoi(base)
+	if err != nil || value <= 0 {
+		return 0
+	}
+	return value
 }
 
 type bunnyCreateVideoRequest struct {

--- a/internal/media/publisher_test.go
+++ b/internal/media/publisher_test.go
@@ -219,6 +219,35 @@ func TestBunnyChunkPublisherListSegmentsSortsByCapturedTimestamp(t *testing.T) {
 	}
 }
 
+func TestBunnyChunkPublisherListSegmentsSortsByIndex(t *testing.T) {
+	dir := t.TempDir()
+	segmentsDir := filepath.Join(dir, "segments")
+	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir segments: %v", err)
+	}
+	files := []string{"000000003.mp4", "000000001.mp4", "000000002.mp4"}
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(segmentsDir, name), []byte(name), 0o644); err != nil {
+			t.Fatalf("write segment %s: %v", name, err)
+		}
+	}
+
+	publisher := NewBunnyChunkPublisher(BunnyChunkPublisherConfig{OutputDir: dir})
+	got, err := publisher.listSegments(segmentsDir)
+	if err != nil {
+		t.Fatalf("listSegments() error = %v", err)
+	}
+
+	want := []string{
+		filepath.Join(segmentsDir, "000000001.mp4"),
+		filepath.Join(segmentsDir, "000000002.mp4"),
+		filepath.Join(segmentsDir, "000000003.mp4"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("listSegments() = %#v, want %#v", got, want)
+	}
+}
+
 func TestParseSegmentCapturedAt(t *testing.T) {
 	got := parseSegmentCapturedAt("20260326T120010_123000000.mp4")
 	want := time.Date(2026, 3, 26, 12, 0, 10, 123000000, time.UTC)
@@ -227,5 +256,14 @@ func TestParseSegmentCapturedAt(t *testing.T) {
 	}
 	if !parseSegmentCapturedAt("legacy.mp4").IsZero() {
 		t.Fatalf("expected zero time for unparseable filename")
+	}
+}
+
+func TestParseSegmentIndex(t *testing.T) {
+	if got := parseSegmentIndex("000000007.mp4"); got != 7 {
+		t.Fatalf("parseSegmentIndex() = %d, want 7", got)
+	}
+	if got := parseSegmentIndex("legacy.mp4"); got != 0 {
+		t.Fatalf("parseSegmentIndex() = %d, want 0", got)
 	}
 }

--- a/internal/media/scheduler.go
+++ b/internal/media/scheduler.go
@@ -135,7 +135,7 @@ func (s *Scheduler) run(ctx context.Context, streamerID string) {
 
 	s.runCycle(ctx, streamerID)
 	for {
-		wait := s.waitUntilNextWindow()
+		wait := s.waitUntilNextCycle()
 		select {
 		case <-ctx.Done():
 			logger.Info("scheduler context cancelled", zap.String("streamerID", streamerID))
@@ -144,6 +144,17 @@ func (s *Scheduler) run(ctx context.Context, streamerID string) {
 			s.runCycle(ctx, streamerID)
 		}
 	}
+}
+
+func (s *Scheduler) waitUntilNextCycle() time.Duration {
+	if s == nil || s.interval <= 0 {
+		return 10 * time.Second
+	}
+	wait := s.waitUntilNextWindow()
+	if wait <= 0 {
+		return 0
+	}
+	return wait
 }
 
 func (s *Scheduler) runCycle(ctx context.Context, streamerID string) {
@@ -199,7 +210,7 @@ func (s *Scheduler) waitUntilNextWindow() time.Duration {
 		wait = next.Sub(current)
 	}
 	if wait <= 0 {
-		return s.interval
+		return 0
 	}
 	return wait
 }


### PR DESCRIPTION
### Motivation
- Reduce chunk boundary loss and eliminate extra idle pause between capture windows by running a long-lived Streamlink→FFmpeg pipeline that continuously emits sequential segments.
- Ensure published windows are assembled in deterministic order by introducing explicit numeric segment indexing and sequential naming when moving chunks into the publisher directory.
- Allow the scheduler to immediately start the next cycle when a previous capture overruns its window instead of always waiting a full interval.

### Description
- Documentation: updated `docs/local_setup.md` to describe continuous capture behavior, segment patterns, and automatic next-cycle start when a capture overruns.
- Stream capture: added continuous capture support to `StreamlinkCaptureAdapter` with session management (`continuousCaptureSession`), `captureContinuous`, `ensureContinuousSession`, and `runContinuousSession` that run `streamlink | ffmpeg` piping and write `%09d.ts` segments into a per-streamer `live_segments` directory.
- Adapter wiring: default runner (nil) enables continuous mode while supplying a custom `StreamlinkCommandRunner` keeps the prior single-run behavior, and `Capture` dispatches to `captureContinuous` when enabled.
- Publisher changes: `BunnyChunkPublisher` now assigns sequential `000000000.mp4` style indices via `nextSegmentIndex` when moving chunks, `listSegments` extracts and sorts by numeric index (falling back to timestamp ordering), and `parseSegmentIndex` helper added so aggregation respects numeric ordering.
- Scheduler timing: changed `waitUntilNextWindow` to return zero when the current window has already passed, and added `waitUntilNextCycle` wrapper used by the run loop so the scheduler can immediately trigger the next cycle without an extra delay.
- Tests: added unit tests for adapter continuous-mode flag, publisher ordering by index, and `parseSegmentIndex`, and updated existing tests as needed.

### Testing
- Ran unit tests with `go test ./...` and all tests completed successfully.
- Executed media package tests with `go test ./internal/media` which passed including the new continuous-mode and segment-indexing tests.
- Verified `TestBunnyChunkPublisherListSegmentsSortsByIndex` and `TestParseSegmentIndex` succeeded locally as part of the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c553d6d0a0832cb0664076466a1afa)