### PR TITLE
Fix vet/build failures in media worker and admin LLM tests

### DIFF
--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"context"
+
 	"go.uber.org/zap"
 
 	"github.com/funpot/funpot-go-core/internal/admin"
@@ -16,7 +18,7 @@ import (
 
 func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	promptsService := prompts.NewService()
-	cfg, err := promptsService.CreateLLMModelConfig(t.Context(), prompts.LLMModelConfigCreateRequest{
+	cfg, err := promptsService.CreateLLMModelConfig(context.Background(), prompts.LLMModelConfigCreateRequest{
 		Name:          "default",
 		Model:         "gemini-2.5-flash",
 		Temperature:   0.2,

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -768,6 +768,10 @@ type activeStateSchemaResolver interface {
 	GetActiveStateSchema(ctx context.Context, gameSlug string) (prompts.StateSchemaVersion, error)
 }
 
+type llmModelConfigResolver interface {
+	GetLLMModelConfig(ctx context.Context, id string) (prompts.LLMModelConfig, error)
+}
+
 func (w *Worker) resolveTrackerConfig(ctx context.Context) string {
 	const gameSlug = "cs2"
 	var stateSchema string
@@ -816,11 +820,12 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 		ID:       step.ID,
 		Stage:    step.ID,
 		Template: step.PromptTemplate,
-		Model:    strings.TrimSpace(step.Model),
 		IsActive: true,
 	}
-	if activePrompt.Model == "" {
-		activePrompt.Model = prompts.DefaultScenarioStepModel
+	if resolver, ok := w.prompts.(llmModelConfigResolver); ok {
+		if cfg, resolveErr := resolver.GetLLMModelConfig(ctx, pkg.LLMModelConfigID); resolveErr == nil {
+			activePrompt.Model = strings.TrimSpace(cfg.Model)
+		}
 	}
 	stateSchema := w.resolveTrackerConfig(ctx)
 	result, err := w.classifyWithRetry(ctx, StageRequest{

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -43,11 +43,13 @@ func (f fakeClassifier) Classify(_ context.Context, input StageRequest) (StageCl
 }
 
 type fakePromptResolver struct {
-	prompts      []prompts.PromptVersion
-	scenario     prompts.ScenarioPackage
-	scenarioErr  error
-	activeSchema prompts.StateSchemaVersion
-	schemaErr    error
+	prompts        []prompts.PromptVersion
+	scenario       prompts.ScenarioPackage
+	scenarioErr    error
+	activeSchema   prompts.StateSchemaVersion
+	schemaErr      error
+	llmModelConfig prompts.LLMModelConfig
+	llmConfigErr   error
 }
 
 func (f fakePromptResolver) ListActive(_ context.Context) []prompts.PromptVersion {
@@ -78,7 +80,6 @@ func (f fakePromptResolver) GetActiveScenarioPackage(_ context.Context, _ string
 			ID:                 stepID,
 			Name:               stepID,
 			PromptTemplate:     prompt.Template,
-			Model:              strings.TrimSpace(prompt.Model),
 			ResponseSchemaJSON: "{}",
 			Initial:            i == 0,
 			Order:              i + 1,
@@ -92,13 +93,29 @@ func (f fakePromptResolver) GetActiveScenarioPackage(_ context.Context, _ string
 		}
 	}
 	return prompts.ScenarioPackage{
-		ID:          "scenario-test",
-		GameSlug:    "global",
-		Name:        "generated",
-		Steps:       steps,
-		Transitions: transitions,
-		IsActive:    true,
+		ID:               "scenario-test",
+		GameSlug:         "global",
+		Name:             "generated",
+		LLMModelConfigID: "cfg-test",
+		Steps:            steps,
+		Transitions:      transitions,
+		IsActive:         true,
 	}, nil
+}
+
+func (f fakePromptResolver) GetLLMModelConfig(_ context.Context, _ string) (prompts.LLMModelConfig, error) {
+	if f.llmConfigErr != nil {
+		return prompts.LLMModelConfig{}, f.llmConfigErr
+	}
+	if strings.TrimSpace(f.llmModelConfig.Model) != "" {
+		return f.llmModelConfig, nil
+	}
+	for _, prompt := range f.prompts {
+		if model := strings.TrimSpace(prompt.Model); model != "" {
+			return prompts.LLMModelConfig{ID: "cfg-test", Model: model}, nil
+		}
+	}
+	return prompts.LLMModelConfig{}, prompts.ErrLLMModelConfigNotFound
 }
 
 func (f fakePromptResolver) GetActiveStateSchema(_ context.Context, _ string) (prompts.StateSchemaVersion, error) {
@@ -244,8 +261,8 @@ func TestWorkerProcessStreamerResetsToInitialStepWhenLatestStepMissingInActivePa
 			GameSlug: "global",
 			Name:     "v2",
 			Steps: []prompts.ScenarioStep{
-				{ID: "root_detect", Name: "Root detect", PromptTemplate: "detect", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-				{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", Model: "gemini-2.0-flash", ResponseSchemaJSON: `{}`, Order: 2},
+				{ID: "root_detect", Name: "Root detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+				{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
 			},
 			Transitions: []prompts.ScenarioTransition{
 				{FromStepID: "root_detect", ToStepID: "cs2_mode", Condition: `$.game == "cs2"`, Priority: 1},


### PR DESCRIPTION
### Motivation
- CI was failing `vet`/build due to removed `ScenarioStep.Model` and `DefaultScenarioStepModel` references in the scenario worker and due to use of `t.Context()` in tests which is unavailable in the current toolchain.
- The runtime should derive LLM model configuration from package-level `LLMModelConfigID` rather than relying on a now-removed per-step `Model` field.
- Tests needed alignment with the updated `ScenarioStep` schema so the media worker and admin router tests compile and run.

### Description
- Added a local `llmModelConfigResolver` interface and updated `processScenarioPackage` in `internal/media/worker.go` to resolve the model via `GetLLMModelConfig(ctx, pkg.LLMModelConfigID)` instead of reading `step.Model`, and removed the `DefaultScenarioStepModel` fallback usage.
- Updated `internal/app/router_admin_llm_test.go` to use `context.Background()` and added the `context` import to replace `t.Context()` usage.
- Adjusted `internal/media/worker_test.go` to reflect the `ScenarioStep` schema change by removing per-step `Model` fields, setting `LLMModelConfigID` on generated scenario packages, and adding a fake `GetLLMModelConfig` resolver to tests.
- Formatted changed files and committed the updates.

### Testing
- Ran `go test ./...` and all packages passed, including `internal/media` tests which now compile and run successfully.
- Ran `go vet ./...` and it completed with no reported issues.
- Checklist aligned to implementation priorities: [x] M2.1: compilation/vet blockers fixed; [x] scenario-graph v2 immediate scope: worker uses package-level `LLMModelConfigID` for model resolution; [ ] M2.1: full scenario-graph v2 transition coverage remains to be implemented; [ ] Additional e2e and multi-level transition tests to expand coverage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c815798350832c902846c85b07ddfe)