### PR TITLE
Add scenario-graph orchestration for LLM tracker and persistable scenario packages

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -94,6 +94,7 @@ stream analysis immediately after a streamer is added:
   iterative state updates for player side, score, evidence, and uncertainties;
   finalization into `win | loss | draw | unknown` only from accumulated
   evidence.
+- [x] Start migration to scenario-graph orchestration (root game-detection step + game-folder steps + concrete game sub-steps) with condition-based transitions and stay-on-step fallback.
 - [ ] Add resilient orchestration with retries, idempotency keys, and dead-letter
   handling for failed LLM jobs.
 - [ ] Publish live match-state/finalization updates to clients via WebSocket.

--- a/docs/llm_stream_orchestration_plan.md
+++ b/docs/llm_stream_orchestration_plan.md
@@ -1,457 +1,62 @@
-# LLM Stream Orchestration Plan (State Tracker + Streamlink)
+# LLM Stream Orchestration Plan (Scenario Graph v2)
 
 ## Goal
-Design and implement the M2.1 stream-analysis flow around a **single-match state tracker** instead of a long prompt-chain narrative.
+Build a single orchestration model where admin-defined **scenario steps** drive the
+LLM analysis loop.
 
-The target behavior is:
-1. Admin configures the **state schema**, **update rules**, **finalization rules**, and runtime limits used by the LLM.
-2. Background workers read livestream fragments via Streamlink every 10 seconds.
-3. Each active match session is treated as **one chat / one match**.
-4. For every fragment, the worker sends:
-   - the previous compact state JSON,
-   - the new chunk observations,
-   - the active admin-managed update prompt/rules.
-5. The LLM returns **updated state JSON only**.
-6. When the match is finished or the video ends, the worker sends the accumulated state to a finalization prompt and stores the final outcome (`win | loss | draw | unknown`).
-7. State changes and final decisions are persisted and published to websocket consumers.
+The old linear prompt-chain / detector entrypoints are deprecated. Runtime should
+move to the model below:
 
-## Scope of this iteration
-- Replace the older "scenario graph / multi-step prompt chain" plan with a **state-machine style** design.
-- Make admin CRUD for state fields and rules the primary product requirement.
-- Keep the MVP focused on Counter-Strike match outcome tracking.
+1. One active **root step** (`initial=true`) for first entry.
+2. Per-game folders (for example `cs2/*`) that contain game-specific scenarios.
+3. Every step has:
+   - entry condition (for first entry optional only for root),
+   - prompt text,
+   - expected JSON contract,
+   - transitions (`if` rules) to other steps.
+4. LLM must return strict JSON only.
+5. Step response updates persisted state; transitions are evaluated from state.
 
-## Priority implementation target
-Treat the following as the top-priority slice for immediate delivery:
-- streamer added -> analysis job starts automatically;
-- Streamlink captures/reads a fragment every 10 seconds;
-- one active match session is tracked as one chat/session;
-- each chunk updates a compact persisted state via LLM;
-- admin can CRUD state fields, evidence fields, and rule sets used by the tracker;
-- legacy detector/scenario-chain codepaths are removed or refactored so only one orchestration model remains;
-- final outcome is derived from accumulated evidence only;
-- decisions and state updates are persisted and published to websocket consumers.
+## Canonical 3-level behavior
 
-## Product flow (high level)
-1. User adds streamer via `POST /api/streamers`.
-2. Worker scheduler starts analysis for the streamer immediately after onboarding.
-3. The worker samples the stream every 10 seconds via Streamlink.
-4. The system opens or resumes the active **match session** for that streamer/game.
-5. For each chunk, the worker calls the LLM with:
-   - `previous_state`,
-   - `new_chunk`,
-   - the active admin-managed update prompt,
-   - the active admin-managed rule set.
-6. The LLM returns `updated_state`, `delta`, and `next_needed_evidence` in strict JSON.
-7. The backend persists the state snapshot, evidence log entries, and derived status.
-8. When end-of-match evidence appears (or the stream/video ends), the worker calls the finalization prompt with the current state.
-9. The backend persists the final decision and resets the streamer back to match discovery mode.
+### Level 1: game detection
+- Root prompt detects game and writes fields such as `game`.
+- Example transition: `if game == cs2 -> cs2_mode`.
 
-## Core modeling decision: one chat = one match
-The LLM must behave as a **finite match state tracker**, not as a commentator.
+### Level 2: game scenario (folder level)
+- Game-specific step (e.g. `cs2_mode`) asks for mode/context.
+- Example transition: `if mode == faceit -> cs2_faceit`.
+- If response says there is no concrete mode yet, remain on current step.
 
-### Required operating rules
-- One chat/session contains exactly one match.
-- Every update call must include `previous_state` explicitly.
-- The LLM must always return valid JSON only.
-- The model must not guess the outcome from gameplay quality or vague impressions.
-- Outcome changes are allowed only when the state contains direct or strongly-supported evidence.
-- If player team/side is not confirmed, or the ending is not visible, the result remains `unknown`.
+### Level 3: concrete in-game scenario
+- Deep step (`cs2_faceit`) handles specific logic and outcomes.
+- Can transition back to root when game changes.
 
-## State model
+## State + transitions
+- Each step writes JSON delta/state fragment.
+- Worker keeps compact persisted state per streamer/session.
+- Transition evaluation happens each cycle from current step + current state.
+- If no transition matches, worker stays on the same step.
 
-### Canonical session state
-```json
-{
-  "session_type": "single_match_single_chat",
-  "game": "cs2",
-  "mode": "competitive | faceit | wingman | unknown",
-  "session_status": {
-    "value": "in_progress | likely_finished | confirmed_finished | likely_truncated | unknown",
-    "confidence": 0.0,
-    "reason": null
-  },
-  "focus_player": {
-    "name": null,
-    "team_side": "CT | T | unknown",
-    "team_label": "team_1 | team_2 | unknown",
-    "confidence": 0.0
-  },
-  "score_state": {
-    "ct_score": null,
-    "t_score": null,
-    "source": "hud | scoreboard | endscreen | inferred | unknown",
-    "confidence": 0.0
-  },
-  "round_tracking": {
-    "observed_round_wins_ct": 0,
-    "observed_round_wins_t": 0,
-    "observed_round_history": [],
-    "confidence": 0.0
-  },
-  "winner_state": {
-    "winner_side": "CT | T | draw | unknown",
-    "winner_team_label": "team_1 | team_2 | unknown",
-    "source": "final_banner | final_scoreboard | round_accumulation | unknown",
-    "confidence": 0.0
-  },
-  "player_result": {
-    "outcome": "win | loss | draw | unknown",
-    "confidence": 0.0,
-    "reason": null,
-    "is_final": false
-  },
-  "terminal_evidence": {
-    "final_banner_seen": false,
-    "final_banner_text": null,
-    "final_scoreboard_seen": false,
-    "final_scoreboard_text": null,
-    "post_match_ui_seen": false,
-    "return_to_lobby_seen": false,
-    "strong_terminal_signals": [],
-    "weak_terminal_signals": []
-  },
-  "supporting_evidence": [],
-  "open_uncertainties": [],
-  "hard_conflicts": [],
-  "next_needed_evidence": [
-    "clear final screen",
-    "clear final scoreboard",
-    "clear player team confirmation"
-  ]
-}
-```
+## Admin UX requirements
+- Scenario tree grouped by `gameSlug` and `folder` path.
+- UI must show graph dependencies: `step -> transitions -> target step`.
+- Editing should not require code changes; all conditions are admin-managed data.
 
+## Immediate backend scope (current iteration)
+- Add scenario package domain model:
+  - `ScenarioPackage`
+  - `ScenarioStep`
+  - `ScenarioTransition`
+- Add active package resolver per game slug.
+- Add step resolution algorithm:
+  - initial selection,
+  - transition by priority,
+  - stay-on-step fallback.
+- Wire worker to prefer scenario package execution when present.
 
-### Practical runtime shape
-```json
-{
-  "match_id": "chat_session_match_001",
-  "game": "cs2",
-  "mode": "competitive",
-  "status": "in_progress",
-  "player": {
-    "name": "unknown",
-    "team_side": "CT",
-    "team_label": "team_1",
-    "team_confidence": 0.82
-  },
-  "score": {
-    "ct": 7,
-    "t": 5,
-    "source": "hud",
-    "confidence": 0.88
-  },
-  "winner": {
-    "side": "unknown",
-    "team_label": "unknown",
-    "source": "unknown",
-    "confidence": 0.0
-  },
-  "player_outcome": {
-    "value": "unknown",
-    "confidence": 0.0
-  },
-  "evidence_log": [],
-  "uncertainties": [
-    "final result not visible yet"
-  ],
-  "hard_conflicts": []
-}
-```
-
-## Update/close protocol
-
-### Update step (`match_update`)
-Each 10-second chunk produces one update request containing:
-- `previous_state`
-- `new_chunk.time_range`
-- structured observations (`observations`, `visible_hud_text`, `scoreboard_text`, `round_result_signals`, `team_identity_signals`, `final_screen_signals`, `post_match_signals`, `truncation_signals`)
-- active admin-managed rules and prompt version metadata
-
-Expected response shape:
-```json
-{
-  "updated_state": {},
-  "delta": [
-    "score updated from 7-5 to 8-5"
-  ],
-  "next_needed_evidence": [
-    "clear final scoreboard"
-  ]
-}
-```
-
-### Session close step (`close_current_session`)
-When no more chunks are currently available and the reason is unknown, backend triggers `close_current_session`.
-
-Expected response shape:
-```json
-{
-  "updated_state": {
-    "session_status": {
-      "value": "likely_truncated",
-      "confidence": 0.86,
-      "reason": "last chunk showed active gameplay without terminal UI"
-    },
-    "player_result": {
-      "outcome": "unknown",
-      "confidence": 0.0,
-      "reason": "match ending not confirmed",
-      "is_final": false
-    }
-  },
-  "final_outcome": "unknown"
-}
-```
-
-## Evidence-first decision rules
-Strong terminal signals can set `session_status=confirmed_finished`:
-1. explicit final banner / match end screen;
-2. explicit final scoreboard;
-3. explicit post-match UI / return to lobby after results;
-4. repeated strong terminal indicators across chunks.
-
-Weak signals can suggest `session_status=likely_finished`:
-- long scoreboard without new gameplay,
-- summary/MVP-like screens without explicit final banner,
-- menu transition without explicit winner confirmation.
-
-Truncation signals should prefer `session_status=likely_truncated`:
-- last chunk shows active gameplay,
-- no terminal UI and no post-match transition,
-- data ends abruptly.
-
-Additional hard rules:
-- Never infer `win` because the player "looked stronger".
-- If player side/team is not confirmed, keep `player_result.outcome=unknown`.
-- `player_result.is_final=true` only when `session_status=confirmed_finished` and winner/player-team evidence is strong.
-- Contradictions must be stored in `hard_conflicts`, not silently overwritten.
-
-## Admin capabilities (backend requirements)
-Admin scope changes in this design. The primary object is no longer a prompt-chain scenario, but a **state/rules configuration package**.
-
-Admins must be able to:
-- CRUD **state schemas** for supported games/modes.
-- CRUD **state fields** and field metadata:
-  - field key,
-  - label/description,
-  - enum constraints,
-  - confidence requirements,
-  - whether the field is evidence-bearing, inferred, or final-only.
-- CRUD **update rules** that define how the LLM should treat new chunks.
-- CRUD **finalization rules** that define how the final outcome is derived from accumulated state.
-- CRUD **evidence categories** such as `team_identification`, `score_update`, `round_result`, `final_screen`, `scoreboard`, `side_switch`, `inference`.
-- Configure active prompt templates for:
-  - match update,
-  - match finalization,
-  - optional match-start detection.
-- Configure runtime limits (`model`, `temperature`, `max_tokens`, `timeout_ms`, `retry_count`, `backoff_ms`).
-- Activate/deactivate a versioned state/rules package.
-- View audit trail for all schema/rule/prompt changes.
-
-## Data model (draft)
-
-### Match sessions
-- `match_session_id`
-- `streamer_id`
-- `game_key`
-- `status` (`discovering|in_progress|finished|interrupted|failed`)
-- `started_at`, `finished_at`
-- `state_schema_version_id`
-- `update_prompt_version_id`
-- `finalize_prompt_version_id`
-
-### Match state snapshots
-- `id`
-- `match_session_id`
-- `chunk_id`
-- `state_json`
-- `delta_json`
-- `next_needed_evidence_json`
-- `confidence_summary`
-- `created_at`
-
-### Match evidence log
-- `id`
-- `match_session_id`
-- `chunk_id`
-- `time_range`
-- `kind`
-- `text`
-- `confidence`
-- `source_type` (`observed|inferred`)
-- `created_at`
-
-### Match final decisions
-- `id`
-- `match_session_id`
-- `final_outcome`
-- `final_score_json`
-- `player_team_json`
-- `winner_team_json`
-- `confidence`
-- `evidence_json`
-- `unresolved_issues_json`
-- `created_at`
-
-### Admin-managed tracker configs
-- `state_schema_versions`
-- `state_schema_fields`
-- `tracker_rule_versions`
-- `tracker_rule_items`
-- `tracker_prompt_versions`
-- `tracker_config_audit_log`
-
-## API/WSS plan (MVP)
-
-### Streamer / tracker read APIs
-- `POST /api/streamers` — add streamer and auto-start analysis.
-- `GET /api/streamers/:id/status` — current aggregated match-tracker status.
-- `GET /api/streamers/:id/llm-decisions?limit=` — recent state-update/finalize history.
-- `GET /api/streamers/:id/match-sessions` — recent match sessions with latest state summary.
-
-### Admin CRUD APIs
-- `GET /api/admin/llm/state-schemas`
-- `POST /api/admin/llm/state-schemas`
-- `PUT /api/admin/llm/state-schemas/:id`
-- `POST /api/admin/llm/state-schemas/:id/activate`
-- `GET /api/admin/llm/rule-sets`
-- `POST /api/admin/llm/rule-sets`
-- `PUT /api/admin/llm/rule-sets/:id`
-- `POST /api/admin/llm/rule-sets/:id/activate`
-- `GET /api/admin/llm/prompts`
-- `POST /api/admin/llm/prompts`
-- `POST /api/admin/llm/prompts/:id/activate`
-
-### WebSocket events
-- `LLM_MATCH_STATE_UPDATED` with payload:
-  `{streamerId, matchSessionId, gameKey, status, stateSummary, confidence, ts}`
-- `LLM_MATCH_FINALIZED` with payload:
-  `{streamerId, matchSessionId, outcome, finalScore, confidence, ts}`
-
-## Phased implementation
-
-### Phase 1 — Legacy removal + admin CRUD for tracker configuration
-- Delete or refactor legacy detector/scenario-chain runtime codepaths before enabling the tracker in production.
-- Add DB-backed CRUD for state schemas, state fields, rule sets, and prompt versions.
-- Add activation/versioning and audit logging.
-- Remove in-memory-only scenario-chain configuration from the roadmap and services.
-
-### Phase 2 — Worker state tracker loop
-- Scheduler selects active streamers.
-- Streamlink chunk fetch + storage reference.
-- Match session discovery/open/resume.
-- LLM update call with `previous_state + new_chunk`.
-- Persist updated state/evidence/conflicts.
-
-### Phase 3 — Finalization and delivery
-- Detect terminal evidence / session end.
-- LLM finalization call from accumulated state.
-- Persist final decision and publish websocket notifications.
-- Expose REST history and state backfill.
-
-### Phase 4 — Reliability & observability
-- Retries/backoff, DLQ, idempotency guards.
-- Metrics for chunk lag, update latency, finalization latency, state conflicts, and unknown-rate.
-- Alerting on drift in final-outcome confidence and conflict frequency.
-
-## Risks and mitigations
-- **Narrative drift**: force strict JSON-only responses and always provide `previous_state`.
-- **Prompt sprawl**: version state schemas/rules separately from prompt text so admins can change logic without rewriting everything.
-- **Conflicting evidence**: keep `hard_conflicts` instead of overwriting prior facts.
-- **False certainty**: outcome remains `unknown` unless evidence passes admin-defined thresholds.
-
-## Open questions before coding
-1. Do we need a lightweight admin-managed match-start detector, or is manual/heuristic session opening enough for the first slice?
-2. Which game modes beyond CS2 competitive/faceit should receive first-class state schemas in MVP?
-3. Should admins be able to define rule ordering/priority explicitly per rule item?
-4. Which fields must be editable in UI versus stored as advanced JSON config only?
-
-## Execution backlog (next two iterations)
-
-This backlog continues implementation according to `docs/implementation_plan.md` (M2.1)
-and is ordered to ship a vertical slice before hardening.
-
-### Iteration A — State tracker baseline
-
-Goal: produce and persist match-session state snapshots for active streamers from real worker cycles.
-
-#### A1. Legacy removal + admin CRUD + persistence
-- [ ] Delete or refactor legacy detector/scenario-chain runtime codepaths and feature flags.
-- [ ] Add DB model/repository for state schema versions, fields, rule sets, and prompt versions.
-- [ ] Add activation + audit history for tracker configs.
-- [ ] Remove references to deprecated scenario-chain storage from active implementation docs and services.
-
-Definition of done:
-- old prompt-chain runtime entrypoints are no longer reachable in normal execution;
-- admin can create/update/activate a tracker config package;
-- workers resolve active config from DB only.
-
-#### A2. Worker update loop
-- [ ] Introduce/update stream capture worker orchestration to:
-  - acquire streamer lock,
-  - fetch fragment via Streamlink every 10 seconds,
-  - resolve active tracker config,
-  - call the LLM with `previous_state + new_chunk`,
-  - persist state snapshot and evidence log.
-- [ ] Add match session repository and link state snapshots to chunk windows.
-- [ ] Add normalized parser/validator for strict update JSON.
-
-Definition of done:
-- one worker pass creates or updates a match session state snapshot for a test streamer;
-- duplicate cycle for the same lock window is rejected.
-
-#### A3. Baseline telemetry
-- [ ] Add metrics for chunk lag, update latency, finalize latency, unknown-rate, and conflict-rate.
-- [ ] Add structured logs with `match_session_id`, `streamer_id`, `game_key`, and `chunk_window`.
-
-Definition of done:
-- metrics are visible in local `/metrics` output;
-- failure logs are correlated by `match_session_id`.
-
-### Iteration B — Final decision flow + reliability
-
-Goal: complete M2.1 exit criteria with finalization, websocket updates, and resilient orchestration.
-
-#### B1. Finalization flow
-- [ ] Implement end-of-match detection / terminal-state trigger.
-- [ ] Implement finalization prompt execution from accumulated state.
-- [ ] Persist final outcome (`win | loss | draw | unknown`) with evidence bundle.
-
-Definition of done:
-- finalized matches produce durable outcome records and state summaries;
-- unknown remains the default when final evidence is insufficient.
-
-#### B2. Retry, idempotency, dead-letter
-- [ ] Add retry policy with exponential backoff for Streamlink and LLM failures.
-- [ ] Add idempotency keys (`streamer_id + match_session_id + chunk_window + request_kind`) with Redis TTL.
-- [ ] Add DLQ payload format and reprocessing admin command.
-
-Definition of done:
-- transient failures are retried and eventually either succeed or move to DLQ;
-- duplicate job delivery does not create duplicate state snapshots or final decisions.
-
-#### B3. Realtime and session integration
-- [ ] Publish `LLM_MATCH_STATE_UPDATED` and `LLM_MATCH_FINALIZED` from the worker path.
-- [ ] Add reconnect backfill flow (`GET status` + `GET llm-decisions` + match session history).
-- [ ] Integrate Redis refresh session store in auth login/refresh/logout endpoints.
-
-Definition of done:
-- websocket clients receive near-real-time tracker updates;
-- refresh token replay is rejected after rotation;
-- revoke-all immediately invalidates prior refresh sessions.
-
-## Delivery checklist mapped to `docs/implementation_plan.md`
-
-### M2.1 completion checklist
-- [ ] Delete or refactor legacy detector/scenario-chain runtime codepaths.
-- [ ] Implement DB-backed admin CRUD for state schemas, rules, and prompt versions.
-- [ ] Implement stream capture worker pipeline with `previous_state + new_chunk -> updated_state` flow.
-- [ ] Persist match sessions, state snapshots, evidence, and final outcomes.
-- [ ] Publish live match-state/finalization updates via WebSocket.
-- [ ] Add retries, idempotency, and dead-letter handling.
-- [ ] Integrate refresh session store into auth flows.
-- [ ] Add observability (latency, unknown-rate, conflict-rate, token usage).
-
-### Next milestone preview (M3)
-- [ ] Start `/internal/worker/events` ingestion only after the M2.1 tracker checklist is completed.
+## Deferred (next iteration)
+- Database persistence and versioning for scenario packages.
+- Full admin CRUD HTTP routes for scenario graph editing.
+- Visual graph API for UI rendering.
+- Removal of all legacy prompt endpoints after migration completes.

--- a/docs/migrations_plan.md
+++ b/docs/migrations_plan.md
@@ -5,7 +5,9 @@
 > decision persistence in `migrations/0001_users.up.sql`,
 > `migrations/0001_users.down.sql`, `migrations/0002_streamer_llm_decisions.up.sql`,
 > `migrations/0002_streamer_llm_decisions.down.sql`, `migrations/0003_streamer_llm_decisions_state_fields.up.sql`,
-> and `migrations/0003_streamer_llm_decisions_state_fields.down.sql`.
+> `migrations/0003_streamer_llm_decisions_state_fields.down.sql`,
+> `migrations/0004_tracker_config.up.sql`, `migrations/0004_tracker_config.down.sql`,
+> `migrations/0005_llm_scenario_packages.up.sql`, and `migrations/0005_llm_scenario_packages.down.sql`.
 
 1. Create core tables: `users`, `wallet_accounts`, `wallet_ledger`, `payments`, `streamers`, `games`, `events`, `votes`, `media_clips`, `prompts`, `config`, `referrals`, `idempotency`.
 2. Seed configuration values: `minViewers=100`, `starsRate`, `limits.votePerMin`, feature flags (`paymentsEnabled`, `referralsEnabled`, `mediaEnabled`, `adminEnabled`).

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -27,12 +27,16 @@ type ChunkRef struct {
 }
 
 type StageRequest struct {
-	StreamerID    string
-	Stage         string
-	Chunk         ChunkRef
-	Prompt        prompts.PromptVersion
-	PreviousState string
-	StateSchema   string
+	StreamerID      string
+	Stage           string
+	Chunk           ChunkRef
+	Prompt          prompts.PromptVersion
+	PreviousState   string
+	StateSchema     string
+	ResponseSchema  string
+	SendPrompt      bool
+	ScenarioFolder  string
+	ScenarioPackage string
 }
 
 const (
@@ -69,6 +73,10 @@ type StageClassifier interface {
 
 type PromptResolver interface {
 	ListActive(ctx context.Context) []prompts.PromptVersion
+}
+
+type activeScenarioPackageResolver interface {
+	GetActiveScenarioPackage(ctx context.Context, gameSlug string) (prompts.ScenarioPackage, error)
 }
 
 type RunStore interface {
@@ -258,6 +266,18 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 	logger := w.logger
 	if logger == nil {
 		logger = zap.NewNop()
+	}
+
+	if resolver, ok := w.prompts.(activeScenarioPackageResolver); ok {
+		gameSlug := w.resolveGameSlug(ctx, streamerID)
+		pkg, err := resolver.GetActiveScenarioPackage(ctx, gameSlug)
+		if err == nil {
+			decision, runErr := w.processScenarioPackage(ctx, runID, streamerID, chunk, pkg)
+			if runErr == nil {
+				return decision, nil
+			}
+			logger.Error("scenario package processing failed, fallback to legacy stages", zap.String("streamerID", streamerID), zap.String("gameSlug", gameSlug), zap.Error(runErr))
+		}
 	}
 
 	activePrompts := filterTrackerPrompts(w.prompts.ListActive(ctx))
@@ -830,4 +850,77 @@ func compactJSON(value any) string {
 		return ""
 	}
 	return string(data)
+}
+
+func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID string, chunk ChunkRef, pkg prompts.ScenarioPackage) (streamers.LLMDecision, error) {
+	latest := w.latestDecisionByStreamer(ctx, streamerID)
+	previousState := w.resolvePreviousState(ctx, streamerID)
+	step, entering, err := pkg.ResolveStep(latest.Stage, previousState)
+	if err != nil {
+		return streamers.LLMDecision{}, err
+	}
+	activePrompt := prompts.PromptVersion{
+		ID:       step.ID,
+		Stage:    step.ID,
+		Template: step.PromptTemplate,
+		Model:    "scenario-graph",
+		IsActive: true,
+	}
+	stateSchema := w.resolveTrackerConfig(ctx)
+	result, err := w.classifyWithRetry(ctx, StageRequest{
+		StreamerID:      streamerID,
+		Stage:           step.ID,
+		Chunk:           chunk,
+		Prompt:          activePrompt,
+		PreviousState:   previousState,
+		StateSchema:     stateSchema,
+		ResponseSchema:  step.ResponseSchemaJSON,
+		SendPrompt:      entering,
+		ScenarioFolder:  step.Folder,
+		ScenarioPackage: pkg.ID,
+	}, activePrompt)
+	if err != nil {
+		return streamers.LLMDecision{}, err
+	}
+	decision, err := w.processStageResult(ctx, activePrompt, result, chunk, runID, streamerID, previousState)
+	if err != nil {
+		return streamers.LLMDecision{}, err
+	}
+	decision.TransitionToStep = step.ID
+	return decision, nil
+}
+
+func (w *Worker) latestDecisionByStreamer(ctx context.Context, streamerID string) streamers.LLMDecision {
+	if w == nil || w.decisions == nil {
+		return streamers.LLMDecision{}
+	}
+	items := w.decisions.ListAllLLMDecisions(ctx, streamerID)
+	if len(items) == 0 {
+		return streamers.LLMDecision{}
+	}
+	return items[len(items)-1]
+}
+
+func (w *Worker) resolveGameSlug(ctx context.Context, streamerID string) string {
+	state := parseSimpleState(w.resolvePreviousState(ctx, streamerID))
+	if value, ok := state["game"]; ok {
+		if game := strings.TrimSpace(fmt.Sprint(value)); game != "" {
+			return game
+		}
+	}
+	return "global"
+}
+
+func parseSimpleState(raw string) map[string]any {
+	out := map[string]any{}
+	if strings.TrimSpace(raw) == "" {
+		return out
+	}
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return map[string]any{}
+	}
+	if nested, ok := out["state"].(map[string]any); ok {
+		return nested
+	}
+	return out
 }

--- a/internal/prompts/postgres_service.go
+++ b/internal/prompts/postgres_service.go
@@ -90,6 +90,28 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_rule_set_versions_active_game
     ON llm_rule_set_versions (game_slug) WHERE is_active;
 CREATE INDEX IF NOT EXISTS idx_llm_rule_set_versions_order
     ON llm_rule_set_versions (game_slug ASC, version DESC, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS llm_scenario_packages (
+    id TEXT PRIMARY KEY,
+    game_slug TEXT NOT NULL,
+    name TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    steps_json JSONB NOT NULL,
+    transitions_json JSONB NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by TEXT NOT NULL,
+    activated_by TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL,
+    activated_at TIMESTAMPTZ,
+    CHECK (char_length(id) > 0),
+    CHECK (char_length(game_slug) > 0),
+    CHECK (char_length(name) > 0),
+    CHECK (version > 0)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_scenario_packages_active_game
+    ON llm_scenario_packages (game_slug) WHERE is_active;
+CREATE INDEX IF NOT EXISTS idx_llm_scenario_packages_order
+    ON llm_scenario_packages (game_slug ASC, version DESC, created_at DESC);
 `
 
 func (s *Service) ensureSchema(ctx context.Context) error {
@@ -181,6 +203,38 @@ func scanRuleSet(row scanner) (RuleSetVersion, error) {
 	}
 	if err := json.Unmarshal(finalizationRules, &item.FinalizationRules); err != nil {
 		return RuleSetVersion{}, err
+	}
+	if activatedAt.Valid {
+		item.ActivatedAt = activatedAt.Time
+	}
+	return item, nil
+}
+
+func scanScenarioPackage(row scanner) (ScenarioPackage, error) {
+	var item ScenarioPackage
+	var steps []byte
+	var transitions []byte
+	var activatedAt sql.NullTime
+	if err := row.Scan(
+		&item.ID,
+		&item.GameSlug,
+		&item.Name,
+		&item.Version,
+		&steps,
+		&transitions,
+		&item.IsActive,
+		&item.CreatedBy,
+		&item.ActivatedBy,
+		&item.CreatedAt,
+		&activatedAt,
+	); err != nil {
+		return ScenarioPackage{}, err
+	}
+	if err := json.Unmarshal(steps, &item.Steps); err != nil {
+		return ScenarioPackage{}, err
+	}
+	if err := json.Unmarshal(transitions, &item.Transitions); err != nil {
+		return ScenarioPackage{}, err
 	}
 	if activatedAt.Valid {
 		item.ActivatedAt = activatedAt.Time
@@ -700,6 +754,113 @@ func (s *Service) getActiveRuleSetDB(ctx context.Context, gameSlug string) (Rule
 			return RuleSetVersion{}, ErrRuleSetNotFound
 		}
 		return RuleSetVersion{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) listScenarioPackagesDB(ctx context.Context) ([]ScenarioPackage, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages ORDER BY game_slug ASC, version DESC, created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]ScenarioPackage, 0)
+	for rows.Next() {
+		item, err := scanScenarioPackage(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *Service) createScenarioPackageDB(ctx context.Context, req ScenarioPackageCreateRequest) (ScenarioPackage, error) {
+	if len(req.Steps) == 0 {
+		return ScenarioPackage{}, ErrInvalidScenarioPackage
+	}
+	for _, step := range req.Steps {
+		if strings.TrimSpace(step.ID) == "" {
+			return ScenarioPackage{}, ErrInvalidScenarioStepID
+		}
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return ScenarioPackage{}, err
+	}
+	gameSlug := strings.TrimSpace(req.GameSlug)
+	if gameSlug == "" {
+		gameSlug = "global"
+	}
+	stepsJSON, err := marshalJSON(req.Steps)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	transitionsJSON, err := marshalJSON(req.Transitions)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	defer tx.Rollback()
+
+	var version int
+	var existing int
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(version), 0) + 1 FROM llm_scenario_packages WHERE game_slug = $1`, gameSlug).Scan(&version); err != nil {
+		return ScenarioPackage{}, err
+	}
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM llm_scenario_packages WHERE game_slug = $1`, gameSlug).Scan(&existing); err != nil {
+		return ScenarioPackage{}, err
+	}
+	now := time.Now().UTC()
+	item := ScenarioPackage{
+		ID:          "scenario-pkg-" + uuid.NewString(),
+		Name:        strings.TrimSpace(req.Name),
+		GameSlug:    gameSlug,
+		Version:     version,
+		Steps:       append([]ScenarioStep(nil), req.Steps...),
+		Transitions: append([]ScenarioTransition(nil), req.Transitions...),
+		IsActive:    existing == 0,
+		CreatedBy:   strings.TrimSpace(req.ActorID),
+		CreatedAt:   now,
+	}
+	if item.IsActive {
+		item.ActivatedBy = item.CreatedBy
+		item.ActivatedAt = now
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO llm_scenario_packages (id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+		item.ID, item.GameSlug, item.Name, item.Version, stepsJSON, transitionsJSON, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt),
+	); err != nil {
+		return ScenarioPackage{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ScenarioPackage{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) getActiveScenarioPackageDB(ctx context.Context, gameSlug string) (ScenarioPackage, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return ScenarioPackage{}, err
+	}
+	key := strings.TrimSpace(gameSlug)
+	if key == "" {
+		key = "global"
+	}
+	item, err := scanScenarioPackage(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, key))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return ScenarioPackage{}, ErrScenarioPackageNotFound
+		}
+		return ScenarioPackage{}, err
 	}
 	return item, nil
 }

--- a/internal/prompts/postgres_service_test.go
+++ b/internal/prompts/postgres_service_test.go
@@ -115,3 +115,79 @@ func TestPostgresServiceGetActiveRuleSet(t *testing.T) {
 		t.Fatalf("ExpectationsWereMet() error = %v", err)
 	}
 }
+
+func TestPostgresServiceCreateScenarioPackage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	svc := NewPostgresService(db)
+	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS delta_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(version), 0) + 1 FROM llm_scenario_packages WHERE game_slug = $1`)).
+		WithArgs("global").
+		WillReturnRows(sqlmock.NewRows([]string{"next_version"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) FROM llm_scenario_packages WHERE game_slug = $1`)).
+		WithArgs("global").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO llm_scenario_packages (id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:     "global-flow",
+		GameSlug: "global",
+		ActorID:  "admin-1",
+		Steps: []ScenarioStep{
+			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true},
+		},
+		Transitions: []ScenarioTransition{},
+	})
+	if err != nil {
+		t.Fatalf("CreateScenarioPackage() error = %v", err)
+	}
+	if !item.IsActive {
+		t.Fatal("expected first scenario package to be active")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestPostgresServiceGetActiveScenarioPackage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	svc := NewPostgresService(db)
+	now := time.Date(2026, 3, 27, 12, 0, 0, 0, time.UTC)
+	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS delta_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`)).
+		WithArgs("global").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "version", "steps_json", "transitions_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
+			AddRow("scenario-pkg-1", "global", "global-flow", 1, `[{"id":"game_detect","name":"Game detect","promptTemplate":"detect","responseSchemaJson":"{}","initial":true,"order":1}]`, `[]`, true, "admin-1", "admin-1", now, now))
+
+	item, err := svc.GetActiveScenarioPackage(context.Background(), "global")
+	if err != nil {
+		t.Fatalf("GetActiveScenarioPackage() error = %v", err)
+	}
+	if item.ID != "scenario-pkg-1" {
+		t.Fatalf("GetActiveScenarioPackage() = %#v", item)
+	}
+	if len(item.Steps) != 1 || item.Steps[0].ID != "game_detect" {
+		t.Fatalf("unexpected steps: %#v", item.Steps)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -1,0 +1,287 @@
+package prompts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrScenarioPackageNotFound = errors.New("scenario package not found")
+	ErrScenarioStepNotFound    = errors.New("scenario step not found")
+	ErrInvalidScenarioPackage  = errors.New("scenario package must contain at least one step")
+	ErrInvalidScenarioStepID   = errors.New("scenario step id must not be empty")
+)
+
+type ScenarioStep struct {
+	ID                 string    `json:"id"`
+	Name               string    `json:"name"`
+	GameSlug           string    `json:"gameSlug"`
+	Folder             string    `json:"folder"`
+	EntryCondition     string    `json:"entryCondition,omitempty"`
+	PromptTemplate     string    `json:"promptTemplate"`
+	ResponseSchemaJSON string    `json:"responseSchemaJson"`
+	Initial            bool      `json:"initial"`
+	Order              int       `json:"order"`
+	CreatedAt          time.Time `json:"createdAt"`
+}
+
+type ScenarioTransition struct {
+	FromStepID string `json:"fromStepId"`
+	ToStepID   string `json:"toStepId"`
+	Condition  string `json:"condition"`
+	Priority   int    `json:"priority"`
+}
+
+type ScenarioPackage struct {
+	ID          string               `json:"id"`
+	Name        string               `json:"name"`
+	Version     int                  `json:"version"`
+	GameSlug    string               `json:"gameSlug"`
+	IsActive    bool                 `json:"isActive"`
+	Steps       []ScenarioStep       `json:"steps"`
+	Transitions []ScenarioTransition `json:"transitions"`
+	CreatedBy   string               `json:"createdBy"`
+	ActivatedBy string               `json:"activatedBy,omitempty"`
+	CreatedAt   time.Time            `json:"createdAt"`
+	ActivatedAt time.Time            `json:"activatedAt,omitempty"`
+}
+
+type ScenarioPackageCreateRequest struct {
+	Name        string
+	GameSlug    string
+	Steps       []ScenarioStep
+	Transitions []ScenarioTransition
+	ActorID     string
+}
+
+func (s *Service) ListScenarioPackages(ctx context.Context) []ScenarioPackage {
+	if s.db != nil {
+		items, err := s.listScenarioPackagesDB(ctx)
+		if err == nil {
+			return items
+		}
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]ScenarioPackage, 0)
+	for _, versions := range s.scenarioPackages {
+		items = append(items, versions...)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].GameSlug == items[j].GameSlug {
+			return items[i].Version > items[j].Version
+		}
+		return items[i].GameSlug < items[j].GameSlug
+	})
+	return items
+}
+
+func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackageCreateRequest) (ScenarioPackage, error) {
+	if s.db != nil {
+		return s.createScenarioPackageDB(ctx, req)
+	}
+	if len(req.Steps) == 0 {
+		return ScenarioPackage{}, ErrInvalidScenarioPackage
+	}
+	for _, step := range req.Steps {
+		if strings.TrimSpace(step.ID) == "" {
+			return ScenarioPackage{}, ErrInvalidScenarioStepID
+		}
+	}
+	gameSlug := strings.TrimSpace(req.GameSlug)
+	if gameSlug == "" {
+		gameSlug = "global"
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.scenarioPackages == nil {
+		s.scenarioPackages = map[string][]ScenarioPackage{}
+	}
+	now := time.Now().UTC()
+	s.counter++
+	version := len(s.scenarioPackages[gameSlug]) + 1
+	item := ScenarioPackage{
+		ID:          fmt.Sprintf("scenario-pkg-%d", s.counter),
+		Name:        strings.TrimSpace(req.Name),
+		Version:     version,
+		GameSlug:    gameSlug,
+		Steps:       append([]ScenarioStep(nil), req.Steps...),
+		Transitions: append([]ScenarioTransition(nil), req.Transitions...),
+		CreatedBy:   strings.TrimSpace(req.ActorID),
+		CreatedAt:   now,
+	}
+	if len(s.scenarioPackages[gameSlug]) == 0 {
+		item.IsActive = true
+		item.ActivatedBy = strings.TrimSpace(req.ActorID)
+		item.ActivatedAt = now
+	}
+	for i := range item.Steps {
+		if item.Steps[i].CreatedAt.IsZero() {
+			item.Steps[i].CreatedAt = now
+		}
+		if item.Steps[i].Order <= 0 {
+			item.Steps[i].Order = i + 1
+		}
+		if strings.TrimSpace(item.Steps[i].GameSlug) == "" {
+			item.Steps[i].GameSlug = gameSlug
+		}
+	}
+	s.scenarioPackages[gameSlug] = append(s.scenarioPackages[gameSlug], item)
+	return item, nil
+}
+
+func (s *Service) GetActiveScenarioPackage(ctx context.Context, gameSlug string) (ScenarioPackage, error) {
+	if s.db != nil {
+		return s.getActiveScenarioPackageDB(ctx, gameSlug)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.scenarioPackages == nil {
+		return ScenarioPackage{}, ErrScenarioPackageNotFound
+	}
+	key := strings.TrimSpace(gameSlug)
+	if key == "" {
+		key = "global"
+	}
+	for _, item := range s.scenarioPackages[key] {
+		if item.IsActive {
+			return item, nil
+		}
+	}
+	return ScenarioPackage{}, ErrScenarioPackageNotFound
+}
+
+func (p ScenarioPackage) ResolveStep(currentStepID, stateJSON string) (ScenarioStep, bool, error) {
+	byID := make(map[string]ScenarioStep, len(p.Steps))
+	for _, step := range p.Steps {
+		byID[step.ID] = step
+	}
+
+	state := parseJSONMap(stateJSON)
+	current := strings.TrimSpace(currentStepID)
+	if current == "" {
+		initial := make([]ScenarioStep, 0, len(p.Steps))
+		for _, step := range p.Steps {
+			if step.Initial {
+				initial = append(initial, step)
+			}
+		}
+		if len(initial) == 0 {
+			initial = append(initial, p.Steps...)
+		}
+		sort.Slice(initial, func(i, j int) bool { return initial[i].Order < initial[j].Order })
+		for _, candidate := range initial {
+			ok, err := evaluateCondition(candidate.EntryCondition, state)
+			if err == nil && ok {
+				return candidate, true, nil
+			}
+		}
+		return ScenarioStep{}, false, ErrScenarioStepNotFound
+	}
+
+	active, ok := byID[current]
+	if !ok {
+		return ScenarioStep{}, false, ErrScenarioStepNotFound
+	}
+
+	transitions := make([]ScenarioTransition, 0)
+	for _, item := range p.Transitions {
+		if strings.EqualFold(strings.TrimSpace(item.FromStepID), current) {
+			transitions = append(transitions, item)
+		}
+	}
+	sort.Slice(transitions, func(i, j int) bool { return transitions[i].Priority < transitions[j].Priority })
+	for _, tr := range transitions {
+		ok, err := evaluateCondition(tr.Condition, state)
+		if err != nil || !ok {
+			continue
+		}
+		next, ok := byID[strings.TrimSpace(tr.ToStepID)]
+		if !ok {
+			continue
+		}
+		return next, next.ID != current, nil
+	}
+	return active, false, nil
+}
+
+func evaluateCondition(condition string, payload map[string]any) (bool, error) {
+	expr := strings.TrimSpace(condition)
+	if expr == "" {
+		return true, nil
+	}
+	if strings.HasPrefix(expr, "exists(") && strings.HasSuffix(expr, ")") {
+		path := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(expr, "exists("), ")"))
+		_, ok := lookupJSONPath(payload, path)
+		return ok, nil
+	}
+	if strings.HasPrefix(expr, "not_exists(") && strings.HasSuffix(expr, ")") {
+		path := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(expr, "not_exists("), ")"))
+		_, ok := lookupJSONPath(payload, path)
+		return !ok, nil
+	}
+	for _, op := range []string{"!=", "=="} {
+		if idx := strings.Index(expr, op); idx > 0 {
+			left := strings.TrimSpace(expr[:idx])
+			right := strings.TrimSpace(expr[idx+len(op):])
+			raw, ok := lookupJSONPath(payload, left)
+			if !ok {
+				return false, nil
+			}
+			leftValue := fmt.Sprint(raw)
+			rightValue := strings.Trim(right, "'\"")
+			if op == "==" {
+				return strings.EqualFold(leftValue, rightValue), nil
+			}
+			return !strings.EqualFold(leftValue, rightValue), nil
+		}
+	}
+	return false, fmt.Errorf("unsupported condition: %s", expr)
+}
+
+func parseJSONMap(raw string) map[string]any {
+	out := map[string]any{}
+	if strings.TrimSpace(raw) == "" {
+		return out
+	}
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+func lookupJSONPath(payload map[string]any, path string) (any, bool) {
+	parts := strings.Split(strings.TrimSpace(path), ".")
+	var current any = payload
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, false
+		}
+		switch typed := current.(type) {
+		case map[string]any:
+			v, ok := typed[part]
+			if !ok {
+				return nil, false
+			}
+			current = v
+		case []any:
+			idx, err := strconv.Atoi(part)
+			if err != nil || idx < 0 || idx >= len(typed) {
+				return nil, false
+			}
+			current = typed[idx]
+		default:
+			return nil, false
+		}
+	}
+	return current, true
+}

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -1,0 +1,90 @@
+package prompts
+
+import (
+	"context"
+	"testing"
+)
+
+func TestScenarioPackageResolveStep(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:     "cs2 flow",
+		GameSlug: "global",
+		ActorID:  "admin-1",
+		Steps: []ScenarioStep{
+			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "cs2_mode", Name: "CS2 mode", Folder: "cs2", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
+			{ID: "cs2_faceit", Name: "Faceit", Folder: "cs2/faceit", PromptTemplate: "faceit", ResponseSchemaJSON: `{}`, Order: 3},
+		},
+		Transitions: []ScenarioTransition{
+			{FromStepID: "game_detect", ToStepID: "cs2_mode", Condition: "game == cs2", Priority: 1},
+			{FromStepID: "cs2_mode", ToStepID: "cs2_faceit", Condition: "mode == faceit", Priority: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+
+	step, entered, err := pkg.ResolveStep("", `{"game":"cs2"}`)
+	if err != nil {
+		t.Fatalf("resolve initial: %v", err)
+	}
+	if !entered || step.ID != "game_detect" {
+		t.Fatalf("expected initial game_detect entered=true, got entered=%v step=%s", entered, step.ID)
+	}
+
+	step, entered, err = pkg.ResolveStep("game_detect", `{"game":"cs2"}`)
+	if err != nil {
+		t.Fatalf("resolve game transition: %v", err)
+	}
+	if !entered || step.ID != "cs2_mode" {
+		t.Fatalf("expected transition to cs2_mode, got entered=%v step=%s", entered, step.ID)
+	}
+
+	step, entered, err = pkg.ResolveStep("cs2_mode", `{"game":"cs2","mode":"none"}`)
+	if err != nil {
+		t.Fatalf("resolve hold transition: %v", err)
+	}
+	if entered || step.ID != "cs2_mode" {
+		t.Fatalf("expected stay at cs2_mode, got entered=%v step=%s", entered, step.ID)
+	}
+
+	step, entered, err = pkg.ResolveStep("cs2_mode", `{"game":"cs2","mode":"faceit"}`)
+	if err != nil {
+		t.Fatalf("resolve faceit transition: %v", err)
+	}
+	if !entered || step.ID != "cs2_faceit" {
+		t.Fatalf("expected transition to cs2_faceit, got entered=%v step=%s", entered, step.ID)
+	}
+}
+
+func TestEvaluateCondition(t *testing.T) {
+	t.Parallel()
+	payload := map[string]any{"game": "cs2", "mode": "faceit", "nested": map[string]any{"value": "x"}}
+
+	cases := []struct {
+		name string
+		expr string
+		want bool
+	}{
+		{name: "equals", expr: "game == cs2", want: true},
+		{name: "not equals", expr: "mode != premier", want: true},
+		{name: "exists", expr: "exists(nested.value)", want: true},
+		{name: "not_exists", expr: "not_exists(nested.missing)", want: true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := evaluateCondition(tc.expr, payload)
+			if err != nil {
+				t.Fatalf("evaluateCondition(%q) error: %v", tc.expr, err)
+			}
+			if got != tc.want {
+				t.Fatalf("evaluateCondition(%q)=%v, want %v", tc.expr, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/prompts/service.go
+++ b/internal/prompts/service.go
@@ -12,30 +12,33 @@ import (
 
 // Service manages versioned LLM prompt templates for each stage.
 type Service struct {
-	mu           sync.RWMutex
-	counter      int
-	versions     map[string][]PromptVersion
-	stateSchemas map[string][]StateSchemaVersion
-	ruleSets     map[string][]RuleSetVersion
-	db           *sql.DB
-	schemaMu     sync.Mutex
-	schemaReady  bool
+	mu               sync.RWMutex
+	counter          int
+	versions         map[string][]PromptVersion
+	stateSchemas     map[string][]StateSchemaVersion
+	ruleSets         map[string][]RuleSetVersion
+	scenarioPackages map[string][]ScenarioPackage
+	db               *sql.DB
+	schemaMu         sync.Mutex
+	schemaReady      bool
 }
 
 func NewService() *Service {
 	return &Service{
-		versions:     map[string][]PromptVersion{},
-		stateSchemas: map[string][]StateSchemaVersion{},
-		ruleSets:     map[string][]RuleSetVersion{},
+		versions:         map[string][]PromptVersion{},
+		stateSchemas:     map[string][]StateSchemaVersion{},
+		ruleSets:         map[string][]RuleSetVersion{},
+		scenarioPackages: map[string][]ScenarioPackage{},
 	}
 }
 
 func NewPostgresService(db *sql.DB) *Service {
 	return &Service{
-		versions:     map[string][]PromptVersion{},
-		stateSchemas: map[string][]StateSchemaVersion{},
-		ruleSets:     map[string][]RuleSetVersion{},
-		db:           db,
+		versions:         map[string][]PromptVersion{},
+		stateSchemas:     map[string][]StateSchemaVersion{},
+		ruleSets:         map[string][]RuleSetVersion{},
+		scenarioPackages: map[string][]ScenarioPackage{},
+		db:               db,
 	}
 }
 

--- a/migrations/0005_llm_scenario_packages.down.sql
+++ b/migrations/0005_llm_scenario_packages.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_llm_scenario_packages_order;
+DROP INDEX IF EXISTS idx_llm_scenario_packages_active_game;
+DROP TABLE IF EXISTS llm_scenario_packages;

--- a/migrations/0005_llm_scenario_packages.up.sql
+++ b/migrations/0005_llm_scenario_packages.up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS llm_scenario_packages (
+    id TEXT PRIMARY KEY,
+    game_slug TEXT NOT NULL,
+    name TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    steps_json JSONB NOT NULL,
+    transitions_json JSONB NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by TEXT NOT NULL,
+    activated_by TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL,
+    activated_at TIMESTAMPTZ,
+    CHECK (char_length(id) > 0),
+    CHECK (char_length(game_slug) > 0),
+    CHECK (char_length(name) > 0),
+    CHECK (version > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_scenario_packages_active_game
+    ON llm_scenario_packages (game_slug) WHERE is_active;
+
+CREATE INDEX IF NOT EXISTS idx_llm_scenario_packages_order
+    ON llm_scenario_packages (game_slug ASC, version DESC, created_at DESC);


### PR DESCRIPTION
### Motivation
- Replace the legacy linear prompt-chain detector with a data-driven scenario-graph model so admin-defined scenario steps drive LLM analysis and state transitions.
- Provide per-game scenario packages (root -> folder -> concrete steps) to allow condition-based transitions, stay-on-step fallback, and clearer admin UX for multi-step orchestration.
- Persist scenario packages and wire them into the worker loop to enable DB-backed activation/versioning and safer migration from in-memory prompts.

### Description
- Add a new scenario orchestration model in `internal/prompts/scenario_flow.go` implementing `ScenarioPackage`, `ScenarioStep`, `ScenarioTransition`, `ResolveStep`, and condition evaluation helpers (`evaluateCondition`, `lookupJSONPath`).
- Extend the prompts service to store scenario packages in-memory and in Postgres, add DB DDL, scan/CRUD functions (`listScenarioPackagesDB`, `createScenarioPackageDB`, `getActiveScenarioPackageDB`), and wire `scenarioPackages` into `Service` initialization.
- Add SQL migration files `migrations/0005_llm_scenario_packages.up.sql` and `.down.sql` and include the new migration in `docs/migrations_plan.md` and Postgres DDL in `internal/prompts/postgres_service.go`.
- Update the media worker to prefer scenario-package execution when available by adding `processScenarioPackage`, extending `StageRequest` with scenario metadata, adding `activeScenarioPackageResolver` interface usage, and falling back to legacy prompt stages on error.
- Add unit tests for the scenario flow and Postgres scenario package behavior in `internal/prompts/scenario_flow_test.go` and extend `internal/prompts/postgres_service_test.go` to cover create/get active package flows.
- Update docs to reflect the new `Scenario Graph v2` orchestration plan and mark related checklist items.

### Testing
- Ran unit tests in the prompts package with `go test ./internal/prompts -v`, which exercised `TestScenarioPackageResolveStep` and `TestEvaluateCondition`, and they passed.
- Ran updated Postgres service unit tests from `internal/prompts/postgres_service_test.go` (mocked DB via `sqlmock`) which cover `CreateScenarioPackage` and `GetActiveScenarioPackage`, and they passed.
- Ran repository-wide tests with `go test ./...` to validate integration points and the worker fallback path, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69f8113d0832c9008d32c173a4407)