### PR TITLE
Add Visual Graph API for scenario package UI rendering

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -201,6 +201,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
   - Service derives a normalized initial tracker state from configured fields (no raw schema JSON blobs in the API contract).
 - `GET /api/admin/llm/rule-sets` / `POST /api/admin/llm/rule-sets` – admin CRUD for versioned tracker update/finalization rule sets.
 - `GET /api/admin/llm/scenario-packages` / `POST /api/admin/llm/scenario-packages` – admin CRUD for scenario graph packages (`steps + transitions`) with per-game versioning and activation.
+- `GET /api/admin/llm/scenario-packages/{id}/graph` – returns a UI-ready visual graph payload (`nodes + edges + groups`) for scenario-graph editors/renderers.
 - `GET /api/admin/prompts` / `POST /api/admin/prompts` – admin CRUD for match update/finalization prompt templates.
 - When PostgreSQL is enabled, admin-managed tracker configuration (`/api/admin/llm/state-schemas`, `/api/admin/llm/rule-sets`, `/api/admin/llm/scenario-packages`, `/api/admin/prompts`) is persisted in dedicated versioned tables and survives service restarts.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -765,6 +765,26 @@ paths:
                 $ref: '#/components/schemas/ScenarioPackageVersion'
         default:
           $ref: '#/components/responses/Error'
+  /api/admin/llm/scenario-packages/{scenarioPackageId}/graph:
+    get:
+      summary: Get LLM scenario package visual graph (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: scenarioPackageId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: LLM scenario package visual graph
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioPackageGraph'
+        default:
+          $ref: '#/components/responses/Error'
   /api/events/live:
     get:
       summary: Get live events for a streamer
@@ -1761,6 +1781,81 @@ components:
               type: string
               format: date-time
               nullable: true
+    ScenarioGraphNode:
+      type: object
+      required: [id, name, gameSlug, folder, initial, order, level]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        gameSlug:
+          type: string
+        folder:
+          type: string
+        initial:
+          type: boolean
+        order:
+          type: integer
+          minimum: 1
+        level:
+          type: integer
+          minimum: 1
+    ScenarioGraphEdge:
+      type: object
+      required: [id, fromStepId, toStepId, condition, priority]
+      properties:
+        id:
+          type: string
+        fromStepId:
+          type: string
+        toStepId:
+          type: string
+        condition:
+          type: string
+        priority:
+          type: integer
+          minimum: 1
+    ScenarioGraphGroup:
+      type: object
+      required: [id, label, gameSlug, folder, nodeIds]
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        gameSlug:
+          type: string
+        folder:
+          type: string
+        nodeIds:
+          type: array
+          items:
+            type: string
+    ScenarioPackageGraph:
+      type: object
+      required: [packageId, packageName, gameSlug, version, nodes, edges, groups]
+      properties:
+        packageId:
+          type: string
+        packageName:
+          type: string
+        gameSlug:
+          type: string
+        version:
+          type: integer
+        nodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScenarioGraphNode'
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScenarioGraphEdge'
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScenarioGraphGroup'
     LiveEvent:
       type: object
       properties:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -1110,6 +1110,24 @@ func NewHandler(
 					writeJSON(w, http.StatusOK, item)
 					return
 				}
+				if strings.HasSuffix(path, "/graph") {
+					id := strings.Trim(strings.TrimSuffix(path, "/graph"), "/")
+					if r.Method != http.MethodGet {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					item, err := promptsService.GetScenarioPackage(r.Context(), id)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrScenarioPackageNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item.BuildVisualGraph())
+					return
+				}
 				switch r.Method {
 				case http.MethodGet:
 					item, err := promptsService.GetScenarioPackage(r.Context(), path)

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -237,6 +237,24 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 		t.Fatalf("scenario package get status = %d body=%s", getRes.Code, getRes.Body.String())
 	}
 
+	graphReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/scenario-packages/"+packageID+"/graph", nil)
+	graphReq.Header.Set("Authorization", "Bearer "+adminToken)
+	graphRes := httptest.NewRecorder()
+	handler.ServeHTTP(graphRes, graphReq)
+	if graphRes.Code != http.StatusOK {
+		t.Fatalf("scenario package graph status = %d body=%s", graphRes.Code, graphRes.Body.String())
+	}
+	var graph map[string]any
+	if err := json.Unmarshal(graphRes.Body.Bytes(), &graph); err != nil {
+		t.Fatalf("scenario package graph decode error = %v", err)
+	}
+	if graph["packageId"] != packageID {
+		t.Fatalf("expected packageId %q, got %#v", packageID, graph["packageId"])
+	}
+	if _, ok := graph["nodes"].([]any); !ok {
+		t.Fatalf("expected nodes array in graph response, got %#v", graph["nodes"])
+	}
+
 	updateBody, _ := json.Marshal(map[string]any{
 		"gameSlug": "global",
 		"name":     "default graph v2",

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -55,6 +55,42 @@ type ScenarioPackage struct {
 	ActivatedAt time.Time            `json:"activatedAt,omitempty"`
 }
 
+type ScenarioGraphNode struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	GameSlug string `json:"gameSlug"`
+	Folder   string `json:"folder"`
+	Initial  bool   `json:"initial"`
+	Order    int    `json:"order"`
+	Level    int    `json:"level"`
+}
+
+type ScenarioGraphEdge struct {
+	ID         string `json:"id"`
+	FromStepID string `json:"fromStepId"`
+	ToStepID   string `json:"toStepId"`
+	Condition  string `json:"condition"`
+	Priority   int    `json:"priority"`
+}
+
+type ScenarioGraphGroup struct {
+	ID       string   `json:"id"`
+	Label    string   `json:"label"`
+	GameSlug string   `json:"gameSlug"`
+	Folder   string   `json:"folder"`
+	NodeIDs  []string `json:"nodeIds"`
+}
+
+type ScenarioPackageGraph struct {
+	PackageID   string               `json:"packageId"`
+	PackageName string               `json:"packageName"`
+	GameSlug    string               `json:"gameSlug"`
+	Version     int                  `json:"version"`
+	Nodes       []ScenarioGraphNode  `json:"nodes"`
+	Edges       []ScenarioGraphEdge  `json:"edges"`
+	Groups      []ScenarioGraphGroup `json:"groups"`
+}
+
 type ScenarioPackageCreateRequest struct {
 	Name        string
 	GameSlug    string
@@ -363,6 +399,110 @@ func (p ScenarioPackage) ResolveStep(currentStepID, stateJSON string) (ScenarioS
 		return next, next.ID != current, nil
 	}
 	return active, false, nil
+}
+
+func (p ScenarioPackage) BuildVisualGraph() ScenarioPackageGraph {
+	nodes := make([]ScenarioGraphNode, 0, len(p.Steps))
+	for _, step := range p.Steps {
+		nodes = append(nodes, ScenarioGraphNode{
+			ID:       step.ID,
+			Name:     step.Name,
+			GameSlug: step.GameSlug,
+			Folder:   step.Folder,
+			Initial:  step.Initial,
+			Order:    step.Order,
+			Level:    scenarioStepLevel(step),
+		})
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].Level == nodes[j].Level {
+			if nodes[i].Order == nodes[j].Order {
+				return nodes[i].ID < nodes[j].ID
+			}
+			return nodes[i].Order < nodes[j].Order
+		}
+		return nodes[i].Level < nodes[j].Level
+	})
+
+	edges := make([]ScenarioGraphEdge, 0, len(p.Transitions))
+	for i, tr := range p.Transitions {
+		edges = append(edges, ScenarioGraphEdge{
+			ID:         "edge-" + strconv.Itoa(i+1),
+			FromStepID: tr.FromStepID,
+			ToStepID:   tr.ToStepID,
+			Condition:  tr.Condition,
+			Priority:   tr.Priority,
+		})
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].FromStepID == edges[j].FromStepID {
+			if edges[i].Priority == edges[j].Priority {
+				return edges[i].ToStepID < edges[j].ToStepID
+			}
+			return edges[i].Priority < edges[j].Priority
+		}
+		return edges[i].FromStepID < edges[j].FromStepID
+	})
+
+	groupsByKey := make(map[string]*ScenarioGraphGroup)
+	for _, node := range nodes {
+		groupFolder := strings.TrimSpace(node.Folder)
+		if groupFolder == "" {
+			groupFolder = "root"
+		}
+		groupGame := strings.TrimSpace(node.GameSlug)
+		if groupGame == "" {
+			groupGame = strings.TrimSpace(p.GameSlug)
+		}
+		if groupGame == "" {
+			groupGame = "global"
+		}
+		key := groupGame + "/" + groupFolder
+		group, ok := groupsByKey[key]
+		if !ok {
+			group = &ScenarioGraphGroup{
+				ID:       key,
+				Label:    key,
+				GameSlug: groupGame,
+				Folder:   groupFolder,
+				NodeIDs:  []string{},
+			}
+			groupsByKey[key] = group
+		}
+		group.NodeIDs = append(group.NodeIDs, node.ID)
+	}
+	groups := make([]ScenarioGraphGroup, 0, len(groupsByKey))
+	for _, group := range groupsByKey {
+		sort.Strings(group.NodeIDs)
+		groups = append(groups, *group)
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].ID < groups[j].ID })
+
+	return ScenarioPackageGraph{
+		PackageID:   p.ID,
+		PackageName: p.Name,
+		GameSlug:    p.GameSlug,
+		Version:     p.Version,
+		Nodes:       nodes,
+		Edges:       edges,
+		Groups:      groups,
+	}
+}
+
+func scenarioStepLevel(step ScenarioStep) int {
+	folder := strings.Trim(strings.TrimSpace(step.Folder), "/")
+	if step.Initial {
+		return 1
+	}
+	if folder == "" {
+		return 1
+	}
+	parts := strings.Split(folder, "/")
+	level := 1 + len(parts)
+	if level < 1 {
+		return 1
+	}
+	return level
 }
 
 func evaluateCondition(condition string, payload map[string]any) (bool, error) {

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -88,3 +88,43 @@ func TestEvaluateCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestScenarioPackageBuildVisualGraph(t *testing.T) {
+	t.Parallel()
+
+	pkg := ScenarioPackage{
+		ID:       "pkg-1",
+		Name:     "default graph",
+		GameSlug: "global",
+		Version:  3,
+		Steps: []ScenarioStep{
+			{ID: "root_detect", Name: "Root", GameSlug: "global", Initial: true, Order: 1},
+			{ID: "cs2_mode", Name: "Mode", GameSlug: "cs2", Folder: "cs2", Order: 2},
+			{ID: "cs2_faceit", Name: "Faceit", GameSlug: "cs2", Folder: "cs2/faceit", Order: 3},
+		},
+		Transitions: []ScenarioTransition{
+			{FromStepID: "root_detect", ToStepID: "cs2_mode", Condition: "game == cs2", Priority: 1},
+			{FromStepID: "cs2_mode", ToStepID: "cs2_faceit", Condition: "mode == faceit", Priority: 1},
+		},
+	}
+
+	graph := pkg.BuildVisualGraph()
+	if graph.PackageID != "pkg-1" || graph.PackageName != "default graph" || graph.Version != 3 {
+		t.Fatalf("unexpected graph metadata: %#v", graph)
+	}
+	if len(graph.Nodes) != 3 {
+		t.Fatalf("expected 3 nodes, got %d", len(graph.Nodes))
+	}
+	if graph.Nodes[0].ID != "root_detect" || graph.Nodes[0].Level != 1 {
+		t.Fatalf("unexpected root node: %#v", graph.Nodes[0])
+	}
+	if graph.Nodes[2].ID != "cs2_faceit" || graph.Nodes[2].Level != 3 {
+		t.Fatalf("unexpected nested node: %#v", graph.Nodes[2])
+	}
+	if len(graph.Edges) != 2 || graph.Edges[0].FromStepID != "cs2_mode" || graph.Edges[1].FromStepID != "root_detect" {
+		t.Fatalf("unexpected edges ordering/content: %#v", graph.Edges)
+	}
+	if len(graph.Groups) != 3 {
+		t.Fatalf("expected 3 groups, got %d (%#v)", len(graph.Groups), graph.Groups)
+	}
+}


### PR DESCRIPTION
### Motivation
- Expose a UI-ready visual graph representation of scenario packages to support the scenario-graph v2 admin/editor UX described in `docs/llm_stream_orchestration_plan.md` and advance milestone M2.1.  
- Checklist: [x] `GET /api/admin/llm/scenario-packages/{id}/graph` endpoint implemented, [x] server-side graph projection (`nodes`, `edges`, `groups`) implemented, [ ] DB persistence & versioning for visual editor, [ ] full admin graph-editing UI/CRUD and resilience features (retries/idempotency/dead-letter).  

### Description
- Added graph projection types and logic in the prompts domain: `ScenarioGraphNode`, `ScenarioGraphEdge`, `ScenarioGraphGroup`, `ScenarioPackageGraph`, and `BuildVisualGraph()` which derives deterministic `nodes`, `edges`, `groups` and a `level` for step depth based on `initial` and folder path. (files: `internal/prompts/scenario_flow.go`)  
- Exposed a new admin route `GET /api/admin/llm/scenario-packages/{scenarioPackageId}/graph` that returns the `ScenarioPackageGraph` payload and wired it into the admin router. (file: `internal/app/router.go`)  
- Added unit tests to cover graph construction and the admin route behavior, and updated API docs and local setup notes to document the new visual graph endpoint and schemas. (files: `internal/prompts/scenario_flow_test.go`, `internal/app/router_admin_llm_test.go`, `docs/openapi.yaml`, `docs/local_setup.md`)  

### Testing
- Ran `go test ./internal/prompts` and the prompts package tests succeeded.  
- Ran `go test ./internal/app` and the app router tests (including the new admin graph route test) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6bc364934832c9daf0df39d5a6405)