### PR TITLE
Increase default Streamlink capture timeout to 30s and update docs/tests

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -43,7 +43,7 @@ FUNPOT_STREAMLINK_ENABLED=false
 FUNPOT_STREAMLINK_BINARY=streamlink
 FUNPOT_STREAMLINK_FFMPEG_BINARY=ffmpeg
 FUNPOT_STREAMLINK_QUALITY=1080p60,1080p,720p60,720p,936p60,936p,648p60,648p,480p,best
-FUNPOT_STREAMLINK_CAPTURE_TIMEOUT=25s
+FUNPOT_STREAMLINK_CAPTURE_TIMEOUT=30s
 FUNPOT_STREAMLINK_OUTPUT_DIR=tmp/stream_chunks
 FUNPOT_STREAMLINK_URL_TEMPLATE=https://twitch.tv/%s
 FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT=5
@@ -88,15 +88,15 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 > when Streamlink capture is enabled.
 
 > Scheduler cycle interval is aligned with `FUNPOT_STREAMLINK_CAPTURE_TIMEOUT`
-> (for example, `25s` timeout means one capture/LLM cycle every ~25 seconds)
+> (for example, `30s` timeout means one capture/LLM cycle every ~30 seconds)
 > and automatically starts the next cycle without an extra idle pause when
 > the previous capture overruns the window.
 >
 > Stream capture now runs as a long-lived Streamlink→FFmpeg pipeline per streamer
-> and cuts sequential ~25s segments continuously (`%09d.mp4`) to minimize boundary
+> and cuts sequential ~30s segments continuously (`%09d.mp4`) to minimize boundary
 > loss between chunks.
 >
-> Each ~25s chunk is analyzed immediately by the worker.
+> Each ~30s chunk is analyzed immediately by the worker.
 > In parallel, chunks are accumulated and merged via `ffmpeg -c copy` (no re-encoding)
 > into ~2-minute windows (`FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT` controls batch size),
 > then uploaded to Bunny Stream when Bunny credentials are configured.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -304,7 +304,7 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 
-	streamlinkCaptureTimeout, err := getDuration("FUNPOT_STREAMLINK_CAPTURE_TIMEOUT", 25*time.Second)
+	streamlinkCaptureTimeout, err := getDuration("FUNPOT_STREAMLINK_CAPTURE_TIMEOUT", 30*time.Second)
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -41,7 +41,7 @@ var streamlinkEndedMarkers = []string{
 }
 
 const defaultPreferredStreamQuality = "1080p60,1080p,720p60,720p,936p60,936p,648p60,648p,480p,best"
-const minimumStreamlinkCaptureTimeout = 25 * time.Second
+const minimumStreamlinkCaptureTimeout = 30 * time.Second
 const streamlinkCaptureShutdownGracePeriod = 5 * time.Second
 
 type StreamlinkChannelResolver interface {

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -3,6 +3,7 @@ package media
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -102,7 +103,7 @@ func TestStreamlinkCaptureAdapterCaptureSuccess(t *testing.T) {
 	if !strings.Contains(joined, "https://twitch.tv/shroud") {
 		t.Fatalf("expected resolved channel in args, got %q", joined)
 	}
-	if !strings.Contains(joined, "--stream-segmented-duration 25") {
+	if !strings.Contains(joined, fmt.Sprintf("--stream-segmented-duration %d", int(minimumStreamlinkCaptureTimeout/time.Second))) {
 		t.Fatalf("expected --stream-segmented-duration argument, got %q", joined)
 	}
 
@@ -168,10 +169,10 @@ func TestStreamlinkCaptureAdapterFallsBackToHLSDurationWhenStreamSegmentedUnsupp
 	}
 	first := strings.Join(runner.argsHistory[0], " ")
 	second := strings.Join(runner.argsHistory[1], " ")
-	if !strings.Contains(first, "--stream-segmented-duration 25") {
+	if !strings.Contains(first, fmt.Sprintf("--stream-segmented-duration %d", int(minimumStreamlinkCaptureTimeout/time.Second))) {
 		t.Fatalf("first streamlink invocation = %q, want --stream-segmented-duration", first)
 	}
-	if !strings.Contains(second, "--hls-duration 25") {
+	if !strings.Contains(second, fmt.Sprintf("--hls-duration %d", int(minimumStreamlinkCaptureTimeout/time.Second))) {
 		t.Fatalf("second streamlink invocation = %q, want --hls-duration", second)
 	}
 }


### PR DESCRIPTION
### Motivation

- Raise the default stream capture window to reduce boundary loss and align scheduler cycle with a slightly longer segment duration.

### Description

- Update default `FUNPOT_STREAMLINK_CAPTURE_TIMEOUT` from `25s` to `30s` in the docs (`docs/local_setup.md`).
- Change the config default in `internal/config/config.go` to use `30 * time.Second` for `FUNPOT_STREAMLINK_CAPTURE_TIMEOUT`.
- Bump the minimum capture timeout constant in `internal/media/adapters.go` to `30s` and keep the shutdown grace period unchanged.
- Adjust unit tests in `internal/media/adapters_test.go` to assert against the `minimumStreamlinkCaptureTimeout` dynamically and add the `fmt` import used for formatting the expected value.

### Testing

- Ran media package unit tests with `go test ./internal/media -v` and the updated tests passed.
- Ran repository tests with `go test ./...` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d332ae60832c8e6cebacf04d3e89)