### PR TITLE
fix: format internal/media publisher imports

### DIFF
--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )


### PR DESCRIPTION
### Motivation
- Fix CI `Verify formatting` failure caused by a non-`gofmt`-compliant import order in `internal/media/publisher.go`.

### Description
- Reformatted `internal/media/publisher.go` with `gofmt` to correct import ordering (moved `strconv` into the proper group) and committed the change; no functional behavior was modified.
- Checklist aligned with `docs/implementation_plan.md` M2.1 and the priority task list: 
  - [x] Resolve CI formatting blocker for `internal/media/publisher.go`.
  - [ ] Auto-start Streamlink worker after streamer onboarding (M2.1.1).
  - [ ] Capture stream chunks every 10 seconds (M2.1.2).
  - [ ] Send each chunk to LLM with active admin prompt (M2.1.3).
  - [ ] Persist decisions and publish live status updates (M2.1.4).

### Testing
- Ran `gofmt -l internal/media/publisher.go` and `go test ./...`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c57613c4d8832caf38293f3ee1df5a)