### PR TITLE
Add LLM model config profiles and bind scenario packages to a model config

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -290,6 +290,121 @@ paths:
           description: Game deleted
         default:
           $ref: '#/components/responses/Error'
+  /api/admin/llm/settings:
+    get:
+      summary: List LLM model configs (admin)
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: LLM model configs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LLMModelConfigVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create LLM model config (admin)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LLMModelConfigCreateRequest'
+      responses:
+        '201':
+          description: Created LLM model config
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMModelConfigVersion'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/llm/settings/{settingsId}:
+    get:
+      summary: Get LLM model config (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: settingsId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: LLM model config
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMModelConfigVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update LLM model config (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: settingsId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LLMModelConfigCreateRequest'
+      responses:
+        '200':
+          description: Updated LLM model config
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMModelConfigVersion'
+        default:
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Delete LLM model config (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: settingsId
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: LLM model config deleted
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/llm/settings/{settingsId}/activate:
+    post:
+      summary: Activate LLM model config (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: settingsId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activated LLM model config
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LLMModelConfigVersion'
+        default:
+          $ref: '#/components/responses/Error'
   /api/admin/llm/scenario-packages:
     get:
       summary: List LLM scenario packages (admin)
@@ -1058,9 +1173,64 @@ components:
           type: string
           format: date-time
           nullable: true
+    LLMModelConfigCreateRequest:
+      type: object
+      required: [name, model, temperature, maxTokens, timeoutMs, retryCount, backoffMs, cooldownMs, minConfidence]
+      properties:
+        name:
+          type: string
+        model:
+          type: string
+        temperature:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 2
+        maxTokens:
+          type: integer
+          minimum: 1
+        timeoutMs:
+          type: integer
+          minimum: 1
+        retryCount:
+          type: integer
+          minimum: 0
+          maximum: 10
+        backoffMs:
+          type: integer
+          minimum: 0
+        cooldownMs:
+          type: integer
+          minimum: 0
+        minConfidence:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+    LLMModelConfigVersion:
+      allOf:
+        - $ref: '#/components/schemas/LLMModelConfigCreateRequest'
+        - type: object
+          properties:
+            id:
+              type: string
+            isActive:
+              type: boolean
+            createdBy:
+              type: string
+            activatedBy:
+              type: string
+              nullable: true
+            createdAt:
+              type: string
+              format: date-time
+            activatedAt:
+              type: string
+              format: date-time
+              nullable: true
     ScenarioStep:
       type: object
-      required: [id, name, promptTemplate, model, responseSchemaJson, initial, order]
+      required: [id, name, promptTemplate, responseSchemaJson, initial, order]
       properties:
         id:
           type: string
@@ -1074,9 +1244,6 @@ components:
           type: string
         promptTemplate:
           type: string
-        model:
-          type: string
-          description: LLM model used for this scenario step.
         responseSchemaJson:
           type: string
         initial:
@@ -1099,11 +1266,13 @@ components:
           minimum: 1
     ScenarioPackageCreateRequest:
       type: object
-      required: [gameSlug, name, steps]
+      required: [gameSlug, name, llmModelConfigId, steps]
       properties:
         gameSlug:
           type: string
         name:
+          type: string
+        llmModelConfigId:
           type: string
         steps:
           type: array

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -65,17 +65,17 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 			Folder:             step.Folder,
 			EntryCondition:     step.EntryCondition,
 			PromptTemplate:     step.PromptTemplate,
-			Model:              step.Model,
 			ResponseSchemaJSON: step.ResponseSchemaJSON,
 			Initial:            step.Initial,
 			Order:              step.Order,
 		})
 	}
 	return prompts.ScenarioPackageCreateRequest{
-		Name:     req.Name,
-		GameSlug: req.GameSlug,
-		Steps:    steps,
-		ActorID:  actorID,
+		Name:             req.Name,
+		GameSlug:         req.GameSlug,
+		LLMModelConfigID: req.LLMModelConfigID,
+		Steps:            steps,
+		ActorID:          actorID,
 	}
 }
 
@@ -103,16 +103,43 @@ type scenarioStepRequest struct {
 	Folder             string `json:"folder"`
 	EntryCondition     string `json:"entryCondition"`
 	PromptTemplate     string `json:"promptTemplate"`
-	Model              string `json:"model"`
 	ResponseSchemaJSON string `json:"responseSchemaJson"`
 	Initial            bool   `json:"initial"`
 	Order              int    `json:"order"`
 }
 
 type scenarioPackageCreateRequest struct {
-	Name     string                `json:"name"`
-	GameSlug string                `json:"gameSlug"`
-	Steps    []scenarioStepRequest `json:"steps"`
+	Name             string                `json:"name"`
+	GameSlug         string                `json:"gameSlug"`
+	LLMModelConfigID string                `json:"llmModelConfigId"`
+	Steps            []scenarioStepRequest `json:"steps"`
+}
+
+type llmSettingsUpsertRequest struct {
+	Name          string  `json:"name"`
+	Model         string  `json:"model"`
+	Temperature   float64 `json:"temperature"`
+	MaxTokens     int     `json:"maxTokens"`
+	TimeoutMS     int     `json:"timeoutMs"`
+	RetryCount    int     `json:"retryCount"`
+	BackoffMS     int     `json:"backoffMs"`
+	CooldownMS    int     `json:"cooldownMs"`
+	MinConfidence float64 `json:"minConfidence"`
+}
+
+func llmSettingsRequestToModelConfigRequest(req llmSettingsUpsertRequest, actorID string) prompts.LLMModelConfigCreateRequest {
+	return prompts.LLMModelConfigCreateRequest{
+		Name:          req.Name,
+		Model:         req.Model,
+		Temperature:   req.Temperature,
+		MaxTokens:     req.MaxTokens,
+		TimeoutMS:     req.TimeoutMS,
+		RetryCount:    req.RetryCount,
+		BackoffMS:     req.BackoffMS,
+		CooldownMS:    req.CooldownMS,
+		MinConfidence: req.MinConfidence,
+		ActorID:       actorID,
+	}
 }
 
 type meResponse struct {
@@ -556,6 +583,126 @@ func NewHandler(
 		}
 
 		if promptsService != nil {
+			mux.Handle("/api/admin/llm/settings", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, promptsService.ListLLMModelConfigs(r.Context()))
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req llmSettingsUpsertRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					created, err := promptsService.CreateLLMModelConfig(r.Context(), llmSettingsRequestToModelConfigRequest(req, claims.Subject))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusCreated, created)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/llm/settings/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+
+				path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/admin/llm/settings/"), "/")
+				if path == "" {
+					writeError(w, http.StatusBadRequest, "llm model config id is required")
+					return
+				}
+				if strings.HasSuffix(path, "/activate") {
+					id := strings.Trim(strings.TrimSuffix(path, "/activate"), "/")
+					if r.Method != http.MethodPost {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					item, err := promptsService.ActivateLLMModelConfig(r.Context(), id, claims.Subject)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrLLMModelConfigNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+					return
+				}
+
+				switch r.Method {
+				case http.MethodGet:
+					item, err := promptsService.GetLLMModelConfig(r.Context(), path)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrLLMModelConfigNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req llmSettingsUpsertRequest
+					if err := json.Unmarshal(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					item, err := promptsService.UpdateLLMModelConfig(r.Context(), path, llmSettingsRequestToModelConfigRequest(req, claims.Subject))
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrLLMModelConfigNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodDelete:
+					if err := promptsService.DeleteLLMModelConfig(r.Context(), path); err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrLLMModelConfigNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
 			mux.Handle("/api/admin/llm/scenario-packages", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				claims, ok := auth.ClaimsFromContext(r.Context())
 				if !ok {

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -16,6 +16,21 @@ import (
 
 func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	promptsService := prompts.NewService()
+	cfg, err := promptsService.CreateLLMModelConfig(t.Context(), prompts.LLMModelConfigCreateRequest{
+		Name:          "default",
+		Model:         "gemini-2.5-flash",
+		Temperature:   0.2,
+		MaxTokens:     1024,
+		TimeoutMS:     4000,
+		RetryCount:    2,
+		BackoffMS:     300,
+		CooldownMS:    500,
+		MinConfidence: 0.7,
+		ActorID:       "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateLLMModelConfig() error = %v", err)
+	}
 	handler := NewHandler(
 		zap.NewNop(),
 		func() bool { return true },
@@ -33,15 +48,15 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	adminToken := buildToken(t, "admin-1")
 
 	createBody, _ := json.Marshal(map[string]any{
-		"gameSlug": "global",
-		"name":     "default graph",
+		"gameSlug":         "global",
+		"name":             "default graph",
+		"llmModelConfigId": cfg.ID,
 		"steps": []map[string]any{
 			{
 				"id":                 "root_detect",
 				"name":               "Root detect",
 				"gameSlug":           "global",
 				"promptTemplate":     "detect",
-				"model":              "gemini-2.0-flash",
 				"responseSchemaJson": "{}",
 				"initial":            true,
 				"order":              1,
@@ -52,7 +67,6 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"gameSlug":           "cs2",
 				"folder":             "cs2",
 				"promptTemplate":     "mode",
-				"model":              "gemini-2.0-flash-lite",
 				"responseSchemaJson": "{}",
 				"order":              2,
 			},
@@ -81,11 +95,6 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	if len(steps) != 2 {
 		t.Fatalf("expected created package steps, got %#v", created["steps"])
 	}
-	rootStep, _ := steps[0].(map[string]any)
-	if rootStep["model"] != "gemini-2.0-flash" {
-		t.Fatalf("expected root step model to round-trip, got %#v", rootStep["model"])
-	}
-
 	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/scenario-packages", nil)
 	listReq.Header.Set("Authorization", "Bearer "+adminToken)
 	listRes := httptest.NewRecorder()
@@ -121,15 +130,15 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	}
 
 	updateBody, _ := json.Marshal(map[string]any{
-		"gameSlug": "global",
-		"name":     "default graph v2",
+		"gameSlug":         "global",
+		"name":             "default graph v2",
+		"llmModelConfigId": cfg.ID,
 		"steps": []map[string]any{
 			{
 				"id":                 "root_detect",
 				"name":               "Root detect",
 				"gameSlug":           "global",
 				"promptTemplate":     "detect-v2",
-				"model":              "gemini-2.0-flash",
 				"responseSchemaJson": "{}",
 				"initial":            true,
 				"order":              1,
@@ -140,7 +149,6 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"gameSlug":           "cs2",
 				"folder":             "cs2",
 				"promptTemplate":     "mode-v2",
-				"model":              "gemini-2.5-flash",
 				"responseSchemaJson": "{}",
 				"order":              2,
 			},
@@ -168,5 +176,103 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	handler.ServeHTTP(deleteRes, deleteReq)
 	if deleteRes.Code != http.StatusNoContent {
 		t.Fatalf("scenario package delete status = %d body=%s", deleteRes.Code, deleteRes.Body.String())
+	}
+}
+
+func TestAdminLLMSettingsRoutes(t *testing.T) {
+	promptsService := prompts.NewService()
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamers.NewService(),
+		nil,
+		promptsService,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+	adminToken := buildToken(t, "admin-1")
+
+	createBody, _ := json.Marshal(map[string]any{
+		"name":          "Gemini Flash profile",
+		"model":         "gemini-2.5-flash",
+		"temperature":   0.2,
+		"maxTokens":     1024,
+		"timeoutMs":     4000,
+		"retryCount":    2,
+		"backoffMs":     300,
+		"cooldownMs":    500,
+		"minConfidence": 0.75,
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/settings", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer "+adminToken)
+	createRes := httptest.NewRecorder()
+	handler.ServeHTTP(createRes, createReq)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("llm settings create status = %d body=%s", createRes.Code, createRes.Body.String())
+	}
+
+	var created map[string]any
+	if err := json.Unmarshal(createRes.Body.Bytes(), &created); err != nil {
+		t.Fatalf("llm settings create decode error = %v", err)
+	}
+	id, _ := created["id"].(string)
+	if id == "" {
+		t.Fatalf("expected created llm settings id, got %#v", created)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/settings", nil)
+	listReq.Header.Set("Authorization", "Bearer "+adminToken)
+	listRes := httptest.NewRecorder()
+	handler.ServeHTTP(listRes, listReq)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("llm settings list status = %d body=%s", listRes.Code, listRes.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/settings/"+id, nil)
+	getReq.Header.Set("Authorization", "Bearer "+adminToken)
+	getRes := httptest.NewRecorder()
+	handler.ServeHTTP(getRes, getReq)
+	if getRes.Code != http.StatusOK {
+		t.Fatalf("llm settings get status = %d body=%s", getRes.Code, getRes.Body.String())
+	}
+
+	updateBody, _ := json.Marshal(map[string]any{
+		"name":          "Gemini Pro profile",
+		"model":         "gemini-2.5-pro",
+		"temperature":   0.4,
+		"maxTokens":     2048,
+		"timeoutMs":     5000,
+		"retryCount":    3,
+		"backoffMs":     500,
+		"cooldownMs":    600,
+		"minConfidence": 0.8,
+	})
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/admin/llm/settings/"+id, bytes.NewReader(updateBody))
+	updateReq.Header.Set("Authorization", "Bearer "+adminToken)
+	updateRes := httptest.NewRecorder()
+	handler.ServeHTTP(updateRes, updateReq)
+	if updateRes.Code != http.StatusOK {
+		t.Fatalf("llm settings update status = %d body=%s", updateRes.Code, updateRes.Body.String())
+	}
+
+	activateReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/settings/"+id+"/activate", nil)
+	activateReq.Header.Set("Authorization", "Bearer "+adminToken)
+	activateRes := httptest.NewRecorder()
+	handler.ServeHTTP(activateRes, activateReq)
+	if activateRes.Code != http.StatusOK {
+		t.Fatalf("llm settings activate status = %d body=%s", activateRes.Code, activateRes.Body.String())
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/admin/llm/settings/"+id, nil)
+	deleteReq.Header.Set("Authorization", "Bearer "+adminToken)
+	deleteRes := httptest.NewRecorder()
+	handler.ServeHTTP(deleteRes, deleteReq)
+	if deleteRes.Code != http.StatusNoContent {
+		t.Fatalf("llm settings delete status = %d body=%s", deleteRes.Code, deleteRes.Body.String())
 	}
 }

--- a/internal/prompts/llm_model_config.go
+++ b/internal/prompts/llm_model_config.go
@@ -1,0 +1,198 @@
+package prompts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+var (
+	ErrLLMModelConfigNotFound    = errors.New("llm model config not found")
+	ErrInvalidLLMModelConfigName = errors.New("llm model config name must not be empty")
+)
+
+type LLMModelConfigCreateRequest struct {
+	Name          string
+	Model         string
+	Temperature   float64
+	MaxTokens     int
+	TimeoutMS     int
+	RetryCount    int
+	BackoffMS     int
+	CooldownMS    int
+	MinConfidence float64
+	ActorID       string
+}
+
+type LLMModelConfig struct {
+	ID            string    `json:"id"`
+	Name          string    `json:"name"`
+	Model         string    `json:"model"`
+	Temperature   float64   `json:"temperature"`
+	MaxTokens     int       `json:"maxTokens"`
+	TimeoutMS     int       `json:"timeoutMs"`
+	RetryCount    int       `json:"retryCount"`
+	BackoffMS     int       `json:"backoffMs"`
+	CooldownMS    int       `json:"cooldownMs"`
+	MinConfidence float64   `json:"minConfidence"`
+	IsActive      bool      `json:"isActive"`
+	CreatedBy     string    `json:"createdBy"`
+	ActivatedBy   string    `json:"activatedBy,omitempty"`
+	CreatedAt     time.Time `json:"createdAt"`
+	ActivatedAt   time.Time `json:"activatedAt,omitempty"`
+}
+
+func validateLLMModelConfigRequest(req LLMModelConfigCreateRequest) error {
+	if strings.TrimSpace(req.Name) == "" {
+		return ErrInvalidLLMModelConfigName
+	}
+	if err := ValidateCreateRequest(CreateRequest{
+		Stage:         "llm_model_config",
+		Template:      "preset",
+		Model:         req.Model,
+		Temperature:   req.Temperature,
+		MaxTokens:     req.MaxTokens,
+		TimeoutMS:     req.TimeoutMS,
+		RetryCount:    req.RetryCount,
+		BackoffMS:     req.BackoffMS,
+		CooldownMS:    req.CooldownMS,
+		MinConfidence: req.MinConfidence,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) ListLLMModelConfigs(ctx context.Context) []LLMModelConfig {
+	if s.db != nil {
+		items, err := s.listLLMModelConfigsDB(ctx)
+		if err == nil {
+			return items
+		}
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := append([]LLMModelConfig(nil), s.modelConfigs...)
+	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.After(items[j].CreatedAt) })
+	return items
+}
+
+func (s *Service) CreateLLMModelConfig(ctx context.Context, req LLMModelConfigCreateRequest) (LLMModelConfig, error) {
+	if err := validateLLMModelConfigRequest(req); err != nil {
+		return LLMModelConfig{}, err
+	}
+	if s.db != nil {
+		return s.createLLMModelConfigDB(ctx, req)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC()
+	s.counter++
+	item := LLMModelConfig{
+		ID:            fmt.Sprintf("llm-model-config-%d", s.counter),
+		Name:          strings.TrimSpace(req.Name),
+		Model:         strings.TrimSpace(req.Model),
+		Temperature:   req.Temperature,
+		MaxTokens:     req.MaxTokens,
+		TimeoutMS:     req.TimeoutMS,
+		RetryCount:    req.RetryCount,
+		BackoffMS:     req.BackoffMS,
+		CooldownMS:    req.CooldownMS,
+		MinConfidence: req.MinConfidence,
+		CreatedBy:     strings.TrimSpace(req.ActorID),
+		CreatedAt:     now,
+		IsActive:      len(s.modelConfigs) == 0,
+	}
+	if item.IsActive {
+		item.ActivatedBy = item.CreatedBy
+		item.ActivatedAt = now
+	}
+	s.modelConfigs = append(s.modelConfigs, item)
+	return item, nil
+}
+
+func (s *Service) GetLLMModelConfig(ctx context.Context, id string) (LLMModelConfig, error) {
+	if s.db != nil {
+		return s.getLLMModelConfigDB(ctx, id)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	lookup := strings.TrimSpace(id)
+	for _, item := range s.modelConfigs {
+		if item.ID == lookup {
+			return item, nil
+		}
+	}
+	return LLMModelConfig{}, ErrLLMModelConfigNotFound
+}
+
+func (s *Service) UpdateLLMModelConfig(ctx context.Context, id string, req LLMModelConfigCreateRequest) (LLMModelConfig, error) {
+	if err := validateLLMModelConfigRequest(req); err != nil {
+		return LLMModelConfig{}, err
+	}
+	if s.db != nil {
+		return s.updateLLMModelConfigDB(ctx, id, req)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lookup := strings.TrimSpace(id)
+	for i := range s.modelConfigs {
+		if s.modelConfigs[i].ID != lookup {
+			continue
+		}
+		s.modelConfigs[i].Name = strings.TrimSpace(req.Name)
+		s.modelConfigs[i].Model = strings.TrimSpace(req.Model)
+		s.modelConfigs[i].Temperature = req.Temperature
+		s.modelConfigs[i].MaxTokens = req.MaxTokens
+		s.modelConfigs[i].TimeoutMS = req.TimeoutMS
+		s.modelConfigs[i].RetryCount = req.RetryCount
+		s.modelConfigs[i].BackoffMS = req.BackoffMS
+		s.modelConfigs[i].CooldownMS = req.CooldownMS
+		s.modelConfigs[i].MinConfidence = req.MinConfidence
+		return s.modelConfigs[i], nil
+	}
+	return LLMModelConfig{}, ErrLLMModelConfigNotFound
+}
+
+func (s *Service) DeleteLLMModelConfig(ctx context.Context, id string) error {
+	if s.db != nil {
+		return s.deleteLLMModelConfigDB(ctx, id)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lookup := strings.TrimSpace(id)
+	for i, item := range s.modelConfigs {
+		if item.ID != lookup {
+			continue
+		}
+		s.modelConfigs = append(s.modelConfigs[:i], s.modelConfigs[i+1:]...)
+		if item.IsActive && len(s.modelConfigs) > 0 {
+			s.modelConfigs[0].IsActive = true
+		}
+		return nil
+	}
+	return ErrLLMModelConfigNotFound
+}
+
+func (s *Service) ActivateLLMModelConfig(ctx context.Context, id, actorID string) (LLMModelConfig, error) {
+	if s.db != nil {
+		return s.activateLLMModelConfigDB(ctx, id, actorID)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lookup := strings.TrimSpace(id)
+	now := time.Now().UTC()
+	for i := range s.modelConfigs {
+		s.modelConfigs[i].IsActive = s.modelConfigs[i].ID == lookup
+		if s.modelConfigs[i].IsActive {
+			s.modelConfigs[i].ActivatedBy = strings.TrimSpace(actorID)
+			s.modelConfigs[i].ActivatedAt = now
+			return s.modelConfigs[i], nil
+		}
+	}
+	return LLMModelConfig{}, ErrLLMModelConfigNotFound
+}

--- a/internal/prompts/postgres_service.go
+++ b/internal/prompts/postgres_service.go
@@ -29,10 +29,35 @@ CREATE TABLE IF NOT EXISTS llm_scenario_packages (
     CHECK (char_length(name) > 0),
     CHECK (version > 0)
 );
+ALTER TABLE llm_scenario_packages
+    ADD COLUMN IF NOT EXISTS llm_model_config_id TEXT NOT NULL DEFAULT '';
 CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_scenario_packages_active_game
     ON llm_scenario_packages (game_slug) WHERE is_active;
 CREATE INDEX IF NOT EXISTS idx_llm_scenario_packages_order
     ON llm_scenario_packages (game_slug ASC, version DESC, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_scenario_packages_model_config
+    ON llm_scenario_packages (llm_model_config_id);
+CREATE TABLE IF NOT EXISTS llm_model_configs (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    model TEXT NOT NULL,
+    temperature DOUBLE PRECISION NOT NULL,
+    max_tokens INTEGER NOT NULL,
+    timeout_ms INTEGER NOT NULL,
+    retry_count INTEGER NOT NULL,
+    backoff_ms INTEGER NOT NULL,
+    cooldown_ms INTEGER NOT NULL,
+    min_confidence DOUBLE PRECISION NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by TEXT NOT NULL,
+    activated_by TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL,
+    activated_at TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_llm_model_configs_order
+    ON llm_model_configs (created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_model_configs_single_active
+    ON llm_model_configs (is_active) WHERE is_active;
 `
 
 func (s *Service) ensureSchema(ctx context.Context) error {
@@ -134,6 +159,7 @@ func scanScenarioPackage(row scanner) (ScenarioPackage, error) {
 		&item.Version,
 		&steps,
 		&transitions,
+		&item.LLMModelConfigID,
 		&item.IsActive,
 		&item.CreatedBy,
 		&item.ActivatedBy,
@@ -147,6 +173,21 @@ func scanScenarioPackage(row scanner) (ScenarioPackage, error) {
 	}
 	if err := json.Unmarshal(transitions, &item.Transitions); err != nil {
 		return ScenarioPackage{}, err
+	}
+	if activatedAt.Valid {
+		item.ActivatedAt = activatedAt.Time
+	}
+	return item, nil
+}
+
+func scanLLMModelConfig(row scanner) (LLMModelConfig, error) {
+	var item LLMModelConfig
+	var activatedAt sql.NullTime
+	if err := row.Scan(
+		&item.ID, &item.Name, &item.Model, &item.Temperature, &item.MaxTokens, &item.TimeoutMS, &item.RetryCount, &item.BackoffMS, &item.CooldownMS, &item.MinConfidence,
+		&item.IsActive, &item.CreatedBy, &item.ActivatedBy, &item.CreatedAt, &activatedAt,
+	); err != nil {
+		return LLMModelConfig{}, err
 	}
 	if activatedAt.Valid {
 		item.ActivatedAt = activatedAt.Time
@@ -758,7 +799,7 @@ func (s *Service) listScenarioPackagesDB(ctx context.Context) ([]ScenarioPackage
 	if err := s.ensureSchema(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages ORDER BY game_slug ASC, version DESC, created_at DESC`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, game_slug, name, version, steps_json, transitions_json, llm_model_config_id, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages ORDER BY game_slug ASC, version DESC, created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -812,15 +853,16 @@ func (s *Service) createScenarioPackageDB(ctx context.Context, req ScenarioPacka
 		return ScenarioPackage{}, err
 	}
 	item := ScenarioPackage{
-		ID:          "scenario-pkg-" + uuid.NewString(),
-		Name:        strings.TrimSpace(req.Name),
-		GameSlug:    gameSlug,
-		Version:     version,
-		Steps:       normalizedSteps,
-		Transitions: append([]ScenarioTransition(nil), transitions...),
-		IsActive:    existing == 0,
-		CreatedBy:   strings.TrimSpace(req.ActorID),
-		CreatedAt:   now,
+		ID:               "scenario-pkg-" + uuid.NewString(),
+		Name:             strings.TrimSpace(req.Name),
+		GameSlug:         gameSlug,
+		Version:          version,
+		LLMModelConfigID: strings.TrimSpace(req.LLMModelConfigID),
+		Steps:            normalizedSteps,
+		Transitions:      append([]ScenarioTransition(nil), transitions...),
+		IsActive:         existing == 0,
+		CreatedBy:        strings.TrimSpace(req.ActorID),
+		CreatedAt:        now,
 	}
 	if item.IsActive {
 		item.ActivatedBy = item.CreatedBy
@@ -828,8 +870,8 @@ func (s *Service) createScenarioPackageDB(ctx context.Context, req ScenarioPacka
 	}
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO llm_scenario_packages (id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
-		item.ID, item.GameSlug, item.Name, item.Version, stepsJSON, transitionsJSON, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt),
+		`INSERT INTO llm_scenario_packages (id, game_slug, name, version, steps_json, transitions_json, llm_model_config_id, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+		item.ID, item.GameSlug, item.Name, item.Version, stepsJSON, transitionsJSON, item.LLMModelConfigID, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt),
 	); err != nil {
 		return ScenarioPackage{}, err
 	}
@@ -847,7 +889,7 @@ func (s *Service) getActiveScenarioPackageDB(ctx context.Context, gameSlug strin
 	if key == "" {
 		key = "global"
 	}
-	item, err := scanScenarioPackage(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, key))
+	item, err := scanScenarioPackage(s.db.QueryRowContext(ctx, `SELECT id, game_slug, name, version, steps_json, transitions_json, llm_model_config_id, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`, key))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return ScenarioPackage{}, ErrScenarioPackageNotFound
@@ -863,7 +905,7 @@ func (s *Service) getScenarioPackageDB(ctx context.Context, id string) (Scenario
 	}
 	item, err := scanScenarioPackage(s.db.QueryRowContext(
 		ctx,
-		`SELECT id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages WHERE id = $1`,
+		`SELECT id, game_slug, name, version, steps_json, transitions_json, llm_model_config_id, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages WHERE id = $1`,
 		strings.TrimSpace(id),
 	))
 	if err != nil {
@@ -937,16 +979,18 @@ func (s *Service) updateScenarioPackageDB(ctx context.Context, id string, req Sc
 			    name = $3,
 			    steps_json = $4,
 			    transitions_json = $5,
-			    is_active = $6,
-			    activated_by = $7,
-			    activated_at = $8
+			    llm_model_config_id = $6,
+			    is_active = $7,
+			    activated_by = $8,
+			    activated_at = $9
 		 WHERE id = $1
-		 RETURNING id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at`,
+		 RETURNING id, game_slug, name, version, steps_json, transitions_json, llm_model_config_id, is_active, created_by, activated_by, created_at, activated_at`,
 		strings.TrimSpace(id),
 		gameSlug,
 		strings.TrimSpace(req.Name),
 		stepsJSON,
 		transitionsJSON,
+		strings.TrimSpace(req.LLMModelConfigID),
 		nextIsActive,
 		nextActivatedBy,
 		nextActivatedAt,
@@ -1019,7 +1063,7 @@ func (s *Service) activateScenarioPackageDB(ctx context.Context, id, actorID str
 	}
 	item, err := scanScenarioPackage(tx.QueryRowContext(
 		ctx,
-		`UPDATE llm_scenario_packages SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at`,
+		`UPDATE llm_scenario_packages SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, game_slug, name, version, steps_json, transitions_json, llm_model_config_id, is_active, created_by, activated_by, created_at, activated_at`,
 		strings.TrimSpace(id),
 		strings.TrimSpace(actorID),
 		time.Now().UTC(),
@@ -1032,6 +1076,137 @@ func (s *Service) activateScenarioPackageDB(ctx context.Context, id, actorID str
 	}
 	if err := tx.Commit(); err != nil {
 		return ScenarioPackage{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) listLLMModelConfigsDB(ctx context.Context) ([]LLMModelConfig, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, model, temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at FROM llm_model_configs ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := make([]LLMModelConfig, 0)
+	for rows.Next() {
+		item, err := scanLLMModelConfig(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *Service) createLLMModelConfigDB(ctx context.Context, req LLMModelConfigCreateRequest) (LLMModelConfig, error) {
+	if err := validateLLMModelConfigRequest(req); err != nil {
+		return LLMModelConfig{}, err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return LLMModelConfig{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return LLMModelConfig{}, err
+	}
+	defer tx.Rollback()
+	var existing int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM llm_model_configs`).Scan(&existing); err != nil {
+		return LLMModelConfig{}, err
+	}
+	now := time.Now().UTC()
+	item := LLMModelConfig{ID: "llm-model-config-" + uuid.NewString(), Name: strings.TrimSpace(req.Name), Model: strings.TrimSpace(req.Model), Temperature: req.Temperature, MaxTokens: req.MaxTokens, TimeoutMS: req.TimeoutMS, RetryCount: req.RetryCount, BackoffMS: req.BackoffMS, CooldownMS: req.CooldownMS, MinConfidence: req.MinConfidence, IsActive: existing == 0, CreatedBy: strings.TrimSpace(req.ActorID), CreatedAt: now}
+	if item.IsActive {
+		item.ActivatedBy = item.CreatedBy
+		item.ActivatedAt = now
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO llm_model_configs (id, name, model, temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`, item.ID, item.Name, item.Model, item.Temperature, item.MaxTokens, item.TimeoutMS, item.RetryCount, item.BackoffMS, item.CooldownMS, item.MinConfidence, item.IsActive, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt)); err != nil {
+		return LLMModelConfig{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return LLMModelConfig{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) getLLMModelConfigDB(ctx context.Context, id string) (LLMModelConfig, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return LLMModelConfig{}, err
+	}
+	item, err := scanLLMModelConfig(s.db.QueryRowContext(ctx, `SELECT id, name, model, temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at FROM llm_model_configs WHERE id = $1`, strings.TrimSpace(id)))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return LLMModelConfig{}, ErrLLMModelConfigNotFound
+		}
+		return LLMModelConfig{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) updateLLMModelConfigDB(ctx context.Context, id string, req LLMModelConfigCreateRequest) (LLMModelConfig, error) {
+	if err := validateLLMModelConfigRequest(req); err != nil {
+		return LLMModelConfig{}, err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return LLMModelConfig{}, err
+	}
+	item, err := scanLLMModelConfig(s.db.QueryRowContext(ctx, `UPDATE llm_model_configs SET name = $2, model = $3, temperature = $4, max_tokens = $5, timeout_ms = $6, retry_count = $7, backoff_ms = $8, cooldown_ms = $9, min_confidence = $10 WHERE id = $1 RETURNING id, name, model, temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at`, strings.TrimSpace(id), strings.TrimSpace(req.Name), strings.TrimSpace(req.Model), req.Temperature, req.MaxTokens, req.TimeoutMS, req.RetryCount, req.BackoffMS, req.CooldownMS, req.MinConfidence))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return LLMModelConfig{}, ErrLLMModelConfigNotFound
+		}
+		return LLMModelConfig{}, err
+	}
+	return item, nil
+}
+
+func (s *Service) deleteLLMModelConfigDB(ctx context.Context, id string) error {
+	if err := s.ensureSchema(ctx); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var wasActive bool
+	if err := tx.QueryRowContext(ctx, `DELETE FROM llm_model_configs WHERE id = $1 RETURNING is_active`, strings.TrimSpace(id)).Scan(&wasActive); err != nil {
+		if err == sql.ErrNoRows {
+			return ErrLLMModelConfigNotFound
+		}
+		return err
+	}
+	if wasActive {
+		if _, err := tx.ExecContext(ctx, `UPDATE llm_model_configs SET is_active = TRUE WHERE id = (SELECT id FROM llm_model_configs ORDER BY created_at DESC LIMIT 1)`); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *Service) activateLLMModelConfigDB(ctx context.Context, id, actorID string) (LLMModelConfig, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return LLMModelConfig{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return LLMModelConfig{}, err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `UPDATE llm_model_configs SET is_active = FALSE`); err != nil {
+		return LLMModelConfig{}, err
+	}
+	item, err := scanLLMModelConfig(tx.QueryRowContext(ctx, `UPDATE llm_model_configs SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 RETURNING id, name, model, temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at`, strings.TrimSpace(id), strings.TrimSpace(actorID), time.Now().UTC()))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return LLMModelConfig{}, ErrLLMModelConfigNotFound
+		}
+		return LLMModelConfig{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return LLMModelConfig{}, err
 	}
 	return item, nil
 }

--- a/internal/prompts/postgres_service_test.go
+++ b/internal/prompts/postgres_service_test.go
@@ -192,16 +192,17 @@ func TestPostgresServiceCreateScenarioPackage(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) FROM llm_scenario_packages WHERE game_slug = $1`)).
 		WithArgs("global").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO llm_scenario_packages (id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`)).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO llm_scenario_packages (id, game_slug, name, version, steps_json, transitions_json, llm_model_config_id, is_active, created_by, activated_by, created_at, activated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
 	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:     "global-flow",
-		GameSlug: "global",
-		ActorID:  "admin-1",
+		Name:             "global-flow",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: "cfg-1",
 		Steps: []ScenarioStep{
-			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Initial: true},
+			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true},
 		},
 	})
 	if err != nil {
@@ -225,10 +226,10 @@ func TestPostgresServiceGetActiveScenarioPackage(t *testing.T) {
 	svc := NewPostgresService(db)
 	now := time.Date(2026, 3, 27, 12, 0, 0, 0, time.UTC)
 	mock.ExpectExec(regexp.QuoteMeta(trackerConfigDDL)).WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, game_slug, name, version, steps_json, transitions_json, llm_model_config_id, is_active, created_by, activated_by, created_at, activated_at FROM llm_scenario_packages WHERE game_slug = $1 AND is_active = TRUE ORDER BY version DESC LIMIT 1`)).
 		WithArgs("global").
-		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "version", "steps_json", "transitions_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
-			AddRow("scenario-pkg-1", "global", "global-flow", 1, `[{"id":"game_detect","name":"Game detect","promptTemplate":"detect","responseSchemaJson":"{}","initial":true,"order":1}]`, `[]`, true, "admin-1", "admin-1", now, now))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "version", "steps_json", "transitions_json", "llm_model_config_id", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
+			AddRow("scenario-pkg-1", "global", "global-flow", 1, `[{"id":"game_detect","name":"Game detect","promptTemplate":"detect","responseSchemaJson":"{}","initial":true,"order":1}]`, `[]`, "cfg-1", true, "admin-1", "admin-1", now, now))
 
 	item, err := svc.GetActiveScenarioPackage(context.Background(), "global")
 	if err != nil {
@@ -265,22 +266,24 @@ func TestPostgresServiceUpdateScenarioPackageCrossGameDeactivates(t *testing.T) 
 			    name = $3,
 			    steps_json = $4,
 			    transitions_json = $5,
-			    is_active = $6,
-			    activated_by = $7,
-			    activated_at = $8
+			    llm_model_config_id = $6,
+			    is_active = $7,
+			    activated_by = $8,
+			    activated_at = $9
 		 WHERE id = $1
-		 RETURNING id, game_slug, name, version, steps_json, transitions_json, is_active, created_by, activated_by, created_at, activated_at`)).
-		WithArgs("scenario-pkg-1", "cs2", "cs2-flow", sqlmock.AnyArg(), sqlmock.AnyArg(), false, "", nil).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "version", "steps_json", "transitions_json", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
-			AddRow("scenario-pkg-1", "cs2", "cs2-flow", 1, `[{"id":"cs2_mode","name":"CS2 mode","gameSlug":"cs2","promptTemplate":"mode","responseSchemaJson":"{}","initial":true,"order":1}]`, `[]`, false, "admin-1", "", now, nil))
+		 RETURNING id, game_slug, name, version, steps_json, transitions_json, llm_model_config_id, is_active, created_by, activated_by, created_at, activated_at`)).
+		WithArgs("scenario-pkg-1", "cs2", "cs2-flow", sqlmock.AnyArg(), sqlmock.AnyArg(), "cfg-2", false, "", nil).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "game_slug", "name", "version", "steps_json", "transitions_json", "llm_model_config_id", "is_active", "created_by", "activated_by", "created_at", "activated_at"}).
+			AddRow("scenario-pkg-1", "cs2", "cs2-flow", 1, `[{"id":"cs2_mode","name":"CS2 mode","gameSlug":"cs2","promptTemplate":"mode","responseSchemaJson":"{}","initial":true,"order":1}]`, `[]`, "cfg-2", false, "admin-1", "", now, nil))
 	mock.ExpectCommit()
 
 	item, err := svc.UpdateScenarioPackage(context.Background(), "scenario-pkg-1", ScenarioPackageCreateRequest{
-		Name:     "cs2-flow",
-		GameSlug: "cs2",
-		ActorID:  "admin-2",
+		Name:             "cs2-flow",
+		GameSlug:         "cs2",
+		ActorID:          "admin-2",
+		LLMModelConfigID: "cfg-2",
 		Steps: []ScenarioStep{
-			{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", Model: "gemini-2.0-flash", ResponseSchemaJSON: "{}", Initial: true},
+			{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", ResponseSchemaJSON: "{}", Initial: true},
 		},
 	})
 	if err != nil {

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -12,12 +12,12 @@ import (
 )
 
 var (
-	ErrScenarioPackageNotFound  = errors.New("scenario package not found")
-	ErrScenarioStepNotFound     = errors.New("scenario step not found")
-	ErrInvalidScenarioPackage   = errors.New("scenario package must contain at least one step")
-	ErrInvalidScenarioStepID    = errors.New("scenario step id must not be empty")
-	ErrInvalidScenarioStepModel = errors.New("scenario step model must not be empty")
-	ErrInvalidScenarioName      = errors.New("scenario package name must not be empty")
+	ErrScenarioPackageNotFound = errors.New("scenario package not found")
+	ErrScenarioStepNotFound    = errors.New("scenario step not found")
+	ErrInvalidScenarioPackage  = errors.New("scenario package must contain at least one step")
+	ErrInvalidScenarioStepID   = errors.New("scenario step id must not be empty")
+	ErrInvalidScenarioModelID  = errors.New("scenario package llmModelConfigId must not be empty")
+	ErrInvalidScenarioName     = errors.New("scenario package name must not be empty")
 )
 
 type ScenarioStep struct {
@@ -27,14 +27,11 @@ type ScenarioStep struct {
 	Folder             string    `json:"folder"`
 	EntryCondition     string    `json:"entryCondition,omitempty"`
 	PromptTemplate     string    `json:"promptTemplate"`
-	Model              string    `json:"model"`
 	ResponseSchemaJSON string    `json:"responseSchemaJson"`
 	Initial            bool      `json:"initial"`
 	Order              int       `json:"order"`
 	CreatedAt          time.Time `json:"createdAt"`
 }
-
-const DefaultScenarioStepModel = "gemini-2.0-flash"
 
 type ScenarioTransition struct {
 	FromStepID string `json:"fromStepId"`
@@ -44,17 +41,18 @@ type ScenarioTransition struct {
 }
 
 type ScenarioPackage struct {
-	ID          string               `json:"id"`
-	Name        string               `json:"name"`
-	Version     int                  `json:"version"`
-	GameSlug    string               `json:"gameSlug"`
-	IsActive    bool                 `json:"isActive"`
-	Steps       []ScenarioStep       `json:"steps"`
-	Transitions []ScenarioTransition `json:"transitions"`
-	CreatedBy   string               `json:"createdBy"`
-	ActivatedBy string               `json:"activatedBy,omitempty"`
-	CreatedAt   time.Time            `json:"createdAt"`
-	ActivatedAt time.Time            `json:"activatedAt,omitempty"`
+	ID               string               `json:"id"`
+	Name             string               `json:"name"`
+	Version          int                  `json:"version"`
+	GameSlug         string               `json:"gameSlug"`
+	LLMModelConfigID string               `json:"llmModelConfigId"`
+	IsActive         bool                 `json:"isActive"`
+	Steps            []ScenarioStep       `json:"steps"`
+	Transitions      []ScenarioTransition `json:"transitions"`
+	CreatedBy        string               `json:"createdBy"`
+	ActivatedBy      string               `json:"activatedBy,omitempty"`
+	CreatedAt        time.Time            `json:"createdAt"`
+	ActivatedAt      time.Time            `json:"activatedAt,omitempty"`
 }
 
 type ScenarioGraphNode struct {
@@ -94,10 +92,11 @@ type ScenarioPackageGraph struct {
 }
 
 type ScenarioPackageCreateRequest struct {
-	Name     string
-	GameSlug string
-	Steps    []ScenarioStep
-	ActorID  string
+	Name             string
+	GameSlug         string
+	LLMModelConfigID string
+	Steps            []ScenarioStep
+	ActorID          string
 }
 
 func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) error {
@@ -107,14 +106,14 @@ func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) erro
 	if len(req.Steps) == 0 {
 		return ErrInvalidScenarioPackage
 	}
+	if strings.TrimSpace(req.LLMModelConfigID) == "" {
+		return ErrInvalidScenarioModelID
+	}
 	seenSteps := make(map[string]struct{}, len(req.Steps))
 	for _, step := range req.Steps {
 		id := strings.TrimSpace(step.ID)
 		if id == "" {
 			return ErrInvalidScenarioStepID
-		}
-		if strings.TrimSpace(step.Model) == "" {
-			return ErrInvalidScenarioStepModel
 		}
 		seenSteps[id] = struct{}{}
 	}
@@ -210,14 +209,15 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 	s.counter++
 	version := len(s.scenarioPackages[gameSlug]) + 1
 	item := ScenarioPackage{
-		ID:          fmt.Sprintf("scenario-pkg-%d", s.counter),
-		Name:        strings.TrimSpace(req.Name),
-		Version:     version,
-		GameSlug:    gameSlug,
-		Steps:       append([]ScenarioStep(nil), req.Steps...),
-		Transitions: append([]ScenarioTransition(nil), normalizedTransitions...),
-		CreatedBy:   strings.TrimSpace(req.ActorID),
-		CreatedAt:   now,
+		ID:               fmt.Sprintf("scenario-pkg-%d", s.counter),
+		Name:             strings.TrimSpace(req.Name),
+		Version:          version,
+		GameSlug:         gameSlug,
+		LLMModelConfigID: strings.TrimSpace(req.LLMModelConfigID),
+		Steps:            append([]ScenarioStep(nil), req.Steps...),
+		Transitions:      append([]ScenarioTransition(nil), normalizedTransitions...),
+		CreatedBy:        strings.TrimSpace(req.ActorID),
+		CreatedAt:        now,
 	}
 	if len(s.scenarioPackages[gameSlug]) == 0 {
 		item.IsActive = true
@@ -271,6 +271,7 @@ func (s *Service) UpdateScenarioPackage(ctx context.Context, id string, req Scen
 			updated := item
 			updated.Name = strings.TrimSpace(req.Name)
 			updated.GameSlug = targetGameSlug
+			updated.LLMModelConfigID = strings.TrimSpace(req.LLMModelConfigID)
 			updated.Steps = append([]ScenarioStep(nil), req.Steps...)
 			updated.Transitions = append([]ScenarioTransition(nil), normalizedTransitions...)
 			if updated.GameSlug != gameSlug {

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -10,13 +10,14 @@ func TestScenarioPackageResolveStep(t *testing.T) {
 
 	svc := NewService()
 	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:     "cs2 flow",
-		GameSlug: "global",
-		ActorID:  "admin-1",
+		Name:             "cs2 flow",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: "cfg-1",
 		Steps: []ScenarioStep{
-			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-			{ID: "cs2_mode", Name: "CS2 mode", Folder: "cs2", EntryCondition: "game == cs2", PromptTemplate: "mode", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Order: 2},
-			{ID: "cs2_faceit", Name: "Faceit", Folder: "cs2/faceit", EntryCondition: "mode == faceit", PromptTemplate: "faceit", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Order: 3},
+			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "cs2_mode", Name: "CS2 mode", Folder: "cs2", EntryCondition: "game == cs2", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
+			{ID: "cs2_faceit", Name: "Faceit", Folder: "cs2/faceit", EntryCondition: "mode == faceit", PromptTemplate: "faceit", ResponseSchemaJSON: `{}`, Order: 3},
 		},
 	})
 	if err != nil {
@@ -155,11 +156,12 @@ func TestScenarioPackageUpdateAcrossGameDeactivatesAndNormalizesSteps(t *testing
 
 	svc := NewService()
 	created, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:     "global flow",
-		GameSlug: "global",
-		ActorID:  "admin-1",
+		Name:             "global flow",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: "cfg-1",
 		Steps: []ScenarioStep{
-			{ID: "root_detect", Name: "Root", PromptTemplate: "detect", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Initial: true},
+			{ID: "root_detect", Name: "Root", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true},
 		},
 	})
 	if err != nil {
@@ -170,11 +172,12 @@ func TestScenarioPackageUpdateAcrossGameDeactivatesAndNormalizesSteps(t *testing
 	}
 
 	updated, err := svc.UpdateScenarioPackage(context.Background(), created.ID, ScenarioPackageCreateRequest{
-		Name:     "cs2 flow",
-		GameSlug: "cs2",
-		ActorID:  "admin-1",
+		Name:             "cs2 flow",
+		GameSlug:         "cs2",
+		ActorID:          "admin-1",
+		LLMModelConfigID: "cfg-1",
 		Steps: []ScenarioStep{
-			{ID: "cs2_mode", Name: "Mode", PromptTemplate: "mode", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`},
+			{ID: "cs2_mode", Name: "Mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`},
 		},
 	})
 	if err != nil {
@@ -199,13 +202,14 @@ func TestScenarioPackageCreateAutowiresTransitionsWhenMissing(t *testing.T) {
 
 	svc := NewService()
 	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:     "auto transitions",
-		GameSlug: "global",
-		ActorID:  "admin-1",
+		Name:             "auto transitions",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: "cfg-1",
 		Steps: []ScenarioStep{
-			{ID: "step_a", Name: "Step A", PromptTemplate: "a", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-			{ID: "step_b", Name: "Step B", PromptTemplate: "b", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, EntryCondition: "mode == faceit", Order: 2},
-			{ID: "step_c", Name: "Step C", PromptTemplate: "c", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Order: 3},
+			{ID: "step_a", Name: "Step A", PromptTemplate: "a", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "step_b", Name: "Step B", PromptTemplate: "b", ResponseSchemaJSON: `{}`, EntryCondition: "mode == faceit", Order: 2},
+			{ID: "step_c", Name: "Step C", PromptTemplate: "c", ResponseSchemaJSON: `{}`, Order: 3},
 		},
 	})
 	if err != nil {
@@ -239,37 +243,39 @@ func TestScenarioPackageCreateAutowiresTransitionsWhenMissing(t *testing.T) {
 	}
 }
 
-func TestScenarioPackageCreateRequiresStepModelAndPreservesConfiguredValue(t *testing.T) {
+func TestScenarioPackageCreateRequiresModelConfigID(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService()
 	_, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:     "model defaults",
-		GameSlug: "global",
-		ActorID:  "admin-1",
+		Name:             "config defaults",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: "",
 		Steps: []ScenarioStep{
 			{ID: "step_missing_model", Name: "Missing model", PromptTemplate: "a", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
 		},
 	})
 	if err == nil {
-		t.Fatalf("expected missing model validation error")
+		t.Fatalf("expected missing llm model config validation error")
 	}
-	if err != ErrInvalidScenarioStepModel {
-		t.Fatalf("expected ErrInvalidScenarioStepModel, got %v", err)
+	if err != ErrInvalidScenarioModelID {
+		t.Fatalf("expected ErrInvalidScenarioModelID, got %v", err)
 	}
 
 	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:     "model configured",
-		GameSlug: "global",
-		ActorID:  "admin-1",
+		Name:             "config configured",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: "cfg-1",
 		Steps: []ScenarioStep{
-			{ID: "step_custom_model", Name: "Custom model", PromptTemplate: "b", Model: "gemini-2.5-flash", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "step_custom_model", Name: "Custom model", PromptTemplate: "b", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
 		},
 	})
 	if err != nil {
 		t.Fatalf("create scenario package: %v", err)
 	}
-	if got := item.Steps[0].Model; got != "gemini-2.5-flash" {
-		t.Fatalf("expected custom model to be preserved, got %q", got)
+	if got := item.LLMModelConfigID; got != "cfg-1" {
+		t.Fatalf("expected llm model config id to be preserved, got %q", got)
 	}
 }

--- a/internal/prompts/service.go
+++ b/internal/prompts/service.go
@@ -18,6 +18,7 @@ type Service struct {
 	stateSchemas     map[string][]StateSchemaVersion
 	ruleSets         map[string][]RuleSetVersion
 	scenarioPackages map[string][]ScenarioPackage
+	modelConfigs     []LLMModelConfig
 	db               *sql.DB
 	schemaMu         sync.Mutex
 	schemaReady      bool
@@ -29,6 +30,7 @@ func NewService() *Service {
 		stateSchemas:     map[string][]StateSchemaVersion{},
 		ruleSets:         map[string][]RuleSetVersion{},
 		scenarioPackages: map[string][]ScenarioPackage{},
+		modelConfigs:     []LLMModelConfig{},
 	}
 }
 
@@ -38,6 +40,7 @@ func NewPostgresService(db *sql.DB) *Service {
 		stateSchemas:     map[string][]StateSchemaVersion{},
 		ruleSets:         map[string][]RuleSetVersion{},
 		scenarioPackages: map[string][]ScenarioPackage{},
+		modelConfigs:     []LLMModelConfig{},
 		db:               db,
 	}
 }

--- a/migrations/0008_llm_model_configs_and_scenario_binding.down.sql
+++ b/migrations/0008_llm_model_configs_and_scenario_binding.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_llm_scenario_packages_model_config;
+ALTER TABLE llm_scenario_packages DROP COLUMN IF EXISTS llm_model_config_id;
+
+DROP INDEX IF EXISTS idx_llm_model_configs_single_active;
+DROP INDEX IF EXISTS idx_llm_model_configs_order;
+DROP TABLE IF EXISTS llm_model_configs;

--- a/migrations/0008_llm_model_configs_and_scenario_binding.up.sql
+++ b/migrations/0008_llm_model_configs_and_scenario_binding.up.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS llm_model_configs (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    model TEXT NOT NULL,
+    temperature DOUBLE PRECISION NOT NULL,
+    max_tokens INTEGER NOT NULL,
+    timeout_ms INTEGER NOT NULL,
+    retry_count INTEGER NOT NULL,
+    backoff_ms INTEGER NOT NULL,
+    cooldown_ms INTEGER NOT NULL,
+    min_confidence DOUBLE PRECISION NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by TEXT NOT NULL,
+    activated_by TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL,
+    activated_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_model_configs_order
+    ON llm_model_configs (created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_model_configs_single_active
+    ON llm_model_configs (is_active) WHERE is_active;
+
+ALTER TABLE llm_scenario_packages
+    ADD COLUMN IF NOT EXISTS llm_model_config_id TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_llm_scenario_packages_model_config
+    ON llm_scenario_packages (llm_model_config_id);


### PR DESCRIPTION
### Motivation

- Centralize LLM model runtime settings into named profiles and stop embedding model identifiers on each scenario step. 
- Allow admins to manage model profiles (CRUD + activate) and bind scenario packages to a chosen profile so packages use a consistent LLM configuration.

### Description

- Introduce `LLMModelConfig` types and service methods in `internal/prompts` including `CreateLLMModelConfig`, `ListLLMModelConfigs`, `Get/Update/Delete/ActivateLLMModelConfig` with in-memory and Postgres backing. 
- Update scenario package model to add `LLMModelConfigID` and remove per-step `Model` field, update validation in `ValidateScenarioPackageCreateRequest`, normalization, creation and update flows across `scenario_flow.go`, `service.go` and DB code. 
- Add admin HTTP endpoints under `/api/admin/llm/settings` (list, create, get, update, delete, activate) and wire handlers in `internal/app/router.go`, plus OpenAPI updates in `docs/openapi.yaml`. 
- Add DB migration and schema changes: new `llm_model_configs` table, `llm_model_config_id` column on `llm_scenario_packages`, updated SQL queries and scan helpers in `internal/prompts/postgres_service.go`.

### Testing

- Unit tests were added/updated for admin routes (`TestAdminLLMSettingsRoutes`, `TestAdminLLMScenarioPackageRoutes`) and prompts logic (`scenario_flow` and `postgres_service` tests) to validate creation, listing, updating, activation and deletion flows. 
- Postgres-related unit tests were updated to expect the new `llm_model_config_id` column and new queries. 
- All modified and added automated tests were executed and passed locally (unit test suite for `internal/app` and `internal/prompts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c800f19634832ca0b5a47b70877d67)