### PR TITLE
Add admin CRUD endpoints for prompts

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -420,6 +420,68 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PromptVersion'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/prompts/{promptId}:
+    get:
+      summary: Get prompt version (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: promptId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Prompt version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update prompt version (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: promptId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PromptCreateRequest'
+      responses:
+        '200':
+          description: Updated prompt version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Delete prompt version (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: promptId
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Prompt version deleted
+        default:
+          $ref: '#/components/responses/Error'
   /api/admin/llm/state-schemas:
     get:
       summary: List LLM state schemas (admin)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -1253,34 +1253,118 @@ func NewHandler(
 					return
 				}
 
-				if !strings.HasSuffix(r.URL.Path, "/activate") {
-					writeError(w, http.StatusBadRequest, "prompt action is required")
-					return
-				}
 				promptID := strings.TrimPrefix(r.URL.Path, "/api/admin/prompts/")
-				promptID = strings.TrimSuffix(promptID, "/activate")
 				promptID = strings.Trim(promptID, "/")
-				if promptID == "" || strings.Contains(promptID, "/") {
+				if promptID == "" {
 					writeError(w, http.StatusBadRequest, "prompt id is required")
 					return
 				}
-				if r.Method != http.MethodPost {
-					w.WriteHeader(http.StatusMethodNotAllowed)
-					return
-				}
 
-				updated, err := promptsService.Activate(r.Context(), promptID, claims.Subject)
-				if err != nil {
-					if errors.Is(err, prompts.ErrNotFound) {
-						writeError(w, http.StatusNotFound, err.Error())
+				if strings.HasSuffix(r.URL.Path, "/activate") {
+					promptID = strings.TrimSuffix(promptID, "activate")
+					promptID = strings.Trim(promptID, "/")
+					if promptID == "" || strings.Contains(promptID, "/") {
+						writeError(w, http.StatusBadRequest, "prompt id is required")
 						return
 					}
-					logger.Error("failed to activate prompt", zap.Error(err))
-					writeError(w, http.StatusInternalServerError, "failed to activate prompt")
+					if r.Method != http.MethodPost {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+
+					updated, err := promptsService.Activate(r.Context(), promptID, claims.Subject)
+					if err != nil {
+						if errors.Is(err, prompts.ErrNotFound) {
+							writeError(w, http.StatusNotFound, err.Error())
+							return
+						}
+						logger.Error("failed to activate prompt", zap.Error(err))
+						writeError(w, http.StatusInternalServerError, "failed to activate prompt")
+						return
+					}
+
+					writeJSON(w, http.StatusOK, updated)
 					return
 				}
 
-				writeJSON(w, http.StatusOK, updated)
+				if strings.Contains(promptID, "/") {
+					writeError(w, http.StatusBadRequest, "prompt id is required")
+					return
+				}
+
+				switch r.Method {
+				case http.MethodGet:
+					item, err := promptsService.Get(r.Context(), promptID)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req promptCreateRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					updated, err := promptsService.Update(r.Context(), promptID, prompts.CreateRequest{
+						Stage:         req.Stage,
+						Position:      req.Position,
+						Template:      req.Template,
+						Model:         req.Model,
+						Temperature:   req.Temperature,
+						MaxTokens:     req.MaxTokens,
+						TimeoutMS:     req.TimeoutMS,
+						RetryCount:    req.RetryCount,
+						BackoffMS:     req.BackoffMS,
+						CooldownMS:    req.CooldownMS,
+						MinConfidence: req.MinConfidence,
+						ActorID:       claims.Subject,
+					})
+					if err != nil {
+						status := http.StatusBadRequest
+						switch {
+						case errors.Is(err, prompts.ErrNotFound):
+							status = http.StatusNotFound
+						case errors.Is(err, prompts.ErrInvalidStage),
+							errors.Is(err, prompts.ErrInvalidTemplate),
+							errors.Is(err, prompts.ErrInvalidModel),
+							errors.Is(err, prompts.ErrInvalidTemperature),
+							errors.Is(err, prompts.ErrInvalidMaxTokens),
+							errors.Is(err, prompts.ErrInvalidTimeoutMS),
+							errors.Is(err, prompts.ErrInvalidRetryCount),
+							errors.Is(err, prompts.ErrInvalidBackoffMS),
+							errors.Is(err, prompts.ErrInvalidCooldownMS),
+							errors.Is(err, prompts.ErrInvalidMinConfidence):
+						default:
+							status = http.StatusInternalServerError
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, updated)
+				case http.MethodDelete:
+					if err := promptsService.Delete(r.Context(), promptID); err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
 			})))
 		}
 

--- a/internal/app/router_prompts_test.go
+++ b/internal/app/router_prompts_test.go
@@ -83,6 +83,105 @@ func TestAdminPromptsCreateListAndActivate(t *testing.T) {
 	}
 }
 
+func TestAdminPromptsCRUD(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		nil,
+		nil,
+		prompts.NewService(),
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+	token := buildToken(t, "admin-1")
+
+	createBody, _ := json.Marshal(map[string]any{
+		"stage":         "detector",
+		"position":      1,
+		"template":      "detect cs2 on stream",
+		"model":         "gemini-2.0-flash",
+		"temperature":   0.2,
+		"maxTokens":     512,
+		"timeoutMs":     2000,
+		"retryCount":    2,
+		"backoffMs":     300,
+		"cooldownMs":    30000,
+		"minConfidence": 0.7,
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/prompts", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createRes := httptest.NewRecorder()
+	handler.ServeHTTP(createRes, createReq)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", createRes.Code)
+	}
+	var created map[string]any
+	if err := json.Unmarshal(createRes.Body.Bytes(), &created); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+	id, _ := created["id"].(string)
+	if id == "" {
+		t.Fatal("expected id")
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/admin/prompts/"+id, nil)
+	getReq.Header.Set("Authorization", "Bearer "+token)
+	getRes := httptest.NewRecorder()
+	handler.ServeHTTP(getRes, getReq)
+	if getRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", getRes.Code)
+	}
+
+	updateBody, _ := json.Marshal(map[string]any{
+		"stage":         "detector",
+		"position":      2,
+		"template":      "updated detector prompt",
+		"model":         "gemini-2.0-flash",
+		"temperature":   0.4,
+		"maxTokens":     256,
+		"timeoutMs":     1500,
+		"retryCount":    1,
+		"backoffMs":     150,
+		"cooldownMs":    1000,
+		"minConfidence": 0.8,
+	})
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/admin/prompts/"+id, bytes.NewReader(updateBody))
+	updateReq.Header.Set("Authorization", "Bearer "+token)
+	updateRes := httptest.NewRecorder()
+	handler.ServeHTTP(updateRes, updateReq)
+	if updateRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", updateRes.Code, updateRes.Body.String())
+	}
+	var updated map[string]any
+	if err := json.Unmarshal(updateRes.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("failed to decode update response: %v", err)
+	}
+	if updated["template"] != "updated detector prompt" {
+		t.Fatalf("expected template to update, got %#v", updated["template"])
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/admin/prompts/"+id, nil)
+	deleteReq.Header.Set("Authorization", "Bearer "+token)
+	deleteRes := httptest.NewRecorder()
+	handler.ServeHTTP(deleteRes, deleteReq)
+	if deleteRes.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", deleteRes.Code)
+	}
+
+	getAfterDeleteReq := httptest.NewRequest(http.MethodGet, "/api/admin/prompts/"+id, nil)
+	getAfterDeleteReq.Header.Set("Authorization", "Bearer "+token)
+	getAfterDeleteRes := httptest.NewRecorder()
+	handler.ServeHTTP(getAfterDeleteRes, getAfterDeleteReq)
+	if getAfterDeleteRes.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 after delete, got %d", getAfterDeleteRes.Code)
+	}
+}
+
 func TestAdminPromptsForbiddenForNonAdmin(t *testing.T) {
 	handler := NewHandler(
 		zap.NewNop(),

--- a/internal/prompts/postgres_service.go
+++ b/internal/prompts/postgres_service.go
@@ -393,6 +393,90 @@ func (s *Service) activatePromptDB(ctx context.Context, id, actorID string) (Pro
 	return item, nil
 }
 
+func (s *Service) getPromptDB(ctx context.Context, id string) (PromptVersion, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return PromptVersion{}, err
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT id, stage, position, version, template, model, temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at FROM llm_prompt_versions WHERE id = $1`, strings.TrimSpace(id))
+	item, err := scanPrompt(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return PromptVersion{}, ErrNotFound
+		}
+		return PromptVersion{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) updatePromptDB(ctx context.Context, id string, req CreateRequest) (PromptVersion, error) {
+	if err := ValidateCreateRequest(req); err != nil {
+		return PromptVersion{}, err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return PromptVersion{}, err
+	}
+	position := req.Position
+	if position <= 0 {
+		current, err := s.getPromptDB(ctx, id)
+		if err != nil {
+			return PromptVersion{}, err
+		}
+		position = current.Position
+	}
+	row := s.db.QueryRowContext(ctx, `UPDATE llm_prompt_versions SET stage = $2, position = $3, template = $4, model = $5, temperature = $6, max_tokens = $7, timeout_ms = $8, retry_count = $9, backoff_ms = $10, cooldown_ms = $11, min_confidence = $12 WHERE id = $1 RETURNING id, stage, position, version, template, model, temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at`,
+		strings.TrimSpace(id), strings.TrimSpace(req.Stage), position, strings.TrimSpace(req.Template), strings.TrimSpace(req.Model), req.Temperature, req.MaxTokens, req.TimeoutMS, req.RetryCount, req.BackoffMS, req.CooldownMS, req.MinConfidence)
+	item, err := scanPrompt(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return PromptVersion{}, ErrNotFound
+		}
+		return PromptVersion{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) deletePromptDB(ctx context.Context, id string) error {
+	if err := s.ensureSchema(ctx); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var stage string
+	var wasActive bool
+	if err := tx.QueryRowContext(ctx, `SELECT stage, is_active FROM llm_prompt_versions WHERE id = $1`, strings.TrimSpace(id)).Scan(&stage, &wasActive); err != nil {
+		if err == sql.ErrNoRows {
+			return ErrNotFound
+		}
+		return err
+	}
+	res, err := tx.ExecContext(ctx, `DELETE FROM llm_prompt_versions WHERE id = $1`, strings.TrimSpace(id))
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+
+	if wasActive {
+		if _, err := tx.ExecContext(ctx, `UPDATE llm_prompt_versions SET is_active = FALSE WHERE stage = $1`, stage); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE llm_prompt_versions SET is_active = TRUE WHERE id = (SELECT id FROM llm_prompt_versions WHERE stage = $1 ORDER BY version DESC, created_at DESC LIMIT 1)`, stage); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
 func (s *Service) listStateSchemasDB(ctx context.Context) ([]StateSchemaVersion, error) {
 	if err := s.ensureSchema(ctx); err != nil {
 		return nil, err

--- a/internal/prompts/postgres_service_test.go
+++ b/internal/prompts/postgres_service_test.go
@@ -57,6 +57,78 @@ func TestPostgresServiceCreatePrompt(t *testing.T) {
 	}
 }
 
+func TestPostgresServicePromptCRUD(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	svc := NewPostgresService(db)
+	now := time.Date(2026, 3, 27, 10, 0, 0, 0, time.UTC)
+	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS initial_state_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS state_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`ALTER TABLE llm_state_schema_versions ADD COLUMN IF NOT EXISTS delta_schema_json JSONB NOT NULL DEFAULT '{}'::jsonb`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, stage, position, version, template, model, temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at FROM llm_prompt_versions WHERE id = $1`)).
+		WithArgs("prompt-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "stage", "position", "version", "template", "model", "temperature", "max_tokens", "timeout_ms", "retry_count", "backoff_ms", "cooldown_ms", "min_confidence", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
+			AddRow("prompt-1", "detector", 1, 1, "detect", "gpt", 0.2, 256, 1000, 1, 10, 10, 0.5, true, "admin-1", "admin-1", now, now))
+	item, err := svc.Get(context.Background(), "prompt-1")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if item.ID != "prompt-1" {
+		t.Fatalf("Get() = %#v", item)
+	}
+
+	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE llm_prompt_versions SET stage = $2, position = $3, template = $4, model = $5, temperature = $6, max_tokens = $7, timeout_ms = $8, retry_count = $9, backoff_ms = $10, cooldown_ms = $11, min_confidence = $12 WHERE id = $1 RETURNING id, stage, position, version, template, model, temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at`)).
+		WithArgs("prompt-1", "detector", 2, "updated", "gpt-2", 0.3, 128, 900, 0, 0, 0, 0.6).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "stage", "position", "version", "template", "model", "temperature", "max_tokens", "timeout_ms", "retry_count", "backoff_ms", "cooldown_ms", "min_confidence", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
+			AddRow("prompt-1", "detector", 2, 1, "updated", "gpt-2", 0.3, 128, 900, 0, 0, 0, 0.6, true, "admin-1", "admin-1", now, now))
+	updated, err := svc.Update(context.Background(), "prompt-1", CreateRequest{
+		Stage:         "detector",
+		Position:      2,
+		Template:      "updated",
+		Model:         "gpt-2",
+		Temperature:   0.3,
+		MaxTokens:     128,
+		TimeoutMS:     900,
+		RetryCount:    0,
+		BackoffMS:     0,
+		CooldownMS:    0,
+		MinConfidence: 0.6,
+	})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated.Template != "updated" {
+		t.Fatalf("Update() = %#v", updated)
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT stage, is_active FROM llm_prompt_versions WHERE id = $1`)).
+		WithArgs("prompt-1").
+		WillReturnRows(sqlmock.NewRows([]string{"stage", "is_active"}).AddRow("detector", true))
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM llm_prompt_versions WHERE id = $1`)).
+		WithArgs("prompt-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE llm_prompt_versions SET is_active = FALSE WHERE stage = $1`)).
+		WithArgs("detector").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE llm_prompt_versions SET is_active = TRUE WHERE id = (SELECT id FROM llm_prompt_versions WHERE stage = $1 ORDER BY version DESC, created_at DESC LIMIT 1)`)).
+		WithArgs("detector").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	if err := svc.Delete(context.Background(), "prompt-1"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
 func TestPostgresServiceListStateSchemas(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/prompts/service.go
+++ b/internal/prompts/service.go
@@ -159,6 +159,126 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (PromptVersion,
 	return item, nil
 }
 
+func (s *Service) Get(ctx context.Context, id string) (PromptVersion, error) {
+	if s.db != nil {
+		return s.getPromptDB(ctx, id)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	trimmedID := strings.TrimSpace(id)
+	for _, byStage := range s.versions {
+		for _, item := range byStage {
+			if item.ID == trimmedID {
+				return item, nil
+			}
+		}
+	}
+	return PromptVersion{}, ErrNotFound
+}
+
+func (s *Service) Update(ctx context.Context, id string, req CreateRequest) (PromptVersion, error) {
+	if s.db != nil {
+		return s.updatePromptDB(ctx, id, req)
+	}
+	if err := ValidateCreateRequest(req); err != nil {
+		return PromptVersion{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	trimmedID := strings.TrimSpace(id)
+	for stage, byStage := range s.versions {
+		for i := range byStage {
+			if byStage[i].ID != trimmedID {
+				continue
+			}
+			item := byStage[i]
+			item.Stage = strings.TrimSpace(req.Stage)
+			if req.Position > 0 {
+				item.Position = req.Position
+			}
+			item.Template = strings.TrimSpace(req.Template)
+			item.Model = strings.TrimSpace(req.Model)
+			item.Temperature = req.Temperature
+			item.MaxTokens = req.MaxTokens
+			item.TimeoutMS = req.TimeoutMS
+			item.RetryCount = req.RetryCount
+			item.BackoffMS = req.BackoffMS
+			item.CooldownMS = req.CooldownMS
+			item.MinConfidence = req.MinConfidence
+			byStage[i] = item
+			if item.Stage == stage {
+				s.versions[stage] = byStage
+				return item, nil
+			}
+
+			s.versions[stage] = append(byStage[:i], byStage[i+1:]...)
+			newStage := s.versions[item.Stage]
+			maxVersion := 0
+			for _, existing := range newStage {
+				if existing.Version > maxVersion {
+					maxVersion = existing.Version
+				}
+			}
+			item.Version = maxVersion + 1
+			item.IsActive = false
+			item.ActivatedBy = ""
+			item.ActivatedAt = time.Time{}
+			s.versions[item.Stage] = append(newStage, item)
+			sortPromptVersions(s.versions[item.Stage])
+			return item, nil
+		}
+	}
+	return PromptVersion{}, ErrNotFound
+}
+
+func (s *Service) Delete(ctx context.Context, id string) error {
+	if s.db != nil {
+		return s.deletePromptDB(ctx, id)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	trimmedID := strings.TrimSpace(id)
+	for stage, byStage := range s.versions {
+		removeIndex := -1
+		wasActive := false
+		for i := range byStage {
+			if byStage[i].ID == trimmedID {
+				removeIndex = i
+				wasActive = byStage[i].IsActive
+				break
+			}
+		}
+		if removeIndex == -1 {
+			continue
+		}
+
+		updated := append(byStage[:removeIndex], byStage[removeIndex+1:]...)
+		if len(updated) == 0 {
+			delete(s.versions, stage)
+			return nil
+		}
+		if wasActive {
+			bestIndex := 0
+			for i := 1; i < len(updated); i++ {
+				if updated[i].Version > updated[bestIndex].Version {
+					bestIndex = i
+				}
+			}
+			for i := range updated {
+				updated[i].IsActive = false
+			}
+			updated[bestIndex].IsActive = true
+		}
+		s.versions[stage] = updated
+		return nil
+	}
+	return ErrNotFound
+}
+
 func (s *Service) nextPositionLocked() int {
 	maxPosition := 0
 	for _, byStage := range s.versions {

--- a/internal/prompts/service_test.go
+++ b/internal/prompts/service_test.go
@@ -124,3 +124,56 @@ func TestCreateAutoActivatesFirstPromptPerStageOnly(t *testing.T) {
 		t.Fatalf("active id = %q, want %q", active.ID, first.ID)
 	}
 }
+
+func TestPromptCRUD(t *testing.T) {
+	svc := NewService()
+	created, err := svc.Create(context.Background(), CreateRequest{
+		Stage:         "detector",
+		Position:      1,
+		Template:      "first",
+		Model:         "m",
+		Temperature:   0.1,
+		MaxTokens:     1,
+		TimeoutMS:     1,
+		MinConfidence: 0.4,
+		ActorID:       "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	got, err := svc.Get(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.ID != created.ID {
+		t.Fatalf("Get().ID = %q, want %q", got.ID, created.ID)
+	}
+
+	updated, err := svc.Update(context.Background(), created.ID, CreateRequest{
+		Stage:         "detector",
+		Position:      2,
+		Template:      "updated",
+		Model:         "m2",
+		Temperature:   0.2,
+		MaxTokens:     2,
+		TimeoutMS:     2,
+		RetryCount:    1,
+		BackoffMS:     10,
+		CooldownMS:    5,
+		MinConfidence: 0.5,
+	})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated.Template != "updated" || updated.Position != 2 {
+		t.Fatalf("Update() = %#v", updated)
+	}
+
+	if err := svc.Delete(context.Background(), created.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, err := svc.Get(context.Background(), created.ID); err != ErrNotFound {
+		t.Fatalf("Get() after delete error = %v, want %v", err, ErrNotFound)
+	}
+}


### PR DESCRIPTION
### Motivation
- The prompts domain exposed only `List`, `Create` and `Activate`, so admins could not fetch, edit or delete individual prompt versions via the API.  
- Admin operational control over LLM prompt versions is required to manage runtime prompt configuration and align with the orchestration plan.  

### Description
- Added service-level CRUD for prompt versions: `Get`, `Update`, `Delete` in the in-memory `Service` and corresponding DB-backed implementations `getPromptDB`, `updatePromptDB`, `deletePromptDB` in `postgres_service.go`.  
- Extended admin HTTP API to support `/api/admin/prompts/{promptId}` with `GET`, `PUT`, `DELETE`, while preserving the existing `/api/admin/prompts/{promptId}/activate` action in the router.  
- Updated the OpenAPI spec `docs/openapi.yaml` to include `GET/PUT/DELETE` for `/api/admin/prompts/{promptId}` and added a default error response for the activate endpoint.  
- Added tests covering the new behavior: router-level CRUD flow (`internal/app/router_prompts_test.go`), in-memory prompt service CRUD (`internal/prompts/service_test.go`), and Postgres CRUD behavior using `sqlmock` (`internal/prompts/postgres_service_test.go`).  

Checklist (aligned to M2.1 + `docs/llm_stream_orchestration_plan.md`):
- [x] Add prompt service CRUD methods and Postgres DB support for prompt `Get/Update/Delete`.
- [x] Expose admin API endpoints `GET/PUT/DELETE /api/admin/prompts/{promptId}` and keep `/activate` unchanged.
- [x] Update `docs/openapi.yaml` and add unit/router/sqlmock tests.
- [ ] Integrate prompt CRUD behavior into broader scenario-graph v2 validations and runtime orchestration (follow-up work).

### Testing
- Ran unit and router tests: `go test ./internal/prompts ./internal/app` — all tests passed.  
- Ran full test suite: `go test ./...` — all packages tested successfully.  
- New tests added passed: service-level CRUD tests, Postgres `sqlmock` tests, and router CRUD flow tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c132b6a4832cb8ac3e9731834290)