### PR TITLE
Add LLM history endpoint and richer decision metadata

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -265,6 +265,31 @@ paths:
                 $ref: '#/components/schemas/LLMDecision'
         default:
           $ref: '#/components/responses/Error'
+  /api/streamers/{streamerId}/llm-history:
+    get:
+      summary: Get latest state updates and final decisions for streamer tracker sessions
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: streamerId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Latest tracker state updates and terminal decisions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMHistory'
+        default:
+          $ref: '#/components/responses/Error'
 
   /api/admin/games:
     get:
@@ -1203,6 +1228,16 @@ components:
           type: string
         transitionTerminal:
           type: boolean
+        previousStateJson:
+          type: string
+        updatedStateJson:
+          type: string
+        evidenceDeltaJson:
+          type: string
+        conflictsJson:
+          type: string
+        finalOutcome:
+          type: string
     LLMDecision:
       type: object
       properties:
@@ -1267,6 +1302,19 @@ components:
         createdAt:
           type: string
           format: date-time
+    LLMHistory:
+      type: object
+      properties:
+        streamerId:
+          type: string
+        latestStateUpdates:
+          type: array
+          items:
+            $ref: '#/components/schemas/LLMDecision'
+        finalDecisions:
+          type: array
+          items:
+            $ref: '#/components/schemas/LLMDecision'
     GameUpsertRequest:
       type: object
       required: [slug, title, status]

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -164,6 +164,11 @@ type llmDecisionRecordRequest struct {
 	TransitionOutcome  string  `json:"transitionOutcome"`
 	TransitionToStep   string  `json:"transitionToStep"`
 	TransitionTerminal bool    `json:"transitionTerminal"`
+	PreviousStateJSON  string  `json:"previousStateJson"`
+	UpdatedStateJSON   string  `json:"updatedStateJson"`
+	EvidenceDeltaJSON  string  `json:"evidenceDeltaJson"`
+	ConflictsJSON      string  `json:"conflictsJson"`
+	FinalOutcome       string  `json:"finalOutcome"`
 }
 
 type stateFieldRequest struct {
@@ -593,6 +598,11 @@ func NewHandler(
 							TransitionOutcome:  req.TransitionOutcome,
 							TransitionToStep:   req.TransitionToStep,
 							TransitionTerminal: req.TransitionTerminal,
+							PreviousStateJSON:  req.PreviousStateJSON,
+							UpdatedStateJSON:   req.UpdatedStateJSON,
+							EvidenceDeltaJSON:  req.EvidenceDeltaJSON,
+							ConflictsJSON:      req.ConflictsJSON,
+							FinalOutcome:       req.FinalOutcome,
 						})
 						if err != nil {
 							writeError(w, http.StatusBadRequest, err.Error())
@@ -602,6 +612,21 @@ func NewHandler(
 					default:
 						w.WriteHeader(http.StatusMethodNotAllowed)
 					}
+				case "llm-history":
+					if r.Method != http.MethodGet {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					limit, err := strconv.Atoi(strings.TrimSpace(r.URL.Query().Get("limit")))
+					if err != nil && r.URL.Query().Get("limit") != "" {
+						writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+						return
+					}
+					if limit < 0 {
+						writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+						return
+					}
+					writeJSON(w, http.StatusOK, streamersService.GetLLMHistory(r.Context(), streamerID, limit))
 				default:
 					writeError(w, http.StatusNotFound, "streamer route not found")
 				}

--- a/internal/app/router_streamers_llm_test.go
+++ b/internal/app/router_streamers_llm_test.go
@@ -143,3 +143,75 @@ func TestStreamerLLMDecisionCreateRejectsInvalidChunkTimestamp(t *testing.T) {
 		t.Fatalf("expected 400, got %d", res.Code)
 	}
 }
+
+func TestStreamerLLMHistoryReturnsLatestUpdatesAndFinals(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamers.NewService(),
+		nil,
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	adminToken := buildToken(t, "admin-1")
+	firstBody, _ := json.Marshal(map[string]any{
+		"runId":            "run-1",
+		"stage":            "match_update",
+		"label":            "score_observed",
+		"confidence":       0.9,
+		"updatedStateJson": "{\"score\":\"8:5\"}",
+	})
+	firstReq := httptest.NewRequest(http.MethodPost, "/api/streamers/str-1/llm-decisions", bytes.NewReader(firstBody))
+	firstReq.Header.Set("Authorization", "Bearer "+adminToken)
+	firstRes := httptest.NewRecorder()
+	handler.ServeHTTP(firstRes, firstReq)
+	if firstRes.Code != http.StatusCreated {
+		t.Fatalf("expected first decision 201, got %d", firstRes.Code)
+	}
+
+	secondBody, _ := json.Marshal(map[string]any{
+		"runId":              "run-1",
+		"stage":              "match_finalize",
+		"label":              "match_done",
+		"confidence":         0.95,
+		"updatedStateJson":   "{\"score\":\"13:10\"}",
+		"finalOutcome":       "win",
+		"transitionTerminal": true,
+	})
+	secondReq := httptest.NewRequest(http.MethodPost, "/api/streamers/str-1/llm-decisions", bytes.NewReader(secondBody))
+	secondReq.Header.Set("Authorization", "Bearer "+adminToken)
+	secondRes := httptest.NewRecorder()
+	handler.ServeHTTP(secondRes, secondReq)
+	if secondRes.Code != http.StatusCreated {
+		t.Fatalf("expected second decision 201, got %d", secondRes.Code)
+	}
+
+	userToken := buildToken(t, "user-1")
+	historyReq := httptest.NewRequest(http.MethodGet, "/api/streamers/str-1/llm-history?limit=1", nil)
+	historyReq.Header.Set("Authorization", "Bearer "+userToken)
+	historyRes := httptest.NewRecorder()
+	handler.ServeHTTP(historyRes, historyReq)
+	if historyRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", historyRes.Code)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(historyRes.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode llm history: %v", err)
+	}
+	updates, ok := payload["latestStateUpdates"].([]any)
+	if !ok || len(updates) != 1 {
+		t.Fatalf("expected one latest state update, got %#v", payload["latestStateUpdates"])
+	}
+	finals, ok := payload["finalDecisions"].([]any)
+	if !ok || len(finals) != 1 {
+		t.Fatalf("expected one final decision, got %#v", payload["finalDecisions"])
+	}
+}

--- a/internal/streamers/model.go
+++ b/internal/streamers/model.go
@@ -63,6 +63,12 @@ type LLMStatus struct {
 	LatestByStage     []LLMDecision `json:"latestByStage"`
 }
 
+type LLMHistory struct {
+	StreamerID         string        `json:"streamerId"`
+	LatestStateUpdates []LLMDecision `json:"latestStateUpdates"`
+	FinalDecisions     []LLMDecision `json:"finalDecisions"`
+}
+
 type RecordDecisionRequest struct {
 	RunID              string
 	StreamerID         string

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -409,6 +409,52 @@ func (s *Service) ListLLMDecisions(ctx context.Context, streamerID string, limit
 	return items
 }
 
+func (s *Service) GetLLMHistory(ctx context.Context, streamerID string, limit int) LLMHistory {
+	key := strings.TrimSpace(streamerID)
+	history := LLMHistory{
+		StreamerID:         key,
+		LatestStateUpdates: []LLMDecision{},
+		FinalDecisions:     []LLMDecision{},
+	}
+	if key == "" {
+		return history
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+
+	items := s.ListAllLLMDecisions(ctx, key)
+	if len(items) == 0 {
+		return history
+	}
+
+	latestUpdates := make([]LLMDecision, 0, limit)
+	finals := make([]LLMDecision, 0, limit)
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		if len(latestUpdates) < limit && strings.TrimSpace(item.UpdatedStateJSON) != "" {
+			latestUpdates = append(latestUpdates, item)
+		}
+		if len(finals) < limit && isFinalDecision(item) {
+			finals = append(finals, item)
+		}
+		if len(latestUpdates) >= limit && len(finals) >= limit {
+			break
+		}
+	}
+	history.LatestStateUpdates = latestUpdates
+	history.FinalDecisions = finals
+	return history
+}
+
+func isFinalDecision(item LLMDecision) bool {
+	if item.TransitionTerminal {
+		return true
+	}
+	outcome := strings.ToLower(strings.TrimSpace(item.FinalOutcome))
+	return outcome == "win" || outcome == "loss" || outcome == "draw" || outcome == "unknown"
+}
+
 func (s *Service) GetLLMStatus(ctx context.Context, streamerID string) LLMStatus {
 	key := strings.TrimSpace(streamerID)
 	status := LLMStatus{StreamerID: key, State: "idle", LatestByStage: []LLMDecision{}}

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -236,3 +236,47 @@ func TestRecordLLMDecisionAllowsCustomStageAndStatusIncludesIt(t *testing.T) {
 		t.Fatalf("stage = %q, want ranked_mode", status.LatestByStage[0].Stage)
 	}
 }
+
+func TestGetLLMHistoryReturnsLatestStateUpdatesAndFinalDecisions(t *testing.T) {
+	svc := NewService()
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	svc.nowFn = func() time.Time { return now }
+
+	if _, err := svc.RecordLLMDecision(context.Background(), RecordDecisionRequest{
+		RunID:            "run-1",
+		StreamerID:       "str-1",
+		Stage:            "match_update",
+		Label:            "awaiting_changes",
+		Confidence:       0.7,
+		UpdatedStateJSON: `{"score":"5:4"}`,
+	}); err != nil {
+		t.Fatalf("first RecordLLMDecision() error = %v", err)
+	}
+	now = now.Add(time.Second)
+	if _, err := svc.RecordLLMDecision(context.Background(), RecordDecisionRequest{
+		RunID:              "run-1",
+		StreamerID:         "str-1",
+		Stage:              "match_finalize",
+		Label:              "finalized",
+		Confidence:         0.9,
+		UpdatedStateJSON:   `{"score":"13:11"}`,
+		FinalOutcome:       "win",
+		TransitionTerminal: true,
+	}); err != nil {
+		t.Fatalf("second RecordLLMDecision() error = %v", err)
+	}
+
+	history := svc.GetLLMHistory(context.Background(), "str-1", 1)
+	if len(history.LatestStateUpdates) != 1 {
+		t.Fatalf("len(LatestStateUpdates) = %d, want 1", len(history.LatestStateUpdates))
+	}
+	if history.LatestStateUpdates[0].Stage != "match_finalize" {
+		t.Fatalf("latest update stage = %q, want match_finalize", history.LatestStateUpdates[0].Stage)
+	}
+	if len(history.FinalDecisions) != 1 {
+		t.Fatalf("len(FinalDecisions) = %d, want 1", len(history.FinalDecisions))
+	}
+	if history.FinalDecisions[0].FinalOutcome != "win" {
+		t.Fatalf("final outcome = %q, want win", history.FinalDecisions[0].FinalOutcome)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide an endpoint to retrieve the latest state updates and terminal decisions for streamer LLM tracker sessions and to capture richer decision metadata for analysis and auditing.

### Description
- Add a new GET endpoint `GET /api/streamers/{streamerId}/llm-history` and expose an `LLMHistory` schema in OpenAPI that returns `latestStateUpdates` and `finalDecisions` arrays.
- Extend the `LLMDecision` model with new fields `previousStateJson`, `updatedStateJson`, `evidenceDeltaJson`, `conflictsJson`, and `finalOutcome` and wire these fields through the router request struct `llmDecisionRecordRequest` into `RecordLLMDecision` calls.
- Implement `GetLLMHistory(ctx, streamerID, limit)` in the streamers service which collects the most recent state updates and final decisions (using `isFinalDecision` to classify finals) with configurable `limit` handling.
- Add request handling in the router for `llm-history` (limit parsing and validation) and update OpenAPI docs to reflect the new endpoint and schema changes.
- Add unit tests `TestGetLLMHistoryReturnsLatestStateUpdatesAndFinalDecisions` and `TestStreamerLLMHistoryReturnsLatestUpdatesAndFinals` covering service and router behavior.

### Testing
- Ran service unit tests for the streamers package including `TestGetLLMHistoryReturnsLatestStateUpdatesAndFinalDecisions`, which passed.
- Ran router tests including `TestStreamerLLMHistoryReturnsLatestUpdatesAndFinals`, which passed.
- Ran `go test ./...` to validate integration of changes across packages and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6adcc1c58832cb0033eff56f065dc)