### PR TITLE
Normalize and persist LLM scenario package steps; deactivate on cross-game update

### DIFF
--- a/internal/prompts/postgres_service.go
+++ b/internal/prompts/postgres_service.go
@@ -786,14 +786,6 @@ func (s *Service) createScenarioPackageDB(ctx context.Context, req ScenarioPacka
 	if gameSlug == "" {
 		gameSlug = "global"
 	}
-	stepsJSON, err := marshalJSON(req.Steps)
-	if err != nil {
-		return ScenarioPackage{}, err
-	}
-	transitionsJSON, err := marshalJSON(req.Transitions)
-	if err != nil {
-		return ScenarioPackage{}, err
-	}
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -810,12 +802,21 @@ func (s *Service) createScenarioPackageDB(ctx context.Context, req ScenarioPacka
 		return ScenarioPackage{}, err
 	}
 	now := time.Now().UTC()
+	normalizedSteps := normalizeScenarioSteps(req.Steps, gameSlug, now)
+	stepsJSON, err := marshalJSON(normalizedSteps)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	transitionsJSON, err := marshalJSON(req.Transitions)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
 	item := ScenarioPackage{
 		ID:          "scenario-pkg-" + uuid.NewString(),
 		Name:        strings.TrimSpace(req.Name),
 		GameSlug:    gameSlug,
 		Version:     version,
-		Steps:       append([]ScenarioStep(nil), req.Steps...),
+		Steps:       normalizedSteps,
 		Transitions: append([]ScenarioTransition(nil), req.Transitions...),
 		IsActive:    existing == 0,
 		CreatedBy:   strings.TrimSpace(req.ActorID),
@@ -885,7 +886,30 @@ func (s *Service) updateScenarioPackageDB(ctx context.Context, id string, req Sc
 	if gameSlug == "" {
 		gameSlug = "global"
 	}
-	stepsJSON, err := marshalJSON(req.Steps)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	defer tx.Rollback()
+
+	var currentGameSlug string
+	var isActive bool
+	var activatedBy string
+	var activatedAt sql.NullTime
+	if err := tx.QueryRowContext(
+		ctx,
+		`SELECT game_slug, is_active, COALESCE(activated_by, ''), activated_at FROM llm_scenario_packages WHERE id = $1`,
+		strings.TrimSpace(id),
+	).Scan(&currentGameSlug, &isActive, &activatedBy, &activatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return ScenarioPackage{}, ErrScenarioPackageNotFound
+		}
+		return ScenarioPackage{}, err
+	}
+
+	now := time.Now().UTC()
+	normalizedSteps := normalizeScenarioSteps(req.Steps, gameSlug, now)
+	stepsJSON, err := marshalJSON(normalizedSteps)
 	if err != nil {
 		return ScenarioPackage{}, err
 	}
@@ -893,19 +917,44 @@ func (s *Service) updateScenarioPackageDB(ctx context.Context, id string, req Sc
 	if err != nil {
 		return ScenarioPackage{}, err
 	}
-	item, err := scanScenarioPackage(s.db.QueryRowContext(
+
+	nextIsActive := isActive
+	nextActivatedBy := strings.TrimSpace(activatedBy)
+	var nextActivatedAt any
+	if activatedAt.Valid {
+		nextActivatedAt = activatedAt.Time
+	}
+	if strings.TrimSpace(currentGameSlug) != gameSlug {
+		nextIsActive = false
+		nextActivatedBy = ""
+		nextActivatedAt = nil
+	}
+
+	item, err := scanScenarioPackage(tx.QueryRowContext(
 		ctx,
-		`UPDATE llm_scenario_packages SET game_slug = $2, name = $3, steps_json = $4, transitions_json = $5 WHERE id = $1 RETURNING id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at`,
+		`UPDATE llm_scenario_packages
+			SET game_slug = $2,
+			    name = $3,
+			    steps_json = $4,
+			    transitions_json = $5,
+			    is_active = $6,
+			    activated_by = $7,
+			    activated_at = $8
+		 WHERE id = $1
+		 RETURNING id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at`,
 		strings.TrimSpace(id),
 		gameSlug,
 		strings.TrimSpace(req.Name),
 		stepsJSON,
 		transitionsJSON,
+		nextIsActive,
+		nextActivatedBy,
+		nextActivatedAt,
 	))
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return ScenarioPackage{}, ErrScenarioPackageNotFound
-		}
+		return ScenarioPackage{}, err
+	}
+	if err := tx.Commit(); err != nil {
 		return ScenarioPackage{}, err
 	}
 	return item, nil

--- a/internal/prompts/postgres_service_test.go
+++ b/internal/prompts/postgres_service_test.go
@@ -245,3 +245,56 @@ func TestPostgresServiceGetActiveScenarioPackage(t *testing.T) {
 		t.Fatalf("ExpectationsWereMet() error = %v", err)
 	}
 }
+
+func TestPostgresServiceUpdateScenarioPackageCrossGameDeactivates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	svc := NewPostgresService(db)
+	now := time.Date(2026, 3, 27, 13, 0, 0, 0, time.UTC)
+	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT game_slug, is_active, COALESCE(activated_by, ''), activated_at FROM llm_scenario_packages WHERE id = $1`)).
+		WithArgs("scenario-pkg-1").
+		WillReturnRows(sqlmock.NewRows([]string{"game_slug", "is_active", "activated_by", "activated_at"}).
+			AddRow("global", true, "admin-1", now))
+	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE llm_scenario_packages
+			SET game_slug = $2,
+			    name = $3,
+			    steps_json = $4,
+			    transitions_json = $5,
+			    is_active = $6,
+			    activated_by = $7,
+			    activated_at = $8
+		 WHERE id = $1
+		 RETURNING id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at`)).
+		WithArgs("scenario-pkg-1", "cs2", "cs2-flow", sqlmock.AnyArg(), sqlmock.AnyArg(), false, "", nil).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "version", "steps_json", "transitions_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
+			AddRow("scenario-pkg-1", "cs2", "cs2-flow", 1, `[{"id":"cs2_mode","name":"CS2 mode","gameSlug":"cs2","promptTemplate":"mode","responseSchemaJson":"{}","initial":true,"order":1}]`, `[]`, false, "admin-1", "", now, nil))
+	mock.ExpectCommit()
+
+	item, err := svc.UpdateScenarioPackage(context.Background(), "scenario-pkg-1", ScenarioPackageCreateRequest{
+		Name:     "cs2-flow",
+		GameSlug: "cs2",
+		ActorID:  "admin-2",
+		Steps: []ScenarioStep{
+			{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", ResponseSchemaJSON: "{}", Initial: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateScenarioPackage() error = %v", err)
+	}
+	if item.IsActive {
+		t.Fatalf("expected moved package to be inactive: %#v", item)
+	}
+	if len(item.Steps) != 1 || item.Steps[0].GameSlug != "cs2" || item.Steps[0].Order != 1 {
+		t.Fatalf("expected normalized steps in updated package, got %#v", item.Steps)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -133,6 +133,23 @@ func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) erro
 	return nil
 }
 
+func normalizeScenarioSteps(steps []ScenarioStep, fallbackGameSlug string, now time.Time) []ScenarioStep {
+	normalized := make([]ScenarioStep, len(steps))
+	for i, step := range steps {
+		normalized[i] = step
+		if normalized[i].CreatedAt.IsZero() {
+			normalized[i].CreatedAt = now
+		}
+		if normalized[i].Order <= 0 {
+			normalized[i].Order = i + 1
+		}
+		if strings.TrimSpace(normalized[i].GameSlug) == "" {
+			normalized[i].GameSlug = fallbackGameSlug
+		}
+	}
+	return normalized
+}
+
 func (s *Service) ListScenarioPackages(ctx context.Context) []ScenarioPackage {
 	if s.db != nil {
 		items, err := s.listScenarioPackagesDB(ctx)
@@ -181,7 +198,7 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 		Name:        strings.TrimSpace(req.Name),
 		Version:     version,
 		GameSlug:    gameSlug,
-		Steps:       append([]ScenarioStep(nil), req.Steps...),
+		Steps:       normalizeScenarioSteps(req.Steps, gameSlug, now),
 		Transitions: append([]ScenarioTransition(nil), req.Transitions...),
 		CreatedBy:   strings.TrimSpace(req.ActorID),
 		CreatedAt:   now,
@@ -190,17 +207,6 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 		item.IsActive = true
 		item.ActivatedBy = strings.TrimSpace(req.ActorID)
 		item.ActivatedAt = now
-	}
-	for i := range item.Steps {
-		if item.Steps[i].CreatedAt.IsZero() {
-			item.Steps[i].CreatedAt = now
-		}
-		if item.Steps[i].Order <= 0 {
-			item.Steps[i].Order = i + 1
-		}
-		if strings.TrimSpace(item.Steps[i].GameSlug) == "" {
-			item.Steps[i].GameSlug = gameSlug
-		}
 	}
 	s.scenarioPackages[gameSlug] = append(s.scenarioPackages[gameSlug], item)
 	return item, nil
@@ -245,19 +251,13 @@ func (s *Service) UpdateScenarioPackage(ctx context.Context, id string, req Scen
 			updated := item
 			updated.Name = strings.TrimSpace(req.Name)
 			updated.GameSlug = targetGameSlug
-			updated.Steps = append([]ScenarioStep(nil), req.Steps...)
-			updated.Transitions = append([]ScenarioTransition(nil), req.Transitions...)
 			now := time.Now().UTC()
-			for idx := range updated.Steps {
-				if updated.Steps[idx].CreatedAt.IsZero() {
-					updated.Steps[idx].CreatedAt = now
-				}
-				if updated.Steps[idx].Order <= 0 {
-					updated.Steps[idx].Order = idx + 1
-				}
-				if strings.TrimSpace(updated.Steps[idx].GameSlug) == "" {
-					updated.Steps[idx].GameSlug = targetGameSlug
-				}
+			updated.Steps = normalizeScenarioSteps(req.Steps, targetGameSlug, now)
+			updated.Transitions = append([]ScenarioTransition(nil), req.Transitions...)
+			if updated.GameSlug != gameSlug {
+				updated.IsActive = false
+				updated.ActivatedBy = ""
+				updated.ActivatedAt = time.Time{}
 			}
 			if updated.GameSlug != gameSlug {
 				s.scenarioPackages[gameSlug] = append(versions[:i], versions[i+1:]...)

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -128,3 +128,47 @@ func TestScenarioPackageBuildVisualGraph(t *testing.T) {
 		t.Fatalf("expected 3 groups, got %d (%#v)", len(graph.Groups), graph.Groups)
 	}
 }
+
+func TestScenarioPackageUpdateAcrossGameDeactivatesAndNormalizesSteps(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	created, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:     "global flow",
+		GameSlug: "global",
+		ActorID:  "admin-1",
+		Steps: []ScenarioStep{
+			{ID: "root_detect", Name: "Root", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+	if !created.IsActive {
+		t.Fatalf("expected created package to be active: %#v", created)
+	}
+
+	updated, err := svc.UpdateScenarioPackage(context.Background(), created.ID, ScenarioPackageCreateRequest{
+		Name:     "cs2 flow",
+		GameSlug: "cs2",
+		ActorID:  "admin-1",
+		Steps: []ScenarioStep{
+			{ID: "cs2_mode", Name: "Mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("update scenario package: %v", err)
+	}
+	if updated.IsActive {
+		t.Fatalf("expected moved package to be inactive: %#v", updated)
+	}
+	if updated.Steps[0].Order != 1 {
+		t.Fatalf("expected normalized step order=1, got %#v", updated.Steps[0])
+	}
+	if updated.Steps[0].GameSlug != "cs2" {
+		t.Fatalf("expected normalized step gameSlug=cs2, got %#v", updated.Steps[0])
+	}
+	if updated.Steps[0].CreatedAt.IsZero() {
+		t.Fatalf("expected normalized step createdAt to be set, got %#v", updated.Steps[0])
+	}
+}


### PR DESCRIPTION
### Motivation
- Ensure admin-managed scenario packages have deterministic, valid step data persisted in PostgreSQL and behave the same as the in-memory implementation. 
- Prevent active-state conflicts when a scenario package is moved between game scopes by deactivating the package on cross-game updates.

### Description
- Added `normalizeScenarioSteps` to populate `CreatedAt`, enforce `Order`, and fill a fallback `GameSlug` for each `ScenarioStep` and used it on create/update for both in-memory and DB-backed paths (`internal/prompts/scenario_flow.go` and `internal/prompts/postgres_service.go`).
- Hardened PostgreSQL update path to run inside a transaction, read current package metadata (`game_slug`, `is_active`, `activated_by`, `activated_at`), normalize steps, and automatically clear `is_active`/activation fields when the package is moved to another `game_slug` (`internal/prompts/postgres_service.go`).
- Kept create paths consistent by storing normalized steps JSON in DB and populating `ActivatedAt/ActivatedBy` for the first package version when appropriate (`internal/prompts/postgres_service.go`).
- Added regression tests for in-memory and postgres-backed behavior covering step normalization and cross-game update deactivation (`internal/prompts/scenario_flow_test.go`, `internal/prompts/postgres_service_test.go`).

### Testing
- Ran `gofmt` on changed files to ensure formatting was applied successfully. 
- Ran `go test ./internal/prompts ./internal/app` and both packages passed: `ok github.com/funpot/funpot-go-core/internal/prompts` and `ok github.com/funpot/funpot-go-core/internal/app`.
- Checklist (aligned with `docs/implementation_plan.md` M2.1 and `docs/llm_stream_orchestration_plan.md`):
  - [x] Admin scenario package CRUD persistence for create/update (DB + in-memory) is implemented and normalized.
  - [x] Cross-game update behavior deactivates moved packages to avoid active-state conflicts.
  - [x] Regression unit tests added for in-memory and sqlmock-backed Postgres flows.
  - [ ] Add integration/e2e tests exercising admin HTTP routes against a real Postgres instance to fully close the integration gap.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6dcc82b9c832c8d763ef6b0192095)