### PR TITLE
Handle stale scenario step IDs in media worker

### DIFF
--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -792,11 +792,25 @@ func compactJSON(value any) string {
 }
 
 func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID string, chunk ChunkRef, pkg prompts.ScenarioPackage) (streamers.LLMDecision, error) {
+	logger := w.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	latest := w.latestDecisionByStreamer(ctx, streamerID)
 	previousState := w.resolvePreviousState(ctx, streamerID)
 	step, entering, err := pkg.ResolveStep(latest.Stage, previousState)
 	if err != nil {
-		return streamers.LLMDecision{}, err
+		if errors.Is(err, prompts.ErrScenarioStepNotFound) && strings.TrimSpace(latest.Stage) != "" {
+			logger.Warn("current scenario step is missing in active package, restarting from initial step",
+				zap.String("streamerID", streamerID),
+				zap.String("missingStepID", latest.Stage),
+				zap.String("scenarioPackageID", pkg.ID),
+			)
+			step, entering, err = pkg.ResolveStep("", previousState)
+		}
+		if err != nil {
+			return streamers.LLMDecision{}, err
+		}
 	}
 	activePrompt := prompts.PromptVersion{
 		ID:       step.ID,

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -220,6 +220,55 @@ func TestWorkerProcessStreamerUsesScenarioPackageFirstStep(t *testing.T) {
 	}
 }
 
+func TestWorkerProcessStreamerResetsToInitialStepWhenLatestStepMissingInActivePackage(t *testing.T) {
+	decisions := &fakeDecisionStore{
+		items: []streamers.RecordDecisionRequest{
+			{
+				RunID:            "run-old",
+				StreamerID:       "str-1",
+				Stage:            "legacy_step",
+				Label:            "state_updated",
+				Confidence:       0.9,
+				UpdatedStateJSON: `{"game":"cs2"}`,
+			},
+		},
+	}
+	worker := NewWorker(
+		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
+		fakeClassifier{results: map[string]StageClassification{
+			"root_detect": {Label: "cs2_detected", Confidence: 0.99, UpdatedStateJSON: `{"game":"cs2"}`},
+		}},
+		fakePromptResolver{scenario: prompts.ScenarioPackage{
+			ID:       "scenario-v2",
+			GameSlug: "global",
+			Name:     "v2",
+			Steps: []prompts.ScenarioStep{
+				{ID: "root_detect", Name: "Root detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+				{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
+			},
+			Transitions: []prompts.ScenarioTransition{
+				{FromStepID: "root_detect", ToStepID: "cs2_mode", Condition: `$.game == "cs2"`, Priority: 1},
+			},
+			IsActive: true,
+		}},
+		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
+	)
+
+	got, err := worker.ProcessStreamer(context.Background(), "str-1")
+	if err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got.Stage != "root_detect" {
+		t.Fatalf("stage = %q, want root_detect", got.Stage)
+	}
+	if len(decisions.items) != 2 {
+		t.Fatalf("recorded %d decisions, want 2", len(decisions.items))
+	}
+	if decisions.items[1].Stage != "root_detect" {
+		t.Fatalf("recorded stage = %q, want root_detect", decisions.items[1].Stage)
+	}
+}
+
 func TestWorkerProcessStageSkipsHistoryWhenStateDidNotChange(t *testing.T) {
 	decisions := &fakeDecisionStore{
 		items: []streamers.RecordDecisionRequest{


### PR DESCRIPTION
### Motivation
- Fix a runtime failure where scheduler cycles logged `scenario step not found` when a streamer's last persisted `Stage` no longer exists in the active scenario package. 
- The intent is to avoid failing the scheduler cycle on package updates/renames and allow affected streamers to recover automatically.
- Checklist aligned to implementation plan: `[x]` M2.1 fix for runtime orchestration crash, `[x]` safe fallback to canonical initial step; `[ ]` add metric/event for resets; `[ ]` add bulk reconcile/migration for historical stage IDs.

### Description
- Add a safe fallback in `Worker.processScenarioPackage` to catch `prompts.ErrScenarioStepNotFound` when `latest.Stage` is missing, log a warning, and re-resolve the step from the package initial step instead of returning an error (changes in `internal/media/worker.go`).
- Initialize a local logger reference in the method to emit the warning with `streamerID`, `missingStepID`, and `scenarioPackageID` when the fallback triggers.
- Add a regression test `TestWorkerProcessStreamerResetsToInitialStepWhenLatestStepMissingInActivePackage` to simulate a legacy `Stage` value and assert processing restarts from the package initial step (changes in `internal/media/worker_test.go`).
- No public API changes; behavior is internal to the media worker and improves resiliency after scenario package updates.

### Testing
- Ran targeted unit tests: `go test ./internal/media -run 'TestWorkerProcessStreamer(UsesScenarioPackageFirstStep|ResetsToInitialStepWhenLatestStepMissingInActivePackage)$'` and they passed.
- Ran full package tests: `go test ./internal/media` and they passed (`ok`).
- All modified unit tests in `internal/media` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f38e244c832cb651faa860fd1a68)