### PR TITLE
Simplify state merge to always prefer LLM output for non-map values and update tests

### DIFF
--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -597,50 +597,8 @@ func mergeStateValue(previous, current any) any {
 			merged[key] = mergeStateValue(previousTyped[key], item)
 		}
 		return merged
-	case []any:
-		if len(currentTyped) == 0 {
-			if previousTyped, ok := previous.([]any); ok && len(previousTyped) > 0 {
-				return previousTyped
-			}
-		}
-		return currentTyped
-	case string:
-		if isPlaceholderString(currentTyped) {
-			if previousTyped, ok := previous.(string); ok && strings.TrimSpace(previousTyped) != "" {
-				return previousTyped
-			}
-		}
-		return currentTyped
-	case float64:
-		if currentTyped == 0 {
-			if previousTyped, ok := previous.(float64); ok && previousTyped != 0 {
-				return previousTyped
-			}
-		}
-		return currentTyped
-	case bool:
-		if !currentTyped {
-			if previousTyped, ok := previous.(bool); ok && previousTyped {
-				return previousTyped
-			}
-		}
-		return currentTyped
-	case nil:
-		if previous != nil {
-			return previous
-		}
-		return nil
 	default:
-		return currentTyped
-	}
-}
-
-func isPlaceholderString(value string) bool {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "", "unknown", "null", "nil", "n/a", "none", "unset":
-		return true
-	default:
-		return false
+		return current
 	}
 }
 

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -682,7 +682,7 @@ func TestWorkerProcessStreamerNormalizesLegacyStatePayloads(t *testing.T) {
 	}
 }
 
-func TestWorkerProcessStreamerPreservesKnownScoreWhenModelReturnsUnknownPlaceholders(t *testing.T) {
+func TestWorkerProcessStreamerUsesLLMStateEvenWhenUnknownPlaceholdersAreReturned(t *testing.T) {
 	decisions := &fakeDecisionStore{}
 	classifier := &flakyClassifier{
 		result: StageClassification{
@@ -705,13 +705,13 @@ func TestWorkerProcessStreamerPreservesKnownScoreWhenModelReturnsUnknownPlacehol
 	if err != nil {
 		t.Fatalf("second ProcessStreamer() error = %v", err)
 	}
-	if second.Label != "awaiting_changes" {
-		t.Fatalf("second label = %q, want awaiting_changes", second.Label)
+	if second.Label != "state_updated" {
+		t.Fatalf("second label = %q, want state_updated", second.Label)
 	}
-	if got := second.UpdatedStateJSON; got != `{"final_outcome":"unknown","state":{"ct_score":8,"mode":"competitive","t_score":5}}` {
+	if got := second.UpdatedStateJSON; got != `{"final_outcome":"unknown","state":{"ct_score":0,"mode":"unknown","t_score":0}}` {
 		t.Fatalf("updated state = %q", got)
 	}
-	if len(decisions.items) != 1 {
-		t.Fatalf("recorded %d decisions, want 1 (skip unchanged updates)", len(decisions.items))
+	if len(decisions.items) != 2 {
+		t.Fatalf("recorded %d decisions, want 2", len(decisions.items))
 	}
 }


### PR DESCRIPTION
### Motivation

- Remove special-casing that preserved previous state values when the LLM returned empty/placeholder/zero values so the system will accept the LLM-provided state for non-object values.

### Description

- Simplified `mergeStateValue` in `internal/media/worker.go` to only recursively merge maps and otherwise return the `current` value for non-map types, removing custom logic for slices, strings, numbers, booleans, and nils.
- Removed the `isPlaceholderString` helper and associated placeholder-preservation branches that treated values like `"unknown"`, `"n/a"`, `0`, or `false` as placeholders.
- Updated test `TestWorkerProcessStreamerPreservesKnownScoreWhenModelReturnsUnknownPlaceholders` to `TestWorkerProcessStreamerUsesLLMStateEvenWhenUnknownPlaceholdersAreReturned` and adjusted assertions to expect the LLM state to be used and a new decision to be recorded.

### Testing

- Ran unit tests in the media package including the updated streamer tests via `go test ./internal/media` and they passed.
- Verified the updated test `TestWorkerProcessStreamerUsesLLMStateEvenWhenUnknownPlaceholdersAreReturned` and related state-normalization test both execute successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c911e35774832caa1a590534f36283)