### PR TITLE
Simplify LLM state-schema admin contract to fields-only configuration

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -197,8 +197,8 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `PUT /api/admin/games/{gameId}` – admin-only endpoint updating a game definition.
 - `DELETE /api/admin/games/{gameId}` – admin-only endpoint deleting a game definition.
 - `GET /api/admin/llm/state-schemas` / `POST /api/admin/llm/state-schemas` – admin CRUD for versioned match state schemas.
-  - `stateSchemaJson` accepts a JSON Schema object that is passed to the tracker prompt as the strict expected LLM response contract.
-  - `initialStateJson` can be used as a tracker bootstrap template: enum-like string placeholders such as `"competitive | faceit | unknown"` are normalized by runtime logic to a concrete value (`unknown` when present, otherwise the first option).
+  - Admin configures tracked state via `fields` (including nested keys with dot notation, e.g. `score.ct`).
+  - Service derives a normalized initial tracker state from configured fields (no raw schema JSON blobs in the API contract).
 - `GET /api/admin/llm/prompts` / `POST /api/admin/llm/prompts` – admin CRUD for match update/finalization prompt templates.
 - When PostgreSQL is enabled, admin-managed tracker configuration (`/api/admin/llm/state-schemas`, `/api/admin/prompts`) is persisted in dedicated versioned tables and survives service restarts.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1283,43 +1283,32 @@ components:
           type: boolean
     StateSchemaCreateRequest:
       type: object
-      required: [gameSlug, name]
+      required: [gameSlug, name, fields]
       description: >
-        Admin-managed tracker schema definition. At least one of `fields` or
-        `stateSchemaJson` or `initialStateJson` must be provided.
+        Admin-managed tracker state definition.
+        The admin defines explicit state fields (`fields`) and the backend
+        derives a normalized tracker state template from those fields.
+        Raw JSON blobs (`stateSchemaJson`, `deltaSchemaJson`,
+        `initialStateJson`) are intentionally not part of the public contract.
       properties:
         gameSlug:
           type: string
+          description: Target game slug (for example `cs2`).
         name:
           type: string
+          description: Human-readable schema name shown in admin tooling.
         description:
           type: string
+          description: Optional notes for operators.
         fields:
           type: array
+          minItems: 1
+          description: >
+            Ordered list of tracked fields that describe the live match state.
+            Nested objects are expressed via dot notation in `key`
+            (for example `score.ct`).
           items:
             $ref: '#/components/schemas/StateFieldDefinition'
-        stateSchemaJson:
-          description: >
-            Full JSON schema for the persisted tracker state object.
-            Can be passed either as a JSON object or as a stringified JSON object.
-          oneOf:
-            - type: string
-            - type: object
-        initialStateJson:
-          description: >
-            Bootstrap state for tracker sessions when no persisted previous
-            state exists. Can be passed either as a JSON object or as a
-            stringified JSON object. Admin templates with enum-like strings
-            (for example `"ct | t | unknown"`) are accepted; runtime
-            normalization resolves them to a concrete value (prefers
-            `unknown`, otherwise the first option).
-          oneOf:
-            - type: string
-            - type: object
-      anyOf:
-        - required: [fields]
-        - required: [stateSchemaJson]
-        - required: [initialStateJson]
     StateSchemaVersion:
       allOf:
         - $ref: '#/components/schemas/StateSchemaCreateRequest'

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -71,29 +71,12 @@ func stateSchemaRequestToCreateRequest(req stateSchemaCreateRequest, actorID str
 		})
 	}
 	return prompts.StateSchemaCreateRequest{
-		GameSlug:         req.GameSlug,
-		Name:             req.Name,
-		Description:      req.Description,
-		Fields:           fields,
-		StateSchemaJSON:  normalizeInitialStateJSON(req.StateSchemaJSON),
-		InitialStateJSON: normalizeInitialStateJSON(req.InitialStateJSON),
-		ActorID:          actorID,
+		GameSlug:    req.GameSlug,
+		Name:        req.Name,
+		Description: req.Description,
+		Fields:      fields,
+		ActorID:     actorID,
 	}
-}
-
-func normalizeInitialStateJSON(raw json.RawMessage) string {
-	trimmed := strings.TrimSpace(string(raw))
-	if trimmed == "" || strings.EqualFold(trimmed, "null") {
-		return ""
-	}
-	if strings.HasPrefix(trimmed, "\"") {
-		var decoded string
-		if err := json.Unmarshal(raw, &decoded); err == nil {
-			return strings.TrimSpace(decoded)
-		}
-		return ""
-	}
-	return trimmed
 }
 
 type configLimits struct {
@@ -164,12 +147,10 @@ type stateFieldRequest struct {
 }
 
 type stateSchemaCreateRequest struct {
-	GameSlug         string              `json:"gameSlug"`
-	Name             string              `json:"name"`
-	Description      string              `json:"description"`
-	Fields           []stateFieldRequest `json:"fields"`
-	StateSchemaJSON  json.RawMessage     `json:"stateSchemaJson"`
-	InitialStateJSON json.RawMessage     `json:"initialStateJson"`
+	GameSlug    string              `json:"gameSlug"`
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	Fields      []stateFieldRequest `json:"fields"`
 }
 
 type meResponse struct {

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -44,43 +44,6 @@ func TestAdminLLMStateSchemaRoutes(t *testing.T) {
 	if stateRes.Code != http.StatusCreated {
 		t.Fatalf("state schema create status = %d body=%s", stateRes.Code, stateRes.Body.String())
 	}
-	stateSchemaBodyWithInitialState, _ := json.Marshal(map[string]any{
-		"gameSlug":         "cs2",
-		"name":             "CS2 tracker with initial state",
-		"initialStateJson": `{"session_type":"single_match_single_chat","game":"cs2","session_status":{"value":"unknown"}}`,
-	})
-	stateInitialReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/state-schemas", bytes.NewReader(stateSchemaBodyWithInitialState))
-	stateInitialReq.Header.Set("Authorization", "Bearer "+adminToken)
-	stateInitialRes := httptest.NewRecorder()
-	handler.ServeHTTP(stateInitialRes, stateInitialReq)
-	if stateInitialRes.Code != http.StatusCreated {
-		t.Fatalf("state schema with initial state create status = %d body=%s", stateInitialRes.Code, stateInitialRes.Body.String())
-	}
-	stateSchemaBodyWithInitialStateObject, _ := json.Marshal(map[string]any{
-		"gameSlug": "cs2",
-		"name":     "CS2 tracker with object initial state",
-		"stateSchemaJson": map[string]any{
-			"type":                 "object",
-			"additionalProperties": false,
-			"properties": map[string]any{
-				"session_type": map[string]any{"type": "string"},
-			},
-		},
-		"initialStateJson": map[string]any{
-			"session_type": "single_match_single_chat",
-			"game":         "cs2",
-			"session_status": map[string]any{
-				"value": "unknown",
-			},
-		},
-	})
-	stateInitialObjectReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/state-schemas", bytes.NewReader(stateSchemaBodyWithInitialStateObject))
-	stateInitialObjectReq.Header.Set("Authorization", "Bearer "+adminToken)
-	stateInitialObjectRes := httptest.NewRecorder()
-	handler.ServeHTTP(stateInitialObjectRes, stateInitialObjectReq)
-	if stateInitialObjectRes.Code != http.StatusCreated {
-		t.Fatalf("state schema with object initial state create status = %d body=%s", stateInitialObjectRes.Code, stateInitialObjectRes.Body.String())
-	}
 
 	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/state-schemas", nil)
 	listReq.Header.Set("Authorization", "Bearer "+adminToken)

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -814,10 +814,7 @@ func (w *Worker) resolveTrackerConfig(ctx context.Context) string {
 	var stateSchema string
 	if resolver, ok := w.prompts.(activeStateSchemaResolver); ok {
 		if item, err := resolver.GetActiveStateSchema(ctx, gameSlug); err == nil {
-			schemaPayload := strings.TrimSpace(item.StateSchemaJSON)
-			if schemaPayload == "" || schemaPayload == "{}" {
-				schemaPayload = compactJSON(item.Fields)
-			}
+			schemaPayload := compactJSON(item.Fields)
 			stateSchema = fmt.Sprintf("state_schema[%s v%d]: %s", item.Name, item.Version, schemaPayload)
 		}
 	}

--- a/internal/prompts/postgres_service.go
+++ b/internal/prompts/postgres_service.go
@@ -153,18 +153,14 @@ func scanPrompt(row scanner) (PromptVersion, error) {
 func scanStateSchema(row scanner) (StateSchemaVersion, error) {
 	var item StateSchemaVersion
 	var fields []byte
-	var schemaJSON []byte
-	var deltaJSON []byte
 	var initialState []byte
 	var activatedAt sql.NullTime
-	if err := row.Scan(&item.ID, &item.GameSlug, &item.Name, &item.Description, &item.Version, &fields, &schemaJSON, &deltaJSON, &initialState, &item.IsActive, &item.CreatedBy, &item.ActivatedBy, &item.CreatedAt, &activatedAt); err != nil {
+	if err := row.Scan(&item.ID, &item.GameSlug, &item.Name, &item.Description, &item.Version, &fields, &initialState, &item.IsActive, &item.CreatedBy, &item.ActivatedBy, &item.CreatedAt, &activatedAt); err != nil {
 		return StateSchemaVersion{}, err
 	}
 	if err := json.Unmarshal(fields, &item.Fields); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item.StateSchemaJSON = strings.TrimSpace(string(schemaJSON))
-	item.DeltaSchemaJSON = strings.TrimSpace(string(deltaJSON))
 	item.InitialStateJSON = strings.TrimSpace(string(initialState))
 	if activatedAt.Valid {
 		item.ActivatedAt = activatedAt.Time
@@ -347,7 +343,7 @@ func (s *Service) listStateSchemasDB(ctx context.Context) ([]StateSchemaVersion,
 	if err := s.ensureSchema(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -374,14 +370,6 @@ func (s *Service) createStateSchemaDB(ctx context.Context, req StateSchemaCreate
 	if err != nil {
 		return StateSchemaVersion{}, err
 	}
-	schemaJSONRaw := strings.TrimSpace(req.StateSchemaJSON)
-	if schemaJSONRaw == "" {
-		schemaJSONRaw = "{}"
-	}
-	deltaSchemaJSONRaw := strings.TrimSpace(req.DeltaSchemaJSON)
-	if deltaSchemaJSONRaw == "" {
-		deltaSchemaJSONRaw = "{}"
-	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return StateSchemaVersion{}, err
@@ -396,17 +384,24 @@ func (s *Service) createStateSchemaDB(ctx context.Context, req StateSchemaCreate
 		return StateSchemaVersion{}, err
 	}
 	now := time.Now().UTC()
-	item := StateSchemaVersion{ID: "state-schema-" + uuid.NewString(), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: version, Fields: append([]StateFieldDefinition(nil), req.Fields...), StateSchemaJSON: strings.TrimSpace(req.StateSchemaJSON), DeltaSchemaJSON: strings.TrimSpace(req.DeltaSchemaJSON), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), IsActive: existing == 0, CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	item := StateSchemaVersion{
+		ID:               "state-schema-" + uuid.NewString(),
+		GameSlug:         gameSlug,
+		Name:             strings.TrimSpace(req.Name),
+		Description:      strings.TrimSpace(req.Description),
+		Version:          version,
+		Fields:           append([]StateFieldDefinition(nil), req.Fields...),
+		InitialStateJSON: buildInitialStateJSON(req.Fields),
+		IsActive:         existing == 0,
+		CreatedBy:        strings.TrimSpace(req.ActorID),
+		CreatedAt:        now,
+	}
 	if item.IsActive {
 		item.ActivatedBy = item.CreatedBy
 		item.ActivatedAt = now
 	}
-	initialStateRaw := strings.TrimSpace(req.InitialStateJSON)
-	if initialStateRaw == "" {
-		initialStateRaw = "{}"
-	}
-	_, err = tx.ExecContext(ctx, `INSERT INTO llm_state_schema_versions (id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8::jsonb,$9::jsonb,$10,$11,$12,$13,$14)`,
-		item.ID, item.GameSlug, item.Name, item.Description, item.Version, fieldsJSON, schemaJSONRaw, deltaSchemaJSONRaw, initialStateRaw, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt))
+	_, err = tx.ExecContext(ctx, `INSERT INTO llm_state_schema_versions (id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,'{}'::jsonb,'{}'::jsonb,$7::jsonb,$8,$9,$10,$11,$12)`,
+		item.ID, item.GameSlug, item.Name, item.Description, item.Version, fieldsJSON, item.InitialStateJSON, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt))
 	if err != nil {
 		return StateSchemaVersion{}, err
 	}
@@ -420,7 +415,7 @@ func (s *Service) getStateSchemaDB(ctx context.Context, id string) (StateSchemaV
 	if err := s.ensureSchema(ctx); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE id = $1`, strings.TrimSpace(id)))
+	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE id = $1`, strings.TrimSpace(id)))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return StateSchemaVersion{}, ErrStateSchemaNotFound
@@ -441,20 +436,9 @@ func (s *Service) updateStateSchemaDB(ctx context.Context, id string, req StateS
 	if err != nil {
 		return StateSchemaVersion{}, err
 	}
-	initialStateRaw := strings.TrimSpace(req.InitialStateJSON)
-	if initialStateRaw == "" {
-		initialStateRaw = "{}"
-	}
-	schemaJSONRaw := strings.TrimSpace(req.StateSchemaJSON)
-	if schemaJSONRaw == "" {
-		schemaJSONRaw = "{}"
-	}
-	deltaSchemaJSONRaw := strings.TrimSpace(req.DeltaSchemaJSON)
-	if deltaSchemaJSONRaw == "" {
-		deltaSchemaJSONRaw = "{}"
-	}
-	row := s.db.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET game_slug = $2, name = $3, description = $4, fields_json = $5, state_schema_json = $6::jsonb, delta_schema_json = $7::jsonb, initial_state_json = $8::jsonb WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
-		strings.TrimSpace(id), strings.TrimSpace(req.GameSlug), strings.TrimSpace(req.Name), strings.TrimSpace(req.Description), fieldsJSON, schemaJSONRaw, deltaSchemaJSONRaw, initialStateRaw)
+	initialStateRaw := buildInitialStateJSON(req.Fields)
+	row := s.db.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET game_slug = $2, name = $3, description = $4, fields_json = $5, state_schema_json = '{}'::jsonb, delta_schema_json = '{}'::jsonb, initial_state_json = $6::jsonb WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
+		strings.TrimSpace(id), strings.TrimSpace(req.GameSlug), strings.TrimSpace(req.Name), strings.TrimSpace(req.Description), fieldsJSON, initialStateRaw)
 	item, err := scanStateSchema(row)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -512,7 +496,7 @@ func (s *Service) activateStateSchemaDB(ctx context.Context, id, actorID string)
 	if _, err := tx.ExecContext(ctx, `UPDATE llm_state_schema_versions SET is_active = FALSE WHERE game_slug = $1`, gameSlug); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(tx.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
+	item, err := scanStateSchema(tx.QueryRowContext(ctx, `UPDATE llm_state_schema_versions SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at`,
 		strings.TrimSpace(id), strings.TrimSpace(actorID), time.Now().UTC()))
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -530,7 +514,7 @@ func (s *Service) getActiveStateSchemaDB(ctx context.Context, gameSlug string) (
 	if err := s.ensureSchema(ctx); err != nil {
 		return StateSchemaVersion{}, err
 	}
-	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, strings.TrimSpace(gameSlug)))
+	item, err := scanStateSchema(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, strings.TrimSpace(gameSlug)))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return StateSchemaVersion{}, ErrStateSchemaNotFound

--- a/internal/prompts/postgres_service_test.go
+++ b/internal/prompts/postgres_service_test.go
@@ -70,16 +70,16 @@ func TestPostgresServiceListStateSchemas(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS delta_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, fields_json, state_schema_json, delta_schema_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "fields_json", "state_schema_json", "delta_schema_json", "initial_state_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
-			AddRow("state-schema-1", "cs2", "Schema", "", 1, `[{"key":"score.ct","type":"number"}]`, `{"type":"object"}`, `{"type":"object","properties":{"chunk_time_range":{"type":"string"}}}`, `{"session_status":{"value":"unknown"}}`, true, "admin-1", "admin-1", now, now))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, description, version, fields_json, initial_state_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_state_schema_versions ORDER BY game_slug ASC, version DESC, created_at DESC`)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "description", "version", "fields_json", "initial_state_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
+			AddRow("state-schema-1", "cs2", "Schema", "", 1, `[{"key":"score.ct","type":"number"}]`, `{"session_status":{"value":"unknown"}}`, true, "admin-1", "admin-1", now, now))
 
 	items := svc.ListStateSchemas(context.Background())
 	if len(items) != 1 || items[0].GameSlug != "cs2" {
 		t.Fatalf("ListStateSchemas() = %#v", items)
 	}
-	if items[0].StateSchemaJSON == "" {
-		t.Fatalf("expected state schema json to be set: %#v", items[0])
+	if items[0].InitialStateJSON == "" {
+		t.Fatalf("expected generated initial state to be set: %#v", items[0])
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet() error = %v", err)

--- a/internal/prompts/tracker_config.go
+++ b/internal/prompts/tracker_config.go
@@ -16,9 +16,6 @@ var (
 	ErrInvalidStateSchemaName    = errors.New("state schema name must not be empty")
 	ErrInvalidStateFieldKey      = errors.New("state field key must not be empty")
 	ErrInvalidStateFieldType     = errors.New("state field type must not be empty")
-	ErrInvalidStateSchemaJSON    = errors.New("stateSchemaJson must be a valid JSON object")
-	ErrInvalidDeltaSchemaJSON    = errors.New("deltaSchemaJson must be a valid JSON object")
-	ErrInvalidInitialStateJSON   = errors.New("initialStateJson must be a valid JSON object")
 	ErrStateSchemaNotFound       = errors.New("state schema not found")
 	ErrInvalidRuleSetName        = errors.New("rule set name must not be empty")
 	ErrInvalidRuleFieldKey       = errors.New("rule item fieldKey must not be empty")
@@ -42,14 +39,11 @@ type StateFieldDefinition struct {
 }
 
 type StateSchemaCreateRequest struct {
-	GameSlug         string
-	Name             string
-	Description      string
-	Fields           []StateFieldDefinition
-	StateSchemaJSON  string
-	DeltaSchemaJSON  string
-	InitialStateJSON string
-	ActorID          string
+	GameSlug    string
+	Name        string
+	Description string
+	Fields      []StateFieldDefinition
+	ActorID     string
 }
 
 type StateSchemaVersion struct {
@@ -59,9 +53,7 @@ type StateSchemaVersion struct {
 	Description      string                 `json:"description,omitempty"`
 	Version          int                    `json:"version"`
 	Fields           []StateFieldDefinition `json:"fields"`
-	StateSchemaJSON  string                 `json:"stateSchemaJson,omitempty"`
-	DeltaSchemaJSON  string                 `json:"deltaSchemaJson,omitempty"`
-	InitialStateJSON string                 `json:"initialStateJson,omitempty"`
+	InitialStateJSON string                 `json:"-"`
 	IsActive         bool                   `json:"isActive"`
 	CreatedBy        string                 `json:"createdBy"`
 	ActivatedBy      string                 `json:"activatedBy,omitempty"`
@@ -117,7 +109,7 @@ func ValidateStateSchemaCreateRequest(req StateSchemaCreateRequest) error {
 	if strings.TrimSpace(req.Name) == "" {
 		return ErrInvalidStateSchemaName
 	}
-	if len(req.Fields) == 0 && strings.TrimSpace(req.InitialStateJSON) == "" && strings.TrimSpace(req.StateSchemaJSON) == "" {
+	if len(req.Fields) == 0 {
 		return ErrInvalidStateFieldKey
 	}
 	seen := map[string]struct{}{}
@@ -133,24 +125,6 @@ func ValidateStateSchemaCreateRequest(req StateSchemaCreateRequest) error {
 			return fmt.Errorf("duplicate state field key: %s", key)
 		}
 		seen[key] = struct{}{}
-	}
-	if raw := strings.TrimSpace(req.InitialStateJSON); raw != "" {
-		var decoded map[string]any
-		if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
-			return ErrInvalidInitialStateJSON
-		}
-	}
-	if raw := strings.TrimSpace(req.StateSchemaJSON); raw != "" {
-		var decoded map[string]any
-		if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
-			return ErrInvalidStateSchemaJSON
-		}
-	}
-	if raw := strings.TrimSpace(req.DeltaSchemaJSON); raw != "" {
-		var decoded map[string]any
-		if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
-			return ErrInvalidDeltaSchemaJSON
-		}
 	}
 	return nil
 }
@@ -235,7 +209,17 @@ func (s *Service) CreateStateSchema(ctx context.Context, req StateSchemaCreateRe
 	gameSlug := strings.TrimSpace(req.GameSlug)
 	now := time.Now().UTC()
 	s.counter++
-	item := StateSchemaVersion{ID: fmt.Sprintf("state-schema-%d", s.counter), GameSlug: gameSlug, Name: strings.TrimSpace(req.Name), Description: strings.TrimSpace(req.Description), Version: len(s.stateSchemas[gameSlug]) + 1, Fields: append([]StateFieldDefinition(nil), req.Fields...), StateSchemaJSON: strings.TrimSpace(req.StateSchemaJSON), DeltaSchemaJSON: strings.TrimSpace(req.DeltaSchemaJSON), InitialStateJSON: strings.TrimSpace(req.InitialStateJSON), CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	item := StateSchemaVersion{
+		ID:               fmt.Sprintf("state-schema-%d", s.counter),
+		GameSlug:         gameSlug,
+		Name:             strings.TrimSpace(req.Name),
+		Description:      strings.TrimSpace(req.Description),
+		Version:          len(s.stateSchemas[gameSlug]) + 1,
+		Fields:           append([]StateFieldDefinition(nil), req.Fields...),
+		InitialStateJSON: buildInitialStateJSON(req.Fields),
+		CreatedBy:        strings.TrimSpace(req.ActorID),
+		CreatedAt:        now,
+	}
 	if len(s.stateSchemas[gameSlug]) == 0 {
 		item.IsActive = true
 		item.ActivatedBy = strings.TrimSpace(req.ActorID)
@@ -282,9 +266,7 @@ func (s *Service) UpdateStateSchema(ctx context.Context, id string, req StateSch
 			updated.Name = strings.TrimSpace(req.Name)
 			updated.Description = strings.TrimSpace(req.Description)
 			updated.Fields = append([]StateFieldDefinition(nil), req.Fields...)
-			updated.StateSchemaJSON = strings.TrimSpace(req.StateSchemaJSON)
-			updated.DeltaSchemaJSON = strings.TrimSpace(req.DeltaSchemaJSON)
-			updated.InitialStateJSON = strings.TrimSpace(req.InitialStateJSON)
+			updated.InitialStateJSON = buildInitialStateJSON(req.Fields)
 			if updated.GameSlug != gameSlug {
 				s.stateSchemas[gameSlug] = append(versions[:i], versions[i+1:]...)
 				s.stateSchemas[updated.GameSlug] = append(s.stateSchemas[updated.GameSlug], updated)
@@ -296,6 +278,71 @@ func (s *Service) UpdateStateSchema(ctx context.Context, id string, req StateSch
 		}
 	}
 	return StateSchemaVersion{}, ErrStateSchemaNotFound
+}
+
+func buildInitialStateJSON(fields []StateFieldDefinition) string {
+	state := map[string]any{}
+	for _, field := range fields {
+		key := strings.TrimSpace(field.Key)
+		if key == "" {
+			continue
+		}
+		setNestedStateValue(state, strings.Split(key, "."), defaultStateValue(field))
+	}
+	body, err := json.Marshal(state)
+	if err != nil {
+		return "{}"
+	}
+	return string(body)
+}
+
+func setNestedStateValue(root map[string]any, parts []string, value any) {
+	current := root
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return
+		}
+		if i == len(parts)-1 {
+			current[part] = value
+			return
+		}
+		next, ok := current[part].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			current[part] = next
+		}
+		current = next
+	}
+}
+
+func defaultStateValue(field StateFieldDefinition) any {
+	fieldType := strings.ToLower(strings.TrimSpace(field.Type))
+	switch fieldType {
+	case "number", "int", "integer", "float":
+		return 0
+	case "boolean", "bool":
+		return false
+	case "array":
+		return []any{}
+	case "object":
+		return map[string]any{}
+	case "enum":
+		if len(field.EnumValues) > 0 {
+			return field.EnumValues[0]
+		}
+		return ""
+	case "string":
+		if len(field.EnumValues) > 0 {
+			return field.EnumValues[0]
+		}
+		return ""
+	default:
+		if len(field.EnumValues) > 0 {
+			return field.EnumValues[0]
+		}
+		return ""
+	}
 }
 
 func (s *Service) DeleteStateSchema(ctx context.Context, id string) error {

--- a/internal/prompts/tracker_config_test.go
+++ b/internal/prompts/tracker_config_test.go
@@ -41,60 +41,49 @@ func TestServiceStateSchemaLifecycle(t *testing.T) {
 	}
 }
 
-func TestValidateStateSchemaCreateRequestAllowsInitialStateJSONWithoutFields(t *testing.T) {
+func TestValidateStateSchemaCreateRequestRequiresFields(t *testing.T) {
 	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
-		GameSlug:         "cs2",
-		Name:             "CS2 full state",
-		InitialStateJSON: `{"session_status":{"value":"unknown"}}`,
+		GameSlug: "cs2",
+		Name:     "CS2 full state",
+	})
+	if !errors.Is(err, ErrInvalidStateFieldKey) {
+		t.Fatalf("error = %v, want %v", err, ErrInvalidStateFieldKey)
+	}
+}
+
+func TestValidateStateSchemaCreateRequestRejectsMissingFieldType(t *testing.T) {
+	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
+		GameSlug: "cs2",
+		Name:     "CS2 full state",
+		Fields:   []StateFieldDefinition{{Key: "score.ct"}},
+	})
+	if !errors.Is(err, ErrInvalidStateFieldType) {
+		t.Fatalf("error = %v, want %v", err, ErrInvalidStateFieldType)
+	}
+}
+
+func TestValidateStateSchemaCreateRequestAllowsFields(t *testing.T) {
+	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
+		GameSlug: "cs2",
+		Name:     "CS2 full schema",
+		Fields:   []StateFieldDefinition{{Key: "score.ct", Type: "number"}},
 	})
 	if err != nil {
 		t.Fatalf("ValidateStateSchemaCreateRequest() error = %v", err)
 	}
 }
 
-func TestValidateStateSchemaCreateRequestRejectsInvalidInitialStateJSON(t *testing.T) {
+func TestValidateStateSchemaCreateRequestRejectsDuplicateFieldKeys(t *testing.T) {
 	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
-		GameSlug:         "cs2",
-		Name:             "CS2 full state",
-		InitialStateJSON: `[]`,
+		GameSlug: "cs2",
+		Name:     "CS2 full schema",
+		Fields: []StateFieldDefinition{
+			{Key: "score.ct", Type: "number"},
+			{Key: "score.ct", Type: "number"},
+		},
 	})
-	if !errors.Is(err, ErrInvalidInitialStateJSON) {
-		t.Fatalf("error = %v, want %v", err, ErrInvalidInitialStateJSON)
-	}
-}
-
-func TestValidateStateSchemaCreateRequestAllowsJSONSchemaWithoutFields(t *testing.T) {
-	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
-		GameSlug:        "cs2",
-		Name:            "CS2 full schema",
-		StateSchemaJSON: `{"type":"object","properties":{"score":{"type":"number"}}}`,
-		DeltaSchemaJSON: `{"type":"object","properties":{"new_evidence":{"type":"array"}}}`,
-	})
-	if err != nil {
-		t.Fatalf("ValidateStateSchemaCreateRequest() error = %v", err)
-	}
-}
-
-func TestValidateStateSchemaCreateRequestRejectsInvalidStateSchemaJSON(t *testing.T) {
-	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
-		GameSlug:        "cs2",
-		Name:            "CS2 full schema",
-		StateSchemaJSON: `[]`,
-	})
-	if !errors.Is(err, ErrInvalidStateSchemaJSON) {
-		t.Fatalf("error = %v, want %v", err, ErrInvalidStateSchemaJSON)
-	}
-}
-
-func TestValidateStateSchemaCreateRequestRejectsInvalidDeltaSchemaJSON(t *testing.T) {
-	err := ValidateStateSchemaCreateRequest(StateSchemaCreateRequest{
-		GameSlug:        "cs2",
-		Name:            "CS2 full schema",
-		StateSchemaJSON: `{"type":"object","properties":{"score":{"type":"number"}}}`,
-		DeltaSchemaJSON: `[]`,
-	})
-	if !errors.Is(err, ErrInvalidDeltaSchemaJSON) {
-		t.Fatalf("error = %v, want %v", err, ErrInvalidDeltaSchemaJSON)
+	if err == nil {
+		t.Fatal("expected duplicate key validation error")
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Reduce admin friction and surface area by removing raw JSON blobs (`stateSchemaJson`, `deltaSchemaJson`, `initialStateJson`) from the public admin contract and expose a concise `fields`-first configuration model. 
- Make it easy for operators to declare tracked state via explicit field definitions while keeping DB compatibility and worker runtime behavior simple and predictable.

### Description
- API/HTTP layer: removed parsing/normalization of raw JSON blobs and map admin requests to `prompts.StateSchemaCreateRequest` containing only `fields` via `stateSchemaRequestToCreateRequest` in `internal/app/router.go`. 
- Domain/service: `internal/prompts/tracker_config.go` no longer accepts raw schema/delta/initial JSON in the public model, enforces `fields` as required, and adds `buildInitialStateJSON` with nested-key support (dot-notation) and type-based default values to derive a normalized initial state template. 
- Postgres layer: `internal/prompts/postgres_service.go` now selects/stores only `fields_json` and `initial_state_json` for API responses, persists `state_schema_json`/`delta_schema_json` as `'{}'` internally for compatibility, and uses the derived initial state on create/update/read paths. 
- Worker: `internal/media/worker.go` now uses the serialized `fields` payload for tracker prompt configuration instead of any raw `stateSchemaJson`. 
- Docs & API spec: updated `docs/openapi.yaml` and `docs/local_setup.md` to document the fields-only admin contract and removed public raw-JSON inputs. 
- Tests: updated and simplified unit tests to match the new contract (`internal/prompts/tracker_config_test.go`, `internal/prompts/postgres_service_test.go`, `internal/app/router_admin_llm_test.go`).
- Checklist aligned to M2.1 implementation plan:
  - [x] Remove admin-facing raw `stateSchemaJson` / `deltaSchemaJson` / `initialStateJson` inputs and require `fields`.
  - [x] Derive normalized initial tracker state from configured `fields` and keep DB-compatible storage for legacy columns.
  - [x] Update OpenAPI + local setup docs to describe the new `fields`-first workflow.
  - [x] Update unit tests and worker serialization to use `fields`.
  - [ ] Automatically start worker after streamer onboarding (M2.1 integration step).
  - [ ] Capture stream chunks every 10 seconds, send each chunk to LLM using active admin prompt, persist decisions and publish live status updates (remaining M2.1 runtime behavior).

### Testing
- Ran unit tests for affected packages with `go test ./internal/prompts ./internal/app ./internal/media` and all tests passed. 
- Updated `sqlmock` expectations in `internal/prompts/postgres_service_test.go` to reflect the new DB query shape and validated with test suite. 
- Ran `gofmt` on modified files to ensure formatting compliance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c695b23138832c9162c7089d8a2f1c)