### PR TITLE
Add bootstrap fallback in ScenarioPackage.ResolveStep to avoid "scenario step not found"

### DIFF
--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -384,6 +384,13 @@ func (p ScenarioPackage) ResolveStep(currentStepID, stateJSON string) (ScenarioS
 				return candidate, true, nil
 			}
 		}
+		// Bootstrap fail-safe: if no initial candidate condition matches,
+		// still start from the first ordered initial/root step.
+		// This keeps scheduler cycles running when state payload is sparse
+		// or legacy entry conditions are too strict.
+		if len(initial) > 0 {
+			return initial[0], true, nil
+		}
 		return ScenarioStep{}, false, ErrScenarioStepNotFound
 	}
 

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -56,6 +56,31 @@ func TestScenarioPackageResolveStep(t *testing.T) {
 	}
 }
 
+func TestScenarioPackageResolveStepFallsBackToFirstInitialWhenNoConditionMatches(t *testing.T) {
+	t.Parallel()
+
+	pkg := ScenarioPackage{
+		ID:       "pkg-1",
+		Name:     "fallback flow",
+		GameSlug: "global",
+		Steps: []ScenarioStep{
+			{ID: "root_detect", Name: "Root detect", Initial: true, Order: 1, EntryCondition: "game == cs2"},
+			{ID: "secondary", Name: "Secondary", Initial: true, Order: 2, EntryCondition: "mode == faceit"},
+		},
+	}
+
+	step, entered, err := pkg.ResolveStep("", `{"game":"dota2"}`)
+	if err != nil {
+		t.Fatalf("resolve initial fallback: %v", err)
+	}
+	if !entered {
+		t.Fatalf("expected entered=true for bootstrap fallback")
+	}
+	if step.ID != "root_detect" {
+		t.Fatalf("expected fallback to first ordered initial step root_detect, got %s", step.ID)
+	}
+}
+
 func TestEvaluateCondition(t *testing.T) {
 	t.Parallel()
 	payload := map[string]any{"game": "cs2", "mode": "faceit", "nested": map[string]any{"value": "x"}}


### PR DESCRIPTION
### Motivation
- Scheduler cycles were failing with `scenario step not found` when no initial step matched strict `EntryCondition` on sparse or legacy state, causing repeated `scheduler cycle failed` logs. 
- To maintain runtime continuity for the scenario-graph orchestration (M2.1), the resolver must bootstrap a sensible initial step instead of returning an error. 
- Checklist (aligned with `docs/implementation_plan.md` M2.1 and `docs/llm_stream_orchestration_plan.md`): [x] fallback bootstrap behavior added, [x] unit test coverage added, [ ] remaining M2.1 items (pipeline/session lifecycle/observability) still to implement.

### Description
- Change `ScenarioPackage.ResolveStep` to return the first ordered initial/root step when no initial candidate conditions match, instead of returning `ErrScenarioStepNotFound`. 
- This adds a bootstrap fail-safe so workers/schedulers start from a root step on sparse state payloads and continue populating state. 
- Added unit test `TestScenarioPackageResolveStepFallsBackToFirstInitialWhenNoConditionMatches` in `internal/prompts/scenario_flow_test.go` to validate the fallback behavior. 
- Modified files: `internal/prompts/scenario_flow.go` and `internal/prompts/scenario_flow_test.go`.

### Testing
- Ran `go test ./internal/prompts` and the tests passed (`ok github.com/funpot/funpot-go-core/internal/prompts`). 
- The new unit test verifies the bootstrap fallback and existing tests ensure no regressions in step resolution and condition evaluation. 
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f6097ecc832ca7917a321c4ee9d5)