### PR TITLE
Autowire scenario transitions from ordered steps and remove explicit transitions from create/update API

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -196,7 +196,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `POST /api/admin/games` – admin-only endpoint creating a game definition.
 - `PUT /api/admin/games/{gameId}` – admin-only endpoint updating a game definition.
 - `DELETE /api/admin/games/{gameId}` – admin-only endpoint deleting a game definition.
-- `GET /api/admin/llm/scenario-packages` / `POST /api/admin/llm/scenario-packages` – admin CRUD for scenario graph packages (`steps + transitions`) with per-game versioning and activation.
+- `GET /api/admin/llm/scenario-packages` / `POST /api/admin/llm/scenario-packages` – admin CRUD for scenario graph packages defined by ordered `steps` (no manual transition payload required) with per-game versioning and activation. Backend auto-links steps by ascending `order` and applies the target step `entryCondition` as the generated transition condition.
 - `GET /api/admin/llm/scenario-packages/{id}/graph` – returns a UI-ready visual graph payload (`nodes + edges + groups`) for scenario-graph editors/renderers.
 - When PostgreSQL is enabled, admin-managed scenario graph configuration (`/api/admin/llm/scenario-packages`) is persisted in dedicated versioned tables and survives service restarts.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1257,10 +1257,6 @@ components:
           minItems: 1
           items:
             $ref: '#/components/schemas/ScenarioStep'
-        transitions:
-          type: array
-          items:
-            $ref: '#/components/schemas/ScenarioTransition'
     ScenarioPackageVersion:
       allOf:
         - $ref: '#/components/schemas/ScenarioPackageCreateRequest'
@@ -1272,6 +1268,11 @@ components:
               type: integer
             isActive:
               type: boolean
+            transitions:
+              type: array
+              description: Auto-generated transitions derived from step ordering and target-step `entryCondition`.
+              items:
+                $ref: '#/components/schemas/ScenarioTransition'
             createdBy:
               type: string
             activatedBy:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -70,21 +70,11 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 			Order:              step.Order,
 		})
 	}
-	transitions := make([]prompts.ScenarioTransition, 0, len(req.Transitions))
-	for _, tr := range req.Transitions {
-		transitions = append(transitions, prompts.ScenarioTransition{
-			FromStepID: tr.FromStepID,
-			ToStepID:   tr.ToStepID,
-			Condition:  tr.Condition,
-			Priority:   tr.Priority,
-		})
-	}
 	return prompts.ScenarioPackageCreateRequest{
-		Name:        req.Name,
-		GameSlug:    req.GameSlug,
-		Steps:       steps,
-		Transitions: transitions,
-		ActorID:     actorID,
+		Name:     req.Name,
+		GameSlug: req.GameSlug,
+		Steps:    steps,
+		ActorID:  actorID,
 	}
 }
 
@@ -146,18 +136,10 @@ type scenarioStepRequest struct {
 	Order              int    `json:"order"`
 }
 
-type scenarioTransitionRequest struct {
-	FromStepID string `json:"fromStepId"`
-	ToStepID   string `json:"toStepId"`
-	Condition  string `json:"condition"`
-	Priority   int    `json:"priority"`
-}
-
 type scenarioPackageCreateRequest struct {
-	Name        string                      `json:"name"`
-	GameSlug    string                      `json:"gameSlug"`
-	Steps       []scenarioStepRequest       `json:"steps"`
-	Transitions []scenarioTransitionRequest `json:"transitions"`
+	Name     string                `json:"name"`
+	GameSlug string                `json:"gameSlug"`
+	Steps    []scenarioStepRequest `json:"steps"`
 }
 
 type meResponse struct {

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -55,9 +55,6 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"order":              2,
 			},
 		},
-		"transitions": []map[string]any{
-			{"fromStepId": "root_detect", "toStepId": "cs2_mode", "condition": "game == 'cs2'", "priority": 1},
-		},
 	})
 	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/scenario-packages", bytes.NewReader(createBody))
 	createReq.Header.Set("Authorization", "Bearer "+adminToken)
@@ -73,6 +70,10 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	packageID, _ := created["id"].(string)
 	if packageID == "" {
 		t.Fatalf("expected created scenario package id, got %#v", created)
+	}
+	transitions, _ := created["transitions"].([]any)
+	if len(transitions) != 1 {
+		t.Fatalf("expected auto-generated transitions in response, got %#v", created["transitions"])
 	}
 
 	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/scenario-packages", nil)
@@ -131,9 +132,6 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"responseSchemaJson": "{}",
 				"order":              2,
 			},
-		},
-		"transitions": []map[string]any{
-			{"fromStepId": "root_detect", "toStepId": "cs2_mode", "condition": "game == 'cs2'", "priority": 1},
 		},
 	})
 	updateReq := httptest.NewRequest(http.MethodPut, "/api/admin/llm/scenario-packages/"+packageID, bytes.NewReader(updateBody))

--- a/internal/prompts/postgres_service.go
+++ b/internal/prompts/postgres_service.go
@@ -775,7 +775,7 @@ func (s *Service) listScenarioPackagesDB(ctx context.Context) ([]ScenarioPackage
 	return items, rows.Err()
 }
 
-func (s *Service) createScenarioPackageDB(ctx context.Context, req ScenarioPackageCreateRequest) (ScenarioPackage, error) {
+func (s *Service) createScenarioPackageDB(ctx context.Context, req ScenarioPackageCreateRequest, transitions []ScenarioTransition) (ScenarioPackage, error) {
 	if err := ValidateScenarioPackageCreateRequest(req); err != nil {
 		return ScenarioPackage{}, err
 	}
@@ -807,7 +807,7 @@ func (s *Service) createScenarioPackageDB(ctx context.Context, req ScenarioPacka
 	if err != nil {
 		return ScenarioPackage{}, err
 	}
-	transitionsJSON, err := marshalJSON(req.Transitions)
+	transitionsJSON, err := marshalJSON(transitions)
 	if err != nil {
 		return ScenarioPackage{}, err
 	}
@@ -817,7 +817,7 @@ func (s *Service) createScenarioPackageDB(ctx context.Context, req ScenarioPacka
 		GameSlug:    gameSlug,
 		Version:     version,
 		Steps:       normalizedSteps,
-		Transitions: append([]ScenarioTransition(nil), req.Transitions...),
+		Transitions: append([]ScenarioTransition(nil), transitions...),
 		IsActive:    existing == 0,
 		CreatedBy:   strings.TrimSpace(req.ActorID),
 		CreatedAt:   now,
@@ -875,7 +875,7 @@ func (s *Service) getScenarioPackageDB(ctx context.Context, id string) (Scenario
 	return item, nil
 }
 
-func (s *Service) updateScenarioPackageDB(ctx context.Context, id string, req ScenarioPackageCreateRequest) (ScenarioPackage, error) {
+func (s *Service) updateScenarioPackageDB(ctx context.Context, id string, req ScenarioPackageCreateRequest, transitions []ScenarioTransition) (ScenarioPackage, error) {
 	if err := ValidateScenarioPackageCreateRequest(req); err != nil {
 		return ScenarioPackage{}, err
 	}
@@ -913,7 +913,7 @@ func (s *Service) updateScenarioPackageDB(ctx context.Context, id string, req Sc
 	if err != nil {
 		return ScenarioPackage{}, err
 	}
-	transitionsJSON, err := marshalJSON(req.Transitions)
+	transitionsJSON, err := marshalJSON(transitions)
 	if err != nil {
 		return ScenarioPackage{}, err
 	}

--- a/internal/prompts/postgres_service_test.go
+++ b/internal/prompts/postgres_service_test.go
@@ -203,7 +203,6 @@ func TestPostgresServiceCreateScenarioPackage(t *testing.T) {
 		Steps: []ScenarioStep{
 			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true},
 		},
-		Transitions: []ScenarioTransition{},
 	})
 	if err != nil {
 		t.Fatalf("CreateScenarioPackage() error = %v", err)

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -17,8 +17,6 @@ var (
 	ErrInvalidScenarioPackage  = errors.New("scenario package must contain at least one step")
 	ErrInvalidScenarioStepID   = errors.New("scenario step id must not be empty")
 	ErrInvalidScenarioName     = errors.New("scenario package name must not be empty")
-	ErrInvalidScenarioFromStep = errors.New("scenario transition fromStepId must not be empty")
-	ErrInvalidScenarioToStep   = errors.New("scenario transition toStepId must not be empty")
 )
 
 type ScenarioStep struct {
@@ -92,11 +90,10 @@ type ScenarioPackageGraph struct {
 }
 
 type ScenarioPackageCreateRequest struct {
-	Name        string
-	GameSlug    string
-	Steps       []ScenarioStep
-	Transitions []ScenarioTransition
-	ActorID     string
+	Name     string
+	GameSlug string
+	Steps    []ScenarioStep
+	ActorID  string
 }
 
 func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) error {
@@ -113,22 +110,6 @@ func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) erro
 			return ErrInvalidScenarioStepID
 		}
 		seenSteps[id] = struct{}{}
-	}
-	for _, tr := range req.Transitions {
-		from := strings.TrimSpace(tr.FromStepID)
-		if from == "" {
-			return ErrInvalidScenarioFromStep
-		}
-		to := strings.TrimSpace(tr.ToStepID)
-		if to == "" {
-			return ErrInvalidScenarioToStep
-		}
-		if _, ok := seenSteps[from]; !ok {
-			return fmt.Errorf("%w: %s", ErrInvalidScenarioFromStep, from)
-		}
-		if _, ok := seenSteps[to]; !ok {
-			return fmt.Errorf("%w: %s", ErrInvalidScenarioToStep, to)
-		}
 	}
 	return nil
 }
@@ -148,6 +129,31 @@ func normalizeScenarioSteps(steps []ScenarioStep, fallbackGameSlug string, now t
 		}
 	}
 	return normalized
+}
+
+func normalizeScenarioTransitions(steps []ScenarioStep) []ScenarioTransition {
+	if len(steps) < 2 {
+		return nil
+	}
+	ordered := make([]ScenarioStep, len(steps))
+	copy(ordered, steps)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].Order == ordered[j].Order {
+			return ordered[i].ID < ordered[j].ID
+		}
+		return ordered[i].Order < ordered[j].Order
+	})
+	autowired := make([]ScenarioTransition, 0, len(ordered)-1)
+	for i := 0; i < len(ordered)-1; i++ {
+		next := ordered[i+1]
+		autowired = append(autowired, ScenarioTransition{
+			FromStepID: strings.TrimSpace(ordered[i].ID),
+			ToStepID:   strings.TrimSpace(next.ID),
+			Condition:  strings.TrimSpace(next.EntryCondition),
+			Priority:   1,
+		})
+	}
+	return autowired
 }
 
 func (s *Service) ListScenarioPackages(ctx context.Context) []ScenarioPackage {
@@ -174,9 +180,6 @@ func (s *Service) ListScenarioPackages(ctx context.Context) []ScenarioPackage {
 }
 
 func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackageCreateRequest) (ScenarioPackage, error) {
-	if s.db != nil {
-		return s.createScenarioPackageDB(ctx, req)
-	}
 	if err := ValidateScenarioPackageCreateRequest(req); err != nil {
 		return ScenarioPackage{}, err
 	}
@@ -184,13 +187,19 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 	if gameSlug == "" {
 		gameSlug = "global"
 	}
+	now := time.Now().UTC()
+	normalizedSteps := normalizeScenarioSteps(req.Steps, gameSlug, now)
+	normalizedTransitions := normalizeScenarioTransitions(normalizedSteps)
+	req.Steps = normalizedSteps
+	if s.db != nil {
+		return s.createScenarioPackageDB(ctx, req, normalizedTransitions)
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.scenarioPackages == nil {
 		s.scenarioPackages = map[string][]ScenarioPackage{}
 	}
-	now := time.Now().UTC()
 	s.counter++
 	version := len(s.scenarioPackages[gameSlug]) + 1
 	item := ScenarioPackage{
@@ -198,8 +207,8 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 		Name:        strings.TrimSpace(req.Name),
 		Version:     version,
 		GameSlug:    gameSlug,
-		Steps:       normalizeScenarioSteps(req.Steps, gameSlug, now),
-		Transitions: append([]ScenarioTransition(nil), req.Transitions...),
+		Steps:       append([]ScenarioStep(nil), req.Steps...),
+		Transitions: append([]ScenarioTransition(nil), normalizedTransitions...),
 		CreatedBy:   strings.TrimSpace(req.ActorID),
 		CreatedAt:   now,
 	}
@@ -230,19 +239,23 @@ func (s *Service) GetScenarioPackage(ctx context.Context, id string) (ScenarioPa
 }
 
 func (s *Service) UpdateScenarioPackage(ctx context.Context, id string, req ScenarioPackageCreateRequest) (ScenarioPackage, error) {
-	if s.db != nil {
-		return s.updateScenarioPackageDB(ctx, id, req)
-	}
 	if err := ValidateScenarioPackageCreateRequest(req); err != nil {
 		return ScenarioPackage{}, err
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	lookup := strings.TrimSpace(id)
 	targetGameSlug := strings.TrimSpace(req.GameSlug)
 	if targetGameSlug == "" {
 		targetGameSlug = "global"
 	}
+	now := time.Now().UTC()
+	normalizedSteps := normalizeScenarioSteps(req.Steps, targetGameSlug, now)
+	normalizedTransitions := normalizeScenarioTransitions(normalizedSteps)
+	req.Steps = normalizedSteps
+	if s.db != nil {
+		return s.updateScenarioPackageDB(ctx, id, req, normalizedTransitions)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lookup := strings.TrimSpace(id)
 	for gameSlug, versions := range s.scenarioPackages {
 		for i, item := range versions {
 			if item.ID != lookup {
@@ -251,9 +264,8 @@ func (s *Service) UpdateScenarioPackage(ctx context.Context, id string, req Scen
 			updated := item
 			updated.Name = strings.TrimSpace(req.Name)
 			updated.GameSlug = targetGameSlug
-			now := time.Now().UTC()
-			updated.Steps = normalizeScenarioSteps(req.Steps, targetGameSlug, now)
-			updated.Transitions = append([]ScenarioTransition(nil), req.Transitions...)
+			updated.Steps = append([]ScenarioStep(nil), req.Steps...)
+			updated.Transitions = append([]ScenarioTransition(nil), normalizedTransitions...)
 			if updated.GameSlug != gameSlug {
 				updated.IsActive = false
 				updated.ActivatedBy = ""

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -15,12 +15,8 @@ func TestScenarioPackageResolveStep(t *testing.T) {
 		ActorID:  "admin-1",
 		Steps: []ScenarioStep{
 			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-			{ID: "cs2_mode", Name: "CS2 mode", Folder: "cs2", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
-			{ID: "cs2_faceit", Name: "Faceit", Folder: "cs2/faceit", PromptTemplate: "faceit", ResponseSchemaJSON: `{}`, Order: 3},
-		},
-		Transitions: []ScenarioTransition{
-			{FromStepID: "game_detect", ToStepID: "cs2_mode", Condition: "game == cs2", Priority: 1},
-			{FromStepID: "cs2_mode", ToStepID: "cs2_faceit", Condition: "mode == faceit", Priority: 1},
+			{ID: "cs2_mode", Name: "CS2 mode", Folder: "cs2", EntryCondition: "game == cs2", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
+			{ID: "cs2_faceit", Name: "Faceit", Folder: "cs2/faceit", EntryCondition: "mode == faceit", PromptTemplate: "faceit", ResponseSchemaJSON: `{}`, Order: 3},
 		},
 	})
 	if err != nil {
@@ -170,5 +166,50 @@ func TestScenarioPackageUpdateAcrossGameDeactivatesAndNormalizesSteps(t *testing
 	}
 	if updated.Steps[0].CreatedAt.IsZero() {
 		t.Fatalf("expected normalized step createdAt to be set, got %#v", updated.Steps[0])
+	}
+}
+
+func TestScenarioPackageCreateAutowiresTransitionsWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:     "auto transitions",
+		GameSlug: "global",
+		ActorID:  "admin-1",
+		Steps: []ScenarioStep{
+			{ID: "step_a", Name: "Step A", PromptTemplate: "a", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "step_b", Name: "Step B", PromptTemplate: "b", ResponseSchemaJSON: `{}`, EntryCondition: "mode == faceit", Order: 2},
+			{ID: "step_c", Name: "Step C", PromptTemplate: "c", ResponseSchemaJSON: `{}`, Order: 3},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+	if len(item.Transitions) != 2 {
+		t.Fatalf("expected 2 auto transitions, got %#v", item.Transitions)
+	}
+	if item.Transitions[0].FromStepID != "step_a" || item.Transitions[0].ToStepID != "step_b" {
+		t.Fatalf("unexpected first transition: %#v", item.Transitions[0])
+	}
+	if item.Transitions[0].Condition != "mode == faceit" {
+		t.Fatalf("expected first auto transition condition from target step entryCondition, got %#v", item.Transitions[0])
+	}
+	if item.Transitions[1].FromStepID != "step_b" || item.Transitions[1].ToStepID != "step_c" {
+		t.Fatalf("unexpected second transition: %#v", item.Transitions[1])
+	}
+	step, entered, err := item.ResolveStep("step_a", `{"mode":"none"}`)
+	if err != nil {
+		t.Fatalf("resolve auto transition hold: %v", err)
+	}
+	if entered || step.ID != "step_a" {
+		t.Fatalf("expected stay on step_a until entry condition matches, got entered=%v step=%s", entered, step.ID)
+	}
+	step, entered, err = item.ResolveStep("step_a", `{"mode":"faceit"}`)
+	if err != nil {
+		t.Fatalf("resolve auto transition: %v", err)
+	}
+	if !entered || step.ID != "step_b" {
+		t.Fatalf("expected auto transition to step_b, got entered=%v step=%s", entered, step.ID)
 	}
 }


### PR DESCRIPTION
### Motivation

- Simplify authoring of LLM scenario packages by letting the backend derive transitions from ordered `steps` and the target step `entryCondition` instead of requiring clients to supply a separate `transitions` payload.
- Keep persistence and API responses compatible by continuing to store and expose transitions, while reducing admin surface area for package creation/update.

### Description

- Removed `transitions` from the scenario package create/update request shapes and router handlers and stopped requiring transitions validation in `ValidateScenarioPackageCreateRequest`.
- Added `normalizeScenarioTransitions` which sorts `steps` by `order` and auto-generates transitions linking each step to the next with the target step `entryCondition` as the transition `condition` and `priority=1`.
- Updated in-memory and Postgres flows so `CreateScenarioPackage` / `UpdateScenarioPackage` normalize steps, autowire transitions, and pass generated transitions to DB-layer functions; DB methods signatures were adjusted to accept transitions from the caller and persist them.
- Updated OpenAPI (`docs/openapi.yaml`) and local docs (`docs/local_setup.md`) to reflect the new API contract and behavior, and adjusted request/response JSON fields returned by admin endpoints accordingly.
- Updated and added unit tests and handler tests to reflect the new behavior and to assert that transitions are auto-generated and persisted.

### Testing

- Ran unit tests under `internal/prompts` and updated admin route tests in `internal/app`; all modified unit tests passed locally including `TestScenarioPackageCreateAutowiresTransitionsWhenMissing` and `TestAdminLLMScenarioPackageRoutes`.
- Ran Postgres-related `sqlmock` tests in `internal/prompts/postgres_service_test.go`, which passed after adjusting expectations to accept generated transitions.
- Verified `go test ./internal/...` completed successfully for the modified packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6e42d9efc832cbfd531067cbe4e6a)