### PR TITLE
Require per-step LLM model for scenario steps and wire model through API, worker and tests

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -195,7 +195,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `POST /api/admin/games` – admin-only endpoint creating a game definition.
 - `PUT /api/admin/games/{gameId}` – admin-only endpoint updating a game definition.
 - `DELETE /api/admin/games/{gameId}` – admin-only endpoint deleting a game definition.
-- `GET /api/admin/llm/scenario-packages` / `POST /api/admin/llm/scenario-packages` – admin CRUD for scenario graph packages defined by ordered `steps` (no manual transition payload required) with per-game versioning and activation. Backend auto-links steps by ascending `order` and applies the target step `entryCondition` as the generated transition condition.
+- `GET /api/admin/llm/scenario-packages` / `POST /api/admin/llm/scenario-packages` – admin CRUD for scenario graph packages defined by ordered `steps` (no manual transition payload required) with per-game versioning and activation. Each step **must** set its own LLM `model`. Backend auto-links steps by ascending `order` and applies the target step `entryCondition` as the generated transition condition.
 - `GET /api/admin/llm/scenario-packages/{id}/graph` – returns a UI-ready visual graph payload (`nodes + edges + groups`) for scenario-graph editors/renderers.
 - When PostgreSQL is enabled, admin-managed scenario graph configuration (`/api/admin/llm/scenario-packages`) is persisted in dedicated versioned tables and survives service restarts.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1060,7 +1060,7 @@ components:
           nullable: true
     ScenarioStep:
       type: object
-      required: [id, name, promptTemplate, responseSchemaJson, initial, order]
+      required: [id, name, promptTemplate, model, responseSchemaJson, initial, order]
       properties:
         id:
           type: string
@@ -1074,6 +1074,9 @@ components:
           type: string
         promptTemplate:
           type: string
+        model:
+          type: string
+          description: LLM model used for this scenario step.
         responseSchemaJson:
           type: string
         initial:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -65,6 +65,7 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 			Folder:             step.Folder,
 			EntryCondition:     step.EntryCondition,
 			PromptTemplate:     step.PromptTemplate,
+			Model:              step.Model,
 			ResponseSchemaJSON: step.ResponseSchemaJSON,
 			Initial:            step.Initial,
 			Order:              step.Order,
@@ -102,6 +103,7 @@ type scenarioStepRequest struct {
 	Folder             string `json:"folder"`
 	EntryCondition     string `json:"entryCondition"`
 	PromptTemplate     string `json:"promptTemplate"`
+	Model              string `json:"model"`
 	ResponseSchemaJSON string `json:"responseSchemaJson"`
 	Initial            bool   `json:"initial"`
 	Order              int    `json:"order"`

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -41,6 +41,7 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"name":               "Root detect",
 				"gameSlug":           "global",
 				"promptTemplate":     "detect",
+				"model":              "gemini-2.0-flash",
 				"responseSchemaJson": "{}",
 				"initial":            true,
 				"order":              1,
@@ -51,6 +52,7 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"gameSlug":           "cs2",
 				"folder":             "cs2",
 				"promptTemplate":     "mode",
+				"model":              "gemini-2.0-flash-lite",
 				"responseSchemaJson": "{}",
 				"order":              2,
 			},
@@ -74,6 +76,14 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	transitions, _ := created["transitions"].([]any)
 	if len(transitions) != 1 {
 		t.Fatalf("expected auto-generated transitions in response, got %#v", created["transitions"])
+	}
+	steps, _ := created["steps"].([]any)
+	if len(steps) != 2 {
+		t.Fatalf("expected created package steps, got %#v", created["steps"])
+	}
+	rootStep, _ := steps[0].(map[string]any)
+	if rootStep["model"] != "gemini-2.0-flash" {
+		t.Fatalf("expected root step model to round-trip, got %#v", rootStep["model"])
 	}
 
 	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/scenario-packages", nil)
@@ -119,6 +129,7 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"name":               "Root detect",
 				"gameSlug":           "global",
 				"promptTemplate":     "detect-v2",
+				"model":              "gemini-2.0-flash",
 				"responseSchemaJson": "{}",
 				"initial":            true,
 				"order":              1,
@@ -129,6 +140,7 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"gameSlug":           "cs2",
 				"folder":             "cs2",
 				"promptTemplate":     "mode-v2",
+				"model":              "gemini-2.5-flash",
 				"responseSchemaJson": "{}",
 				"order":              2,
 			},

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -816,8 +816,11 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 		ID:       step.ID,
 		Stage:    step.ID,
 		Template: step.PromptTemplate,
-		Model:    "scenario-graph",
+		Model:    strings.TrimSpace(step.Model),
 		IsActive: true,
+	}
+	if activePrompt.Model == "" {
+		activePrompt.Model = prompts.DefaultScenarioStepModel
 	}
 	stateSchema := w.resolveTrackerConfig(ctx)
 	result, err := w.classifyWithRetry(ctx, StageRequest{

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -78,6 +78,7 @@ func (f fakePromptResolver) GetActiveScenarioPackage(_ context.Context, _ string
 			ID:                 stepID,
 			Name:               stepID,
 			PromptTemplate:     prompt.Template,
+			Model:              strings.TrimSpace(prompt.Model),
 			ResponseSchemaJSON: "{}",
 			Initial:            i == 0,
 			Order:              i + 1,
@@ -243,8 +244,8 @@ func TestWorkerProcessStreamerResetsToInitialStepWhenLatestStepMissingInActivePa
 			GameSlug: "global",
 			Name:     "v2",
 			Steps: []prompts.ScenarioStep{
-				{ID: "root_detect", Name: "Root detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-				{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
+				{ID: "root_detect", Name: "Root detect", PromptTemplate: "detect", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+				{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Order: 2},
 			},
 			Transitions: []prompts.ScenarioTransition{
 				{FromStepID: "root_detect", ToStepID: "cs2_mode", Condition: `$.game == "cs2"`, Priority: 1},

--- a/internal/prompts/postgres_service_test.go
+++ b/internal/prompts/postgres_service_test.go
@@ -201,7 +201,7 @@ func TestPostgresServiceCreateScenarioPackage(t *testing.T) {
 		GameSlug: "global",
 		ActorID:  "admin-1",
 		Steps: []ScenarioStep{
-			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true},
+			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Initial: true},
 		},
 	})
 	if err != nil {
@@ -280,7 +280,7 @@ func TestPostgresServiceUpdateScenarioPackageCrossGameDeactivates(t *testing.T) 
 		GameSlug: "cs2",
 		ActorID:  "admin-2",
 		Steps: []ScenarioStep{
-			{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", ResponseSchemaJSON: "{}", Initial: true},
+			{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", Model: "gemini-2.0-flash", ResponseSchemaJSON: "{}", Initial: true},
 		},
 	})
 	if err != nil {

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -12,11 +12,12 @@ import (
 )
 
 var (
-	ErrScenarioPackageNotFound = errors.New("scenario package not found")
-	ErrScenarioStepNotFound    = errors.New("scenario step not found")
-	ErrInvalidScenarioPackage  = errors.New("scenario package must contain at least one step")
-	ErrInvalidScenarioStepID   = errors.New("scenario step id must not be empty")
-	ErrInvalidScenarioName     = errors.New("scenario package name must not be empty")
+	ErrScenarioPackageNotFound  = errors.New("scenario package not found")
+	ErrScenarioStepNotFound     = errors.New("scenario step not found")
+	ErrInvalidScenarioPackage   = errors.New("scenario package must contain at least one step")
+	ErrInvalidScenarioStepID    = errors.New("scenario step id must not be empty")
+	ErrInvalidScenarioStepModel = errors.New("scenario step model must not be empty")
+	ErrInvalidScenarioName      = errors.New("scenario package name must not be empty")
 )
 
 type ScenarioStep struct {
@@ -26,11 +27,14 @@ type ScenarioStep struct {
 	Folder             string    `json:"folder"`
 	EntryCondition     string    `json:"entryCondition,omitempty"`
 	PromptTemplate     string    `json:"promptTemplate"`
+	Model              string    `json:"model"`
 	ResponseSchemaJSON string    `json:"responseSchemaJson"`
 	Initial            bool      `json:"initial"`
 	Order              int       `json:"order"`
 	CreatedAt          time.Time `json:"createdAt"`
 }
+
+const DefaultScenarioStepModel = "gemini-2.0-flash"
 
 type ScenarioTransition struct {
 	FromStepID string `json:"fromStepId"`
@@ -108,6 +112,9 @@ func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) erro
 		id := strings.TrimSpace(step.ID)
 		if id == "" {
 			return ErrInvalidScenarioStepID
+		}
+		if strings.TrimSpace(step.Model) == "" {
+			return ErrInvalidScenarioStepModel
 		}
 		seenSteps[id] = struct{}{}
 	}

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -14,9 +14,9 @@ func TestScenarioPackageResolveStep(t *testing.T) {
 		GameSlug: "global",
 		ActorID:  "admin-1",
 		Steps: []ScenarioStep{
-			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-			{ID: "cs2_mode", Name: "CS2 mode", Folder: "cs2", EntryCondition: "game == cs2", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
-			{ID: "cs2_faceit", Name: "Faceit", Folder: "cs2/faceit", EntryCondition: "mode == faceit", PromptTemplate: "faceit", ResponseSchemaJSON: `{}`, Order: 3},
+			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "cs2_mode", Name: "CS2 mode", Folder: "cs2", EntryCondition: "game == cs2", PromptTemplate: "mode", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Order: 2},
+			{ID: "cs2_faceit", Name: "Faceit", Folder: "cs2/faceit", EntryCondition: "mode == faceit", PromptTemplate: "faceit", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Order: 3},
 		},
 	})
 	if err != nil {
@@ -159,7 +159,7 @@ func TestScenarioPackageUpdateAcrossGameDeactivatesAndNormalizesSteps(t *testing
 		GameSlug: "global",
 		ActorID:  "admin-1",
 		Steps: []ScenarioStep{
-			{ID: "root_detect", Name: "Root", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true},
+			{ID: "root_detect", Name: "Root", PromptTemplate: "detect", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Initial: true},
 		},
 	})
 	if err != nil {
@@ -174,7 +174,7 @@ func TestScenarioPackageUpdateAcrossGameDeactivatesAndNormalizesSteps(t *testing
 		GameSlug: "cs2",
 		ActorID:  "admin-1",
 		Steps: []ScenarioStep{
-			{ID: "cs2_mode", Name: "Mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`},
+			{ID: "cs2_mode", Name: "Mode", PromptTemplate: "mode", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`},
 		},
 	})
 	if err != nil {
@@ -203,9 +203,9 @@ func TestScenarioPackageCreateAutowiresTransitionsWhenMissing(t *testing.T) {
 		GameSlug: "global",
 		ActorID:  "admin-1",
 		Steps: []ScenarioStep{
-			{ID: "step_a", Name: "Step A", PromptTemplate: "a", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-			{ID: "step_b", Name: "Step B", PromptTemplate: "b", ResponseSchemaJSON: `{}`, EntryCondition: "mode == faceit", Order: 2},
-			{ID: "step_c", Name: "Step C", PromptTemplate: "c", ResponseSchemaJSON: `{}`, Order: 3},
+			{ID: "step_a", Name: "Step A", PromptTemplate: "a", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "step_b", Name: "Step B", PromptTemplate: "b", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, EntryCondition: "mode == faceit", Order: 2},
+			{ID: "step_c", Name: "Step C", PromptTemplate: "c", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Order: 3},
 		},
 	})
 	if err != nil {
@@ -236,5 +236,40 @@ func TestScenarioPackageCreateAutowiresTransitionsWhenMissing(t *testing.T) {
 	}
 	if !entered || step.ID != "step_b" {
 		t.Fatalf("expected auto transition to step_b, got entered=%v step=%s", entered, step.ID)
+	}
+}
+
+func TestScenarioPackageCreateRequiresStepModelAndPreservesConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	_, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:     "model defaults",
+		GameSlug: "global",
+		ActorID:  "admin-1",
+		Steps: []ScenarioStep{
+			{ID: "step_missing_model", Name: "Missing model", PromptTemplate: "a", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected missing model validation error")
+	}
+	if err != ErrInvalidScenarioStepModel {
+		t.Fatalf("expected ErrInvalidScenarioStepModel, got %v", err)
+	}
+
+	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:     "model configured",
+		GameSlug: "global",
+		ActorID:  "admin-1",
+		Steps: []ScenarioStep{
+			{ID: "step_custom_model", Name: "Custom model", PromptTemplate: "b", Model: "gemini-2.5-flash", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+	if got := item.Steps[0].Model; got != "gemini-2.5-flash" {
+		t.Fatalf("expected custom model to be preserved, got %q", got)
 	}
 }


### PR DESCRIPTION
### Motivation
- Ensure each scenario graph step explicitly declares the LLM to use so operators can control per-step model selection and avoid ambiguous runtime behavior.
- Surface the model field in the public API and OpenAPI contract so clients and admin UIs can supply and validate it.

### Description
- Add a `Model` field to `ScenarioStep`, include `DefaultScenarioStepModel` constant, and require `model` in OpenAPI by marking it required and adding a description. 
- Enforce validation in `ValidateScenarioPackageCreateRequest` with `ErrInvalidScenarioStepModel`, and autowire `Model` in router request mapping (`scenarioPackageRequestToCreateRequest` and `scenarioStepRequest`).
- Use the configured step `Model` in the worker pipeline (`processScenarioPackage`) and fall back to `DefaultScenarioStepModel` when an existing step has an empty value to preserve forward compatibility.
- Update docs to state that each step must set its LLM `model`, and adjust many unit tests and DB mocks to include the new `model` field or to verify validation and preservation behavior.

### Testing
- Ran unit tests with `go test ./...` including `internal/prompts` tests (`scenario_flow_test.go`, `postgres_service_test.go`), worker tests (`internal/media/worker_test.go`), and router tests (`internal/app/router_admin_llm_test.go`), and they passed.
- Added `TestScenarioPackageCreateRequiresStepModelAndPreservesConfiguredValue` to assert missing-model validation and preservation of explicit model values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f8ad0bc4832c98536c1b08408ba2)