### PR TITLE
Add admin CRUD endpoints for LLM rule-sets (API, router, OpenAPI, tests)

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -199,6 +199,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/admin/llm/state-schemas` / `POST /api/admin/llm/state-schemas` – admin CRUD for versioned match state schemas.
   - Admin configures tracked state via `fields` (including nested keys with dot notation, e.g. `score.ct`).
   - Service derives a normalized initial tracker state from configured fields (no raw schema JSON blobs in the API contract).
+- `GET /api/admin/llm/rule-sets` / `POST /api/admin/llm/rule-sets` – admin CRUD for versioned tracker update/finalization rule sets.
 - `GET /api/admin/llm/prompts` / `POST /api/admin/llm/prompts` – admin CRUD for match update/finalization prompt templates.
 - When PostgreSQL is enabled, admin-managed tracker configuration (`/api/admin/llm/state-schemas`, `/api/admin/prompts`) is persisted in dedicated versioned tables and survives service restarts.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -510,6 +510,121 @@ paths:
                 $ref: '#/components/schemas/StateSchemaVersion'
         default:
           $ref: '#/components/responses/Error'
+  /api/admin/llm/rule-sets:
+    get:
+      summary: List LLM rule sets (admin)
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: LLM rule sets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RuleSetVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create LLM rule set (admin)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RuleSetCreateRequest'
+      responses:
+        '201':
+          description: Created LLM rule set
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuleSetVersion'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/llm/rule-sets/{ruleSetId}:
+    get:
+      summary: Get LLM rule set (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: ruleSetId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: LLM rule set
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuleSetVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update LLM rule set (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: ruleSetId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RuleSetCreateRequest'
+      responses:
+        '200':
+          description: Updated LLM rule set
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuleSetVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Delete LLM rule set (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: ruleSetId
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: LLM rule set deleted
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/llm/rule-sets/{ruleSetId}/activate:
+    post:
+      summary: Activate LLM rule set (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: ruleSetId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activated LLM rule set
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuleSetVersion'
+        default:
+          $ref: '#/components/responses/Error'
   /api/events/live:
     get:
       summary: Get live events for a streamer
@@ -1312,6 +1427,81 @@ components:
     StateSchemaVersion:
       allOf:
         - $ref: '#/components/schemas/StateSchemaCreateRequest'
+        - type: object
+          properties:
+            id:
+              type: string
+            version:
+              type: integer
+            isActive:
+              type: boolean
+            createdBy:
+              type: string
+            activatedBy:
+              type: string
+              nullable: true
+            createdAt:
+              type: string
+              format: date-time
+            activatedAt:
+              type: string
+              format: date-time
+              nullable: true
+    RuleItem:
+      type: object
+      required: [id, fieldKey, operation, confidenceMode, finalOnly]
+      properties:
+        id:
+          type: string
+        fieldKey:
+          type: string
+        operation:
+          type: string
+        evidenceKinds:
+          type: array
+          items:
+            type: string
+        confidenceMode:
+          type: string
+        finalOnly:
+          type: boolean
+    RuleCondition:
+      type: object
+      required: [id, priority, condition, action]
+      properties:
+        id:
+          type: string
+        priority:
+          type: integer
+        condition:
+          type: string
+        action:
+          type: string
+        targetField:
+          type: string
+    RuleSetCreateRequest:
+      type: object
+      required: [gameSlug, name, ruleItems, finalizationRules]
+      properties:
+        gameSlug:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        ruleItems:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/RuleItem'
+        finalizationRules:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/RuleCondition'
+    RuleSetVersion:
+      allOf:
+        - $ref: '#/components/schemas/RuleSetCreateRequest'
         - type: object
           properties:
             id:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -79,6 +79,38 @@ func stateSchemaRequestToCreateRequest(req stateSchemaCreateRequest, actorID str
 	}
 }
 
+func ruleSetRequestToCreateRequest(req ruleSetCreateRequest, actorID string) prompts.RuleSetCreateRequest {
+	items := make([]prompts.RuleItem, 0, len(req.RuleItems))
+	for _, item := range req.RuleItems {
+		items = append(items, prompts.RuleItem{
+			ID:             item.ID,
+			FieldKey:       item.FieldKey,
+			Operation:      item.Operation,
+			EvidenceKinds:  item.EvidenceKinds,
+			ConfidenceMode: item.ConfidenceMode,
+			FinalOnly:      item.FinalOnly,
+		})
+	}
+	conditions := make([]prompts.RuleCondition, 0, len(req.FinalizationRules))
+	for _, item := range req.FinalizationRules {
+		conditions = append(conditions, prompts.RuleCondition{
+			ID:          item.ID,
+			Priority:    item.Priority,
+			Condition:   item.Condition,
+			Action:      item.Action,
+			TargetField: item.TargetField,
+		})
+	}
+	return prompts.RuleSetCreateRequest{
+		GameSlug:          req.GameSlug,
+		Name:              req.Name,
+		Description:       req.Description,
+		RuleItems:         items,
+		FinalizationRules: conditions,
+		ActorID:           actorID,
+	}
+}
+
 type configLimits struct {
 	VotePerMin int `json:"votePerMin"`
 }
@@ -151,6 +183,31 @@ type stateSchemaCreateRequest struct {
 	Name        string              `json:"name"`
 	Description string              `json:"description"`
 	Fields      []stateFieldRequest `json:"fields"`
+}
+
+type ruleItemRequest struct {
+	ID             string   `json:"id"`
+	FieldKey       string   `json:"fieldKey"`
+	Operation      string   `json:"operation"`
+	EvidenceKinds  []string `json:"evidenceKinds"`
+	ConfidenceMode string   `json:"confidenceMode"`
+	FinalOnly      bool     `json:"finalOnly"`
+}
+
+type ruleConditionRequest struct {
+	ID          string `json:"id"`
+	Priority    int    `json:"priority"`
+	Condition   string `json:"condition"`
+	Action      string `json:"action"`
+	TargetField string `json:"targetField"`
+}
+
+type ruleSetCreateRequest struct {
+	GameSlug          string                 `json:"gameSlug"`
+	Name              string                 `json:"name"`
+	Description       string                 `json:"description"`
+	RuleItems         []ruleItemRequest      `json:"ruleItems"`
+	FinalizationRules []ruleConditionRequest `json:"finalizationRules"`
 }
 
 type meResponse struct {
@@ -771,6 +828,124 @@ func NewHandler(
 					if err := promptsService.DeleteStateSchema(r.Context(), path); err != nil {
 						status := http.StatusBadRequest
 						if errors.Is(err, prompts.ErrStateSchemaNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/llm/rule-sets", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, promptsService.ListRuleSets(r.Context()))
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req ruleSetCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					created, err := promptsService.CreateRuleSet(r.Context(), ruleSetRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusCreated, created)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/llm/rule-sets/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/admin/llm/rule-sets/"), "/")
+				if path == "" {
+					writeError(w, http.StatusBadRequest, "rule set id is required")
+					return
+				}
+				if strings.HasSuffix(path, "/activate") {
+					id := strings.Trim(strings.TrimSuffix(path, "/activate"), "/")
+					if r.Method != http.MethodPost {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					item, err := promptsService.ActivateRuleSet(r.Context(), id, claims.Subject)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrRuleSetNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					item, err := promptsService.GetRuleSet(r.Context(), path)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrRuleSetNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req ruleSetCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					item, err := promptsService.UpdateRuleSet(r.Context(), path, ruleSetRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrRuleSetNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodDelete:
+					if err := promptsService.DeleteRuleSet(r.Context(), path); err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrRuleSetNotFound) {
 							status = http.StatusNotFound
 						}
 						writeError(w, status, err.Error())

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -59,11 +59,103 @@ func TestAdminLLMStateSchemaRoutes(t *testing.T) {
 	if len(schemas) == 0 {
 		t.Fatal("expected non-empty state schema list")
 	}
+	ruleSetBody, _ := json.Marshal(map[string]any{
+		"gameSlug": "cs2",
+		"name":     "CS2 finalize rules",
+		"ruleItems": []map[string]any{
+			{
+				"id":             "r1",
+				"fieldKey":       "score.ct",
+				"operation":      "set",
+				"evidenceKinds":  []string{"scoreboard"},
+				"confidenceMode": "direct",
+				"finalOnly":      false,
+			},
+		},
+		"finalizationRules": []map[string]any{
+			{
+				"id":        "f1",
+				"priority":  1,
+				"condition": "score.ct == 13",
+				"action":    "set_outcome_win",
+			},
+		},
+	})
+	ruleCreateReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/rule-sets", bytes.NewReader(ruleSetBody))
+	ruleCreateReq.Header.Set("Authorization", "Bearer "+adminToken)
+	ruleCreateRes := httptest.NewRecorder()
+	handler.ServeHTTP(ruleCreateRes, ruleCreateReq)
+	if ruleCreateRes.Code != http.StatusCreated {
+		t.Fatalf("rule set create status = %d body=%s", ruleCreateRes.Code, ruleCreateRes.Body.String())
+	}
+	var createdRuleSet map[string]any
+	if err := json.Unmarshal(ruleCreateRes.Body.Bytes(), &createdRuleSet); err != nil {
+		t.Fatalf("rule set create decode error = %v", err)
+	}
+	ruleSetID, _ := createdRuleSet["id"].(string)
+	if ruleSetID == "" {
+		t.Fatalf("expected created rule set id, got %#v", createdRuleSet)
+	}
+
 	ruleListReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/rule-sets", nil)
 	ruleListReq.Header.Set("Authorization", "Bearer "+adminToken)
 	ruleListRes := httptest.NewRecorder()
 	handler.ServeHTTP(ruleListRes, ruleListReq)
-	if ruleListRes.Code != http.StatusNoContent {
-		t.Fatalf("expected removed rule-set route to fall through (204), got %d body=%s", ruleListRes.Code, ruleListRes.Body.String())
+	if ruleListRes.Code != http.StatusOK {
+		t.Fatalf("rule set list status = %d body=%s", ruleListRes.Code, ruleListRes.Body.String())
+	}
+
+	ruleGetReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/rule-sets/"+ruleSetID, nil)
+	ruleGetReq.Header.Set("Authorization", "Bearer "+adminToken)
+	ruleGetRes := httptest.NewRecorder()
+	handler.ServeHTTP(ruleGetRes, ruleGetReq)
+	if ruleGetRes.Code != http.StatusOK {
+		t.Fatalf("rule set get status = %d body=%s", ruleGetRes.Code, ruleGetRes.Body.String())
+	}
+
+	ruleUpdateBody, _ := json.Marshal(map[string]any{
+		"gameSlug": "cs2",
+		"name":     "CS2 finalize rules v2",
+		"ruleItems": []map[string]any{
+			{
+				"id":             "r1",
+				"fieldKey":       "winner_state.winner_side",
+				"operation":      "set",
+				"evidenceKinds":  []string{"final_banner"},
+				"confidenceMode": "direct",
+				"finalOnly":      true,
+			},
+		},
+		"finalizationRules": []map[string]any{
+			{
+				"id":        "f1",
+				"priority":  1,
+				"condition": "winner_state.winner_side == ct",
+				"action":    "set_outcome_win",
+			},
+		},
+	})
+	ruleUpdateReq := httptest.NewRequest(http.MethodPut, "/api/admin/llm/rule-sets/"+ruleSetID, bytes.NewReader(ruleUpdateBody))
+	ruleUpdateReq.Header.Set("Authorization", "Bearer "+adminToken)
+	ruleUpdateRes := httptest.NewRecorder()
+	handler.ServeHTTP(ruleUpdateRes, ruleUpdateReq)
+	if ruleUpdateRes.Code != http.StatusOK {
+		t.Fatalf("rule set update status = %d body=%s", ruleUpdateRes.Code, ruleUpdateRes.Body.String())
+	}
+
+	ruleActivateReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/rule-sets/"+ruleSetID+"/activate", nil)
+	ruleActivateReq.Header.Set("Authorization", "Bearer "+adminToken)
+	ruleActivateRes := httptest.NewRecorder()
+	handler.ServeHTTP(ruleActivateRes, ruleActivateReq)
+	if ruleActivateRes.Code != http.StatusOK {
+		t.Fatalf("rule set activate status = %d body=%s", ruleActivateRes.Code, ruleActivateRes.Body.String())
+	}
+
+	ruleDeleteReq := httptest.NewRequest(http.MethodDelete, "/api/admin/llm/rule-sets/"+ruleSetID, nil)
+	ruleDeleteReq.Header.Set("Authorization", "Bearer "+adminToken)
+	ruleDeleteRes := httptest.NewRecorder()
+	handler.ServeHTTP(ruleDeleteRes, ruleDeleteReq)
+	if ruleDeleteRes.Code != http.StatusNoContent {
+		t.Fatalf("rule set delete status = %d body=%s", ruleDeleteRes.Code, ruleDeleteRes.Body.String())
 	}
 }


### PR DESCRIPTION
### Motivation
- Expose admin-facing CRUD and activation operations for tracker update/finalization rule sets so rule-driven finalization can be managed via the HTTP API and survive restarts.
- Provide OpenAPI surface and request/response schemas for tooling and client integration.
- Add automated coverage for the new endpoints to ensure endpoint wiring and authorization behave as expected.

### Description
- Added new admin endpoints in `internal/app/router.go` for `/api/admin/llm/rule-sets` and `/api/admin/llm/rule-sets/{id}` including `GET`, `POST`, `PUT`, `DELETE`, and `POST .../activate`, with admin authorization checks and JSON request handling.
- Introduced request types and a conversion helper `ruleSetRequestToCreateRequest` to map HTTP payloads to the internal `prompts` service types, and wired calls to `promptsService` methods (`ListRuleSets`, `CreateRuleSet`, `GetRuleSet`, `UpdateRuleSet`, `DeleteRuleSet`, `ActivateRuleSet`).
- Updated OpenAPI (`docs/openapi.yaml`) with the new paths and component schemas (`RuleItem`, `RuleCondition`, `RuleSetCreateRequest`, `RuleSetVersion`) and added the brief reference in `docs/local_setup.md`.
- Added and extended tests in `internal/app/router_admin_llm_test.go` to cover create/list/get/update/activate/delete flows for rule sets.

### Testing
- Ran the updated unit test `TestAdminLLMStateSchemaRoutes` which includes rule-set create/list/get/update/activate/delete flows and observed it succeed.
- Executed `go test ./...` to run package tests locally and observed the test suite passed (including the new admin LLM route tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6aa50f4a4832cbbe687feb6d3eb7c)