### PR TITLE
Use global scenario package for execution plan lookup; remove resolveGameSlug

### DIFF
--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -248,10 +248,9 @@ func (w *Worker) processExecutionPlan(ctx context.Context, runID, streamerID str
 		return streamers.LLMDecision{}, prompts.ErrScenarioPackageNotFound
 	}
 
-	gameSlug := w.resolveGameSlug(ctx, streamerID)
-	pkg, err := resolver.GetActiveScenarioPackage(ctx, gameSlug)
+	pkg, err := resolver.GetActiveScenarioPackage(ctx, "global")
 	if err != nil {
-		logger.Error("active scenario package lookup failed", zap.String("streamerID", streamerID), zap.String("gameSlug", gameSlug), zap.Error(err))
+		logger.Error("active scenario package lookup failed", zap.String("streamerID", streamerID), zap.String("gameSlug", "global"), zap.Error(err))
 		return streamers.LLMDecision{}, err
 	}
 	return w.processScenarioPackage(ctx, runID, streamerID, chunk, pkg)
@@ -839,16 +838,6 @@ func (w *Worker) latestDecisionByStreamer(ctx context.Context, streamerID string
 		return streamers.LLMDecision{}
 	}
 	return items[len(items)-1]
-}
-
-func (w *Worker) resolveGameSlug(ctx context.Context, streamerID string) string {
-	state := parseSimpleState(w.resolvePreviousState(ctx, streamerID))
-	if value, ok := state["game"]; ok {
-		if game := strings.TrimSpace(fmt.Sprint(value)); game != "" {
-			return game
-		}
-	}
-	return "global"
 }
 
 func parseSimpleState(raw string) map[string]any {


### PR DESCRIPTION
### Motivation
- Replace dynamic game-specific scenario resolution with a global package lookup to simplify execution plan retrieval and avoid relying on per-streamer game slug inference (`resolveGameSlug`).

### Description
- Call `resolver.GetActiveScenarioPackage(ctx, "global")` in `processExecutionPlan` and update the error log to indicate `gameSlug: "global"`, and remove the now-unused `resolveGameSlug` helper from `internal/media/worker.go`.

### Testing
- Ran `go test ./...` and all unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e55c1148832c8f2acd5e0775d38a)