### PR TITLE
Delete source segments after successful upload

### DIFF
--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -96,9 +96,6 @@ func (p *BunnyChunkPublisher) Publish(ctx context.Context, streamerID string, ch
 	if err != nil {
 		return err
 	}
-	for _, segment := range selected {
-		_ = os.Remove(segment)
-	}
 	defer os.Remove(windowPath) //nolint:errcheck
 
 	videoID, err := p.createVideo(ctx, streamerID, chunk.CapturedAt)
@@ -107,6 +104,9 @@ func (p *BunnyChunkPublisher) Publish(ctx context.Context, streamerID string, ch
 	}
 	if err := p.uploadVideo(ctx, videoID, windowPath); err != nil {
 		return err
+	}
+	for _, segment := range selected {
+		_ = os.Remove(segment)
 	}
 	return nil
 }


### PR DESCRIPTION
### Motivation
- Prevent deleting the source segment files before the video is created and uploaded to avoid potential race conditions or data loss.

### Description
- Move the removal of the `selected` segment files to after the `uploadVideo` call so the segments are retained until upload completes and keep the `defer os.Remove(windowPath)` for the concatenated window file.

### Testing
- Ran `go test ./...` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68c1eb5f0832ca954ac6321c0defb)