### PR TITLE
Add LLM scenario-packages: API endpoints, service logic, DB persistence and tests

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -200,8 +200,9 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
   - Admin configures tracked state via `fields` (including nested keys with dot notation, e.g. `score.ct`).
   - Service derives a normalized initial tracker state from configured fields (no raw schema JSON blobs in the API contract).
 - `GET /api/admin/llm/rule-sets` / `POST /api/admin/llm/rule-sets` – admin CRUD for versioned tracker update/finalization rule sets.
-- `GET /api/admin/llm/prompts` / `POST /api/admin/llm/prompts` – admin CRUD for match update/finalization prompt templates.
-- When PostgreSQL is enabled, admin-managed tracker configuration (`/api/admin/llm/state-schemas`, `/api/admin/prompts`) is persisted in dedicated versioned tables and survives service restarts.
+- `GET /api/admin/llm/scenario-packages` / `POST /api/admin/llm/scenario-packages` – admin CRUD for scenario graph packages (`steps + transitions`) with per-game versioning and activation.
+- `GET /api/admin/prompts` / `POST /api/admin/prompts` – admin CRUD for match update/finalization prompt templates.
+- When PostgreSQL is enabled, admin-managed tracker configuration (`/api/admin/llm/state-schemas`, `/api/admin/llm/rule-sets`, `/api/admin/llm/scenario-packages`, `/api/admin/prompts`) is persisted in dedicated versioned tables and survives service restarts.
 
 When database connection fields are unset the server falls back to the in-memory
 repository for user profiles. This is useful for quick smoke tests but bypasses

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -650,6 +650,121 @@ paths:
                 $ref: '#/components/schemas/RuleSetVersion'
         default:
           $ref: '#/components/responses/Error'
+  /api/admin/llm/scenario-packages:
+    get:
+      summary: List LLM scenario packages (admin)
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: LLM scenario packages
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScenarioPackageVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create LLM scenario package (admin)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScenarioPackageCreateRequest'
+      responses:
+        '201':
+          description: Created LLM scenario package
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioPackageVersion'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/llm/scenario-packages/{scenarioPackageId}:
+    get:
+      summary: Get LLM scenario package (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: scenarioPackageId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: LLM scenario package
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioPackageVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update LLM scenario package (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: scenarioPackageId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScenarioPackageCreateRequest'
+      responses:
+        '200':
+          description: Updated LLM scenario package
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioPackageVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Delete LLM scenario package (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: scenarioPackageId
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: LLM scenario package deleted
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/llm/scenario-packages/{scenarioPackageId}/activate:
+    post:
+      summary: Activate LLM scenario package (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: scenarioPackageId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activated LLM scenario package
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioPackageVersion'
+        default:
+          $ref: '#/components/responses/Error'
   /api/events/live:
     get:
       summary: Get live events for a streamer
@@ -1550,6 +1665,82 @@ components:
     RuleSetVersion:
       allOf:
         - $ref: '#/components/schemas/RuleSetCreateRequest'
+        - type: object
+          properties:
+            id:
+              type: string
+            version:
+              type: integer
+            isActive:
+              type: boolean
+            createdBy:
+              type: string
+            activatedBy:
+              type: string
+              nullable: true
+            createdAt:
+              type: string
+              format: date-time
+            activatedAt:
+              type: string
+              format: date-time
+              nullable: true
+    ScenarioStep:
+      type: object
+      required: [id, name, promptTemplate, responseSchemaJson, initial, order]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        gameSlug:
+          type: string
+        folder:
+          type: string
+        entryCondition:
+          type: string
+        promptTemplate:
+          type: string
+        responseSchemaJson:
+          type: string
+        initial:
+          type: boolean
+        order:
+          type: integer
+          minimum: 1
+    ScenarioTransition:
+      type: object
+      required: [fromStepId, toStepId, condition, priority]
+      properties:
+        fromStepId:
+          type: string
+        toStepId:
+          type: string
+        condition:
+          type: string
+        priority:
+          type: integer
+          minimum: 1
+    ScenarioPackageCreateRequest:
+      type: object
+      required: [gameSlug, name, steps]
+      properties:
+        gameSlug:
+          type: string
+        name:
+          type: string
+        steps:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/ScenarioStep'
+        transitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScenarioTransition'
+    ScenarioPackageVersion:
+      allOf:
+        - $ref: '#/components/schemas/ScenarioPackageCreateRequest'
         - type: object
           properties:
             id:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -111,6 +111,39 @@ func ruleSetRequestToCreateRequest(req ruleSetCreateRequest, actorID string) pro
 	}
 }
 
+func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, actorID string) prompts.ScenarioPackageCreateRequest {
+	steps := make([]prompts.ScenarioStep, 0, len(req.Steps))
+	for _, step := range req.Steps {
+		steps = append(steps, prompts.ScenarioStep{
+			ID:                 step.ID,
+			Name:               step.Name,
+			GameSlug:           step.GameSlug,
+			Folder:             step.Folder,
+			EntryCondition:     step.EntryCondition,
+			PromptTemplate:     step.PromptTemplate,
+			ResponseSchemaJSON: step.ResponseSchemaJSON,
+			Initial:            step.Initial,
+			Order:              step.Order,
+		})
+	}
+	transitions := make([]prompts.ScenarioTransition, 0, len(req.Transitions))
+	for _, tr := range req.Transitions {
+		transitions = append(transitions, prompts.ScenarioTransition{
+			FromStepID: tr.FromStepID,
+			ToStepID:   tr.ToStepID,
+			Condition:  tr.Condition,
+			Priority:   tr.Priority,
+		})
+	}
+	return prompts.ScenarioPackageCreateRequest{
+		Name:        req.Name,
+		GameSlug:    req.GameSlug,
+		Steps:       steps,
+		Transitions: transitions,
+		ActorID:     actorID,
+	}
+}
+
 type configLimits struct {
 	VotePerMin int `json:"votePerMin"`
 }
@@ -213,6 +246,32 @@ type ruleSetCreateRequest struct {
 	Description       string                 `json:"description"`
 	RuleItems         []ruleItemRequest      `json:"ruleItems"`
 	FinalizationRules []ruleConditionRequest `json:"finalizationRules"`
+}
+
+type scenarioStepRequest struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	GameSlug           string `json:"gameSlug"`
+	Folder             string `json:"folder"`
+	EntryCondition     string `json:"entryCondition"`
+	PromptTemplate     string `json:"promptTemplate"`
+	ResponseSchemaJSON string `json:"responseSchemaJson"`
+	Initial            bool   `json:"initial"`
+	Order              int    `json:"order"`
+}
+
+type scenarioTransitionRequest struct {
+	FromStepID string `json:"fromStepId"`
+	ToStepID   string `json:"toStepId"`
+	Condition  string `json:"condition"`
+	Priority   int    `json:"priority"`
+}
+
+type scenarioPackageCreateRequest struct {
+	Name        string                      `json:"name"`
+	GameSlug    string                      `json:"gameSlug"`
+	Steps       []scenarioStepRequest       `json:"steps"`
+	Transitions []scenarioTransitionRequest `json:"transitions"`
 }
 
 type meResponse struct {
@@ -971,6 +1030,124 @@ func NewHandler(
 					if err := promptsService.DeleteRuleSet(r.Context(), path); err != nil {
 						status := http.StatusBadRequest
 						if errors.Is(err, prompts.ErrRuleSetNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/llm/scenario-packages", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, promptsService.ListScenarioPackages(r.Context()))
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req scenarioPackageCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					created, err := promptsService.CreateScenarioPackage(r.Context(), scenarioPackageRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusCreated, created)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/llm/scenario-packages/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/admin/llm/scenario-packages/"), "/")
+				if path == "" {
+					writeError(w, http.StatusBadRequest, "scenario package id is required")
+					return
+				}
+				if strings.HasSuffix(path, "/activate") {
+					id := strings.Trim(strings.TrimSuffix(path, "/activate"), "/")
+					if r.Method != http.MethodPost {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					item, err := promptsService.ActivateScenarioPackage(r.Context(), id, claims.Subject)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrScenarioPackageNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					item, err := promptsService.GetScenarioPackage(r.Context(), path)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrScenarioPackageNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req scenarioPackageCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					item, err := promptsService.UpdateScenarioPackage(r.Context(), path, scenarioPackageRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrScenarioPackageNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodDelete:
+					if err := promptsService.DeleteScenarioPackage(r.Context(), path); err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrScenarioPackageNotFound) {
 							status = http.StatusNotFound
 						}
 						writeError(w, status, err.Error())

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -159,3 +159,132 @@ func TestAdminLLMStateSchemaRoutes(t *testing.T) {
 		t.Fatalf("rule set delete status = %d body=%s", ruleDeleteRes.Code, ruleDeleteRes.Body.String())
 	}
 }
+
+func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
+	promptsService := prompts.NewService()
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamers.NewService(),
+		nil,
+		promptsService,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+	adminToken := buildToken(t, "admin-1")
+
+	createBody, _ := json.Marshal(map[string]any{
+		"gameSlug": "global",
+		"name":     "default graph",
+		"steps": []map[string]any{
+			{
+				"id":                 "root_detect",
+				"name":               "Root detect",
+				"gameSlug":           "global",
+				"promptTemplate":     "detect",
+				"responseSchemaJson": "{}",
+				"initial":            true,
+				"order":              1,
+			},
+			{
+				"id":                 "cs2_mode",
+				"name":               "CS2 mode",
+				"gameSlug":           "cs2",
+				"folder":             "cs2",
+				"promptTemplate":     "mode",
+				"responseSchemaJson": "{}",
+				"order":              2,
+			},
+		},
+		"transitions": []map[string]any{
+			{"fromStepId": "root_detect", "toStepId": "cs2_mode", "condition": "game == 'cs2'", "priority": 1},
+		},
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/scenario-packages", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer "+adminToken)
+	createRes := httptest.NewRecorder()
+	handler.ServeHTTP(createRes, createReq)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("scenario package create status = %d body=%s", createRes.Code, createRes.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(createRes.Body.Bytes(), &created); err != nil {
+		t.Fatalf("scenario package create decode error = %v", err)
+	}
+	packageID, _ := created["id"].(string)
+	if packageID == "" {
+		t.Fatalf("expected created scenario package id, got %#v", created)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/scenario-packages", nil)
+	listReq.Header.Set("Authorization", "Bearer "+adminToken)
+	listRes := httptest.NewRecorder()
+	handler.ServeHTTP(listRes, listReq)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("scenario package list status = %d body=%s", listRes.Code, listRes.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/scenario-packages/"+packageID, nil)
+	getReq.Header.Set("Authorization", "Bearer "+adminToken)
+	getRes := httptest.NewRecorder()
+	handler.ServeHTTP(getRes, getReq)
+	if getRes.Code != http.StatusOK {
+		t.Fatalf("scenario package get status = %d body=%s", getRes.Code, getRes.Body.String())
+	}
+
+	updateBody, _ := json.Marshal(map[string]any{
+		"gameSlug": "global",
+		"name":     "default graph v2",
+		"steps": []map[string]any{
+			{
+				"id":                 "root_detect",
+				"name":               "Root detect",
+				"gameSlug":           "global",
+				"promptTemplate":     "detect-v2",
+				"responseSchemaJson": "{}",
+				"initial":            true,
+				"order":              1,
+			},
+			{
+				"id":                 "cs2_mode",
+				"name":               "CS2 mode",
+				"gameSlug":           "cs2",
+				"folder":             "cs2",
+				"promptTemplate":     "mode-v2",
+				"responseSchemaJson": "{}",
+				"order":              2,
+			},
+		},
+		"transitions": []map[string]any{
+			{"fromStepId": "root_detect", "toStepId": "cs2_mode", "condition": "game == 'cs2'", "priority": 1},
+		},
+	})
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/admin/llm/scenario-packages/"+packageID, bytes.NewReader(updateBody))
+	updateReq.Header.Set("Authorization", "Bearer "+adminToken)
+	updateRes := httptest.NewRecorder()
+	handler.ServeHTTP(updateRes, updateReq)
+	if updateRes.Code != http.StatusOK {
+		t.Fatalf("scenario package update status = %d body=%s", updateRes.Code, updateRes.Body.String())
+	}
+
+	activateReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/scenario-packages/"+packageID+"/activate", nil)
+	activateReq.Header.Set("Authorization", "Bearer "+adminToken)
+	activateRes := httptest.NewRecorder()
+	handler.ServeHTTP(activateRes, activateReq)
+	if activateRes.Code != http.StatusOK {
+		t.Fatalf("scenario package activate status = %d body=%s", activateRes.Code, activateRes.Body.String())
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/admin/llm/scenario-packages/"+packageID, nil)
+	deleteReq.Header.Set("Authorization", "Bearer "+adminToken)
+	deleteRes := httptest.NewRecorder()
+	handler.ServeHTTP(deleteRes, deleteReq)
+	if deleteRes.Code != http.StatusNoContent {
+		t.Fatalf("scenario package delete status = %d body=%s", deleteRes.Code, deleteRes.Body.String())
+	}
+}

--- a/internal/prompts/postgres_service.go
+++ b/internal/prompts/postgres_service.go
@@ -780,13 +780,8 @@ func (s *Service) listScenarioPackagesDB(ctx context.Context) ([]ScenarioPackage
 }
 
 func (s *Service) createScenarioPackageDB(ctx context.Context, req ScenarioPackageCreateRequest) (ScenarioPackage, error) {
-	if len(req.Steps) == 0 {
-		return ScenarioPackage{}, ErrInvalidScenarioPackage
-	}
-	for _, step := range req.Steps {
-		if strings.TrimSpace(step.ID) == "" {
-			return ScenarioPackage{}, ErrInvalidScenarioStepID
-		}
+	if err := ValidateScenarioPackageCreateRequest(req); err != nil {
+		return ScenarioPackage{}, err
 	}
 	if err := s.ensureSchema(ctx); err != nil {
 		return ScenarioPackage{}, err
@@ -860,6 +855,137 @@ func (s *Service) getActiveScenarioPackageDB(ctx context.Context, gameSlug strin
 		if err == sql.ErrNoRows {
 			return ScenarioPackage{}, ErrScenarioPackageNotFound
 		}
+		return ScenarioPackage{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) getScenarioPackageDB(ctx context.Context, id string) (ScenarioPackage, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return ScenarioPackage{}, err
+	}
+	item, err := scanScenarioPackage(s.db.QueryRowContext(
+		ctx,
+		`SELECT id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages WHERE id = $1`,
+		strings.TrimSpace(id),
+	))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return ScenarioPackage{}, ErrScenarioPackageNotFound
+		}
+		return ScenarioPackage{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) updateScenarioPackageDB(ctx context.Context, id string, req ScenarioPackageCreateRequest) (ScenarioPackage, error) {
+	if err := ValidateScenarioPackageCreateRequest(req); err != nil {
+		return ScenarioPackage{}, err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return ScenarioPackage{}, err
+	}
+	gameSlug := strings.TrimSpace(req.GameSlug)
+	if gameSlug == "" {
+		gameSlug = "global"
+	}
+	stepsJSON, err := marshalJSON(req.Steps)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	transitionsJSON, err := marshalJSON(req.Transitions)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	item, err := scanScenarioPackage(s.db.QueryRowContext(
+		ctx,
+		`UPDATE llm_scenario_packages SET game_slug = $2, name = $3, steps_json = $4, transitions_json = $5 WHERE id = $1 RETURNING id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at`,
+		strings.TrimSpace(id),
+		gameSlug,
+		strings.TrimSpace(req.Name),
+		stepsJSON,
+		transitionsJSON,
+	))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return ScenarioPackage{}, ErrScenarioPackageNotFound
+		}
+		return ScenarioPackage{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) deleteScenarioPackageDB(ctx context.Context, id string) error {
+	if err := s.ensureSchema(ctx); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var gameSlug string
+	var wasActive bool
+	if err := tx.QueryRowContext(
+		ctx,
+		`DELETE FROM llm_scenario_packages WHERE id = $1 RETURNING game_slug, is_active`,
+		strings.TrimSpace(id),
+	).Scan(&gameSlug, &wasActive); err != nil {
+		if err == sql.ErrNoRows {
+			return ErrScenarioPackageNotFound
+		}
+		return err
+	}
+
+	if wasActive {
+		if _, err := tx.ExecContext(
+			ctx,
+			`UPDATE llm_scenario_packages SET is_active = TRUE WHERE id = (
+				SELECT id FROM llm_scenario_packages WHERE game_slug = $1 ORDER BY version DESC, created_at DESC LIMIT 1
+			)`,
+			gameSlug,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *Service) activateScenarioPackageDB(ctx context.Context, id, actorID string) (ScenarioPackage, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return ScenarioPackage{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	defer tx.Rollback()
+
+	var gameSlug string
+	if err := tx.QueryRowContext(ctx, `SELECT game_slug FROM llm_scenario_packages WHERE id = $1`, strings.TrimSpace(id)).Scan(&gameSlug); err != nil {
+		if err == sql.ErrNoRows {
+			return ScenarioPackage{}, ErrScenarioPackageNotFound
+		}
+		return ScenarioPackage{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE llm_scenario_packages SET is_active = FALSE WHERE game_slug = $1`, gameSlug); err != nil {
+		return ScenarioPackage{}, err
+	}
+	item, err := scanScenarioPackage(tx.QueryRowContext(
+		ctx,
+		`UPDATE llm_scenario_packages SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at`,
+		strings.TrimSpace(id),
+		strings.TrimSpace(actorID),
+		time.Now().UTC(),
+	))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return ScenarioPackage{}, ErrScenarioPackageNotFound
+		}
+		return ScenarioPackage{}, err
+	}
+	if err := tx.Commit(); err != nil {
 		return ScenarioPackage{}, err
 	}
 	return item, nil

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -16,6 +16,9 @@ var (
 	ErrScenarioStepNotFound    = errors.New("scenario step not found")
 	ErrInvalidScenarioPackage  = errors.New("scenario package must contain at least one step")
 	ErrInvalidScenarioStepID   = errors.New("scenario step id must not be empty")
+	ErrInvalidScenarioName     = errors.New("scenario package name must not be empty")
+	ErrInvalidScenarioFromStep = errors.New("scenario transition fromStepId must not be empty")
+	ErrInvalidScenarioToStep   = errors.New("scenario transition toStepId must not be empty")
 )
 
 type ScenarioStep struct {
@@ -60,6 +63,40 @@ type ScenarioPackageCreateRequest struct {
 	ActorID     string
 }
 
+func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) error {
+	if strings.TrimSpace(req.Name) == "" {
+		return ErrInvalidScenarioName
+	}
+	if len(req.Steps) == 0 {
+		return ErrInvalidScenarioPackage
+	}
+	seenSteps := make(map[string]struct{}, len(req.Steps))
+	for _, step := range req.Steps {
+		id := strings.TrimSpace(step.ID)
+		if id == "" {
+			return ErrInvalidScenarioStepID
+		}
+		seenSteps[id] = struct{}{}
+	}
+	for _, tr := range req.Transitions {
+		from := strings.TrimSpace(tr.FromStepID)
+		if from == "" {
+			return ErrInvalidScenarioFromStep
+		}
+		to := strings.TrimSpace(tr.ToStepID)
+		if to == "" {
+			return ErrInvalidScenarioToStep
+		}
+		if _, ok := seenSteps[from]; !ok {
+			return fmt.Errorf("%w: %s", ErrInvalidScenarioFromStep, from)
+		}
+		if _, ok := seenSteps[to]; !ok {
+			return fmt.Errorf("%w: %s", ErrInvalidScenarioToStep, to)
+		}
+	}
+	return nil
+}
+
 func (s *Service) ListScenarioPackages(ctx context.Context) []ScenarioPackage {
 	if s.db != nil {
 		items, err := s.listScenarioPackagesDB(ctx)
@@ -87,13 +124,8 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 	if s.db != nil {
 		return s.createScenarioPackageDB(ctx, req)
 	}
-	if len(req.Steps) == 0 {
-		return ScenarioPackage{}, ErrInvalidScenarioPackage
-	}
-	for _, step := range req.Steps {
-		if strings.TrimSpace(step.ID) == "" {
-			return ScenarioPackage{}, ErrInvalidScenarioStepID
-		}
+	if err := ValidateScenarioPackageCreateRequest(req); err != nil {
+		return ScenarioPackage{}, err
 	}
 	gameSlug := strings.TrimSpace(req.GameSlug)
 	if gameSlug == "" {
@@ -136,6 +168,126 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 	}
 	s.scenarioPackages[gameSlug] = append(s.scenarioPackages[gameSlug], item)
 	return item, nil
+}
+
+func (s *Service) GetScenarioPackage(ctx context.Context, id string) (ScenarioPackage, error) {
+	if s.db != nil {
+		return s.getScenarioPackageDB(ctx, id)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	lookup := strings.TrimSpace(id)
+	for _, versions := range s.scenarioPackages {
+		for _, item := range versions {
+			if item.ID == lookup {
+				return item, nil
+			}
+		}
+	}
+	return ScenarioPackage{}, ErrScenarioPackageNotFound
+}
+
+func (s *Service) UpdateScenarioPackage(ctx context.Context, id string, req ScenarioPackageCreateRequest) (ScenarioPackage, error) {
+	if s.db != nil {
+		return s.updateScenarioPackageDB(ctx, id, req)
+	}
+	if err := ValidateScenarioPackageCreateRequest(req); err != nil {
+		return ScenarioPackage{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lookup := strings.TrimSpace(id)
+	targetGameSlug := strings.TrimSpace(req.GameSlug)
+	if targetGameSlug == "" {
+		targetGameSlug = "global"
+	}
+	for gameSlug, versions := range s.scenarioPackages {
+		for i, item := range versions {
+			if item.ID != lookup {
+				continue
+			}
+			updated := item
+			updated.Name = strings.TrimSpace(req.Name)
+			updated.GameSlug = targetGameSlug
+			updated.Steps = append([]ScenarioStep(nil), req.Steps...)
+			updated.Transitions = append([]ScenarioTransition(nil), req.Transitions...)
+			now := time.Now().UTC()
+			for idx := range updated.Steps {
+				if updated.Steps[idx].CreatedAt.IsZero() {
+					updated.Steps[idx].CreatedAt = now
+				}
+				if updated.Steps[idx].Order <= 0 {
+					updated.Steps[idx].Order = idx + 1
+				}
+				if strings.TrimSpace(updated.Steps[idx].GameSlug) == "" {
+					updated.Steps[idx].GameSlug = targetGameSlug
+				}
+			}
+			if updated.GameSlug != gameSlug {
+				s.scenarioPackages[gameSlug] = append(versions[:i], versions[i+1:]...)
+				s.scenarioPackages[updated.GameSlug] = append(s.scenarioPackages[updated.GameSlug], updated)
+			} else {
+				versions[i] = updated
+				s.scenarioPackages[gameSlug] = versions
+			}
+			return updated, nil
+		}
+	}
+	return ScenarioPackage{}, ErrScenarioPackageNotFound
+}
+
+func (s *Service) DeleteScenarioPackage(ctx context.Context, id string) error {
+	if s.db != nil {
+		return s.deleteScenarioPackageDB(ctx, id)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lookup := strings.TrimSpace(id)
+	for gameSlug, versions := range s.scenarioPackages {
+		for i, item := range versions {
+			if item.ID != lookup {
+				continue
+			}
+			s.scenarioPackages[gameSlug] = append(versions[:i], versions[i+1:]...)
+			if item.IsActive && len(s.scenarioPackages[gameSlug]) > 0 {
+				s.scenarioPackages[gameSlug][0].IsActive = true
+			}
+			return nil
+		}
+	}
+	return ErrScenarioPackageNotFound
+}
+
+func (s *Service) ActivateScenarioPackage(ctx context.Context, id, actorID string) (ScenarioPackage, error) {
+	if s.db != nil {
+		return s.activateScenarioPackageDB(ctx, id, actorID)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lookup := strings.TrimSpace(id)
+	for gameSlug, versions := range s.scenarioPackages {
+		active := -1
+		for i := range versions {
+			if versions[i].ID == lookup {
+				active = i
+				break
+			}
+		}
+		if active == -1 {
+			continue
+		}
+		now := time.Now().UTC()
+		for i := range versions {
+			versions[i].IsActive = i == active
+			if i == active {
+				versions[i].ActivatedAt = now
+				versions[i].ActivatedBy = strings.TrimSpace(actorID)
+			}
+		}
+		s.scenarioPackages[gameSlug] = versions
+		return versions[active], nil
+	}
+	return ScenarioPackage{}, ErrScenarioPackageNotFound
 }
 
 func (s *Service) GetActiveScenarioPackage(ctx context.Context, gameSlug string) (ScenarioPackage, error) {


### PR DESCRIPTION
### Motivation
- Add first-class scenario graph packages (`steps + transitions`) to support multi-step LLM flows with per-game versioning and activation.
- Provide admin CRUD + activation endpoints and persist configuration when PostgreSQL is enabled so scenario packages survive restarts.
- Expose scenario package contracts in the OpenAPI spec and document the new admin endpoints for local setup and observability.

### Description
- Added OpenAPI paths and component schemas for `ScenarioStep`, `ScenarioTransition`, `ScenarioPackageCreateRequest`, and `ScenarioPackageVersion` and wired `/api/admin/llm/scenario-packages` endpoints (list, create, get, update, delete, activate).
- Updated `docs/local_setup.md` to mention the new admin endpoints and persistence behavior for scenario packages.
- Implemented scenario package types and logic in `internal/prompts/scenario_flow.go`, including `ScenarioPackage` model, validation (`ValidateScenarioPackageCreateRequest`), and in-memory CRUD + activation methods (`CreateScenarioPackage`, `ListScenarioPackages`, `GetScenarioPackage`, `UpdateScenarioPackage`, `DeleteScenarioPackage`, `ActivateScenarioPackage`).
- Added PostgreSQL-backed implementations in `internal/prompts/postgres_service.go` for listing, creating, getting, updating, deleting, and activating scenario packages, with transactional semantics and promotion of previous version when deleting an active package.
- Wired HTTP handlers in `internal/app/router.go` to parse requests, enforce admin auth, convert request DTOs (`scenarioPackageRequestToCreateRequest`) and call the prompts service, returning appropriate status codes and error handling.
- Added integration-style unit tests in `internal/app/router_admin_llm_test.go` (`TestAdminLLMScenarioPackageRoutes`) exercising create/list/get/update/activate/delete flows.

### Testing
- Ran `go test ./...` and unit tests completed successfully, including the new `TestAdminLLMScenarioPackageRoutes` which passed.
- Existing LLM admin tests (rule sets/state schemas) also passed during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b61ed1b4832ca0252566deea4973)