### PR TITLE
docs: deprecate legacy stream priority checklist and point to llm_stream_orchestration_plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,16 +26,15 @@ This repository contains the backend modular monolith for the FunPot Telegram Mi
 
 
 ## Priority Task for Agents (current)
-- Top priority: implement Streamlink-driven analysis after streamer onboarding.
-- Required target behavior:
-  1. After streamer is added, connect/start worker job automatically.
-  2. Download/capture stream chunks every 10 seconds.
-  3. Send each chunk to LLM with the active admin-created prompt.
-  4. Persist decisions and publish live status updates.
-- Keep your final checklist explicitly aligned with `docs/implementation_plan.md` M2.1 and the priority checklist.
+- Legacy "Priority Directive / Priority checklist" in `docs/implementation_plan.md` is deprecated and should no longer be used for planning.
+- Canonical business logic for stream orchestration is now `docs/llm_stream_orchestration_plan.md`.
+- Top priority: implement and align runtime behavior to the scenario-graph v2 model described in `docs/llm_stream_orchestration_plan.md`.
+- Keep your final checklist explicitly aligned with:
+  1. `docs/implementation_plan.md` milestone **M2.1**, and
+  2. `docs/llm_stream_orchestration_plan.md` (Goal, Canonical 3-level behavior, State + transitions, Immediate backend scope).
 
 ## Status Reporting
 - Every deliverable or follow-up task must include an explicit checklist in the final
   response that marks what has been completed (`[x]`) and what remains (`[ ]`).
 - Keep the checklist aligned with the implementation plan in `docs/implementation_plan.md`
-  so stakeholders can track progress across iterations.
+  and with `docs/llm_stream_orchestration_plan.md` so stakeholders can track progress across iterations.

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -12,38 +12,11 @@ approximate sequencing, and validation criteria.
 - **Operational readiness first**: tracing, metrics, and idempotency are enabled
   before public exposure of new routes.
 
-## Priority Directive (current focus for agents)
-The highest-priority delivery for the next iteration is enabling continuous
-stream analysis immediately after a streamer is added:
-
-- Trigger background orchestration when a streamer is created/activated.
-- Capture stream fragments every **10 seconds** via Streamlink.
-- For each fragment, resolve the **active admin-managed state schema and prompt
-  package** from the database.
-- Treat each detected match as **one chat / one match session** with an explicit,
-  compact persisted state JSON passed back to the model on every update.
-- Replace narrative prompt chains with a **state-tracker loop**:
-  `previous_state + new_chunk -> updated_state`.
-- Let admins CRUD the tracked state fields, evidence fields, and finalization
-  rules so outcome logic is data-driven and auditable.
-- Explicitly delete or refactor the old detector/scenario-chain orchestration
-  codepaths so the runtime has a single tracker-based source of truth.
-- Persist state snapshots, evidence logs, final outcomes, and broadcast live
-  state updates to clients.
-
-### Priority checklist (must be tracked in status updates)
-- [x] Auto-start Streamlink analysis job after `POST /api/streamers` success.
-- [x] Provide a stop-tracking control path so clients can end per-streamer monitoring without restarting the service.
-- [x] Fixed 10-second capture cadence with lock/idempotency protections.
-- [x] Delete or refactor legacy detector/scenario-chain codepaths before enabling the new tracker flow in production.
-- [x] Persist the active state schema, rule set, and prompt package in the database with audit/version history.
-- [ ] Provide admin CRUD for tracked state fields, evidence categories, and finalization rules.
-- [ ] Resolve the active tracker configuration (state schema + prompts) from admin configuration.
-- [ ] Worker payload includes `previous_state`, prompt text, `state_schema`, runtime params, and the new chunk payload for each 10-second window.
-- [ ] Persist chunk metadata, LLM request/response refs, updated state snapshot, evidence delta, conflicts, and finalization outcome when available.
-- [ ] Publish realtime `LLM_MATCH_STATE_UPDATED` / `LLM_MATCH_FINALIZED` events and provide REST backfill/history.
-- [ ] Add retry/backoff + DLQ behavior for Streamlink and LLM failures.
-- [ ] Add observability for chunk lag, state-update/finalization latency, conflict rate, unknown-outcome rate, and per-streamer failure rate.
+## Priority Directive (deprecated)
+The old "Priority Directive / Priority checklist" for stream analysis has been
+deprecated. Agents and contributors must use
+`docs/llm_stream_orchestration_plan.md` as the canonical source for current
+business logic and immediate backend scope.
 
 ## Milestones
 


### PR DESCRIPTION
### Motivation
- Clarify and centralize the canonical business logic for stream orchestration by deprecating the legacy priority checklist and directing agents to the new plan document. 
- Reduce confusion around runtime behavior and planning by making `docs/llm_stream_orchestration_plan.md` the authoritative source for the stream analysis flow. 
- Ensure status reporting and checklists reference the right artifacts so stakeholders can track progress consistently.

### Description
- Update `AGENTS.md` to mark the legacy "Priority Directive / Priority checklist" as deprecated and replace it with explicit references to `docs/llm_stream_orchestration_plan.md` and the scenario-graph v2 model. 
- Adjust the top-priority wording in `AGENTS.md` to align runtime behavior to the scenario-graph v2 model and require checklists to reference both `docs/implementation_plan.md` (M2.1) and `docs/llm_stream_orchestration_plan.md`. 
- Remove the detailed, now-deprecated priority directive and checklist from `docs/implementation_plan.md` and add a short deprecation note directing readers to `docs/llm_stream_orchestration_plan.md`. 
- Minor editorial tweaks to the status reporting paragraph to link it to the new canonical plan.

### Testing
- This is a documentation-only change and did not modify executable code, so no automated tests were required or executed. 
- No CI test failures were introduced by these docs edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a73d0158832ca7073a9accd6ed16)