### PR TITLE
Use ResponseSchema for prompts and remove active state schema resolution

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -349,7 +349,7 @@ func geminiPromptFingerprint(input StageRequest) string {
 	return strings.Join([]string{
 		strings.TrimSpace(input.Prompt.ID),
 		strings.TrimSpace(input.Prompt.Template),
-		strings.TrimSpace(input.StateSchema),
+		strings.TrimSpace(input.ResponseSchema),
 	}, "|")
 }
 
@@ -399,7 +399,7 @@ Chunk captured at: %s
 Chunk reference: %s
 Use this admin-managed tracker prompt as the source of truth (including the expected JSON template):
 %s
-Active state schema:
+Expected response schema:
 %s`
 	previousState := strings.TrimSpace(input.PreviousState)
 	if previousState == "" {
@@ -412,7 +412,7 @@ For detector stages, the JSON must include keys: label, confidence, summary.
 - label: short snake_case decision for this stage.
 - confidence: number between 0 and 1.
 - summary: short rationale.
-Do not include any keys that are not part of the admin-managed template.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema)))
+Do not include any keys that are not part of the admin-managed template.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.ResponseSchema)))
 	}
 	return strings.TrimSpace(fmt.Sprintf(base+`
 Previous persisted tracker state JSON:
@@ -451,7 +451,7 @@ Mandatory rules:
 5. If chunk stream appears cut during active gameplay, prefer session_status=likely_truncated.
 6. Preserve previously confirmed evidence unless clearly contradicted.
 7. Store contradictions in hard_conflicts instead of silently overwriting facts.
-8. Never emit narrative commentary outside JSON.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.StateSchema), previousState))
+8. Never emit narrative commentary outside JSON.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.ResponseSchema), previousState))
 }
 
 func buildGeminiContinuationInstruction(input StageRequest) string {
@@ -460,14 +460,14 @@ Stage: %s
 Streamer ID: %s
 Chunk captured at: %s
 Chunk reference: %s
-Active state schema:
+Expected response schema:
 %s
 Do not repeat full state snapshots from earlier turns.
-Use only the active admin state schema for this request and keep payload compact.
+Use only the expected response schema for this request and keep payload compact.
 Return ONLY concrete changes discovered in this chunk and keep delta minimal.
 If there are no concrete changes, return updated_state with the current known state and an empty delta.
 Return JSON that matches the admin-managed JSON template and include only changed fields when possible.
-Return ONLY valid JSON using the same schema as before.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.StateSchema)))
+Return ONLY valid JSON using the same schema as before.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.ResponseSchema)))
 }
 
 func allowsEmptyChunk(stage string) bool {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -156,7 +156,7 @@ func TestGeminiStageClassifierReusesChatSessionWithoutResendingPrompt(t *testing
 	if !strings.Contains(requestBodies[1], "Continue the existing match chat session.") {
 		t.Fatalf("expected second request to include continuation marker, got %s", requestBodies[1])
 	}
-	if !strings.Contains(requestBodies[1], "Active state schema:") {
+	if !strings.Contains(requestBodies[1], "Expected response schema:") {
 		t.Fatalf("expected second request to include active state schema reminder, got %s", requestBodies[1])
 	}
 	if strings.Contains(requestBodies[1], "Previous persisted tracker state JSON:") {
@@ -457,11 +457,11 @@ func TestGeminiStageClassifierRejectsUnsupportedChunkMimeType(t *testing.T) {
 
 func TestBuildGeminiInstructionUsesTrackerContract(t *testing.T) {
 	instruction := buildGeminiInstruction(StageRequest{
-		StreamerID:  "str-42",
-		Stage:       "match_update",
-		Chunk:       ChunkRef{Reference: "/tmp/chunk.mp4", CapturedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
-		Prompt:      prompts.PromptVersion{Template: "Update the CS2 tracker state"},
-		StateSchema: `state_schema[CS2 v1]: [{"key":"score.ct"}]`,
+		StreamerID:     "str-42",
+		Stage:          "match_update",
+		Chunk:          ChunkRef{Reference: "/tmp/chunk.mp4", CapturedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
+		Prompt:         prompts.PromptVersion{Template: "Update the CS2 tracker state"},
+		ResponseSchema: `state_schema[CS2 v1]: [{"key":"score.ct"}]`,
 	})
 	for _, fragment := range []string{
 		"Streamer ID: str-42",
@@ -470,7 +470,7 @@ func TestBuildGeminiInstructionUsesTrackerContract(t *testing.T) {
 		defaultTrackerState(),
 		"updated_state",
 		"next_needed_evidence",
-		"Active state schema:",
+		"Expected response schema:",
 		"state_schema[CS2 v1]",
 	} {
 		if !strings.Contains(instruction, fragment) {
@@ -479,17 +479,17 @@ func TestBuildGeminiInstructionUsesTrackerContract(t *testing.T) {
 	}
 }
 
-func TestBuildGeminiContinuationInstructionIncludesActiveStateSchema(t *testing.T) {
+func TestBuildGeminiContinuationInstructionIncludesExpectedResponseSchema(t *testing.T) {
 	instruction := buildGeminiContinuationInstruction(StageRequest{
-		StreamerID:  "str-42",
-		Stage:       "match_update",
-		Chunk:       ChunkRef{Reference: "/tmp/chunk.mp4", CapturedAt: time.Date(2025, 1, 1, 12, 0, 10, 0, time.UTC)},
-		Prompt:      prompts.PromptVersion{Template: "Update the CS2 tracker state"},
-		StateSchema: `state_schema[CS2 v1]: [{"key":"score.ct"}]`,
+		StreamerID:     "str-42",
+		Stage:          "match_update",
+		Chunk:          ChunkRef{Reference: "/tmp/chunk.mp4", CapturedAt: time.Date(2025, 1, 1, 12, 0, 10, 0, time.UTC)},
+		Prompt:         prompts.PromptVersion{Template: "Update the CS2 tracker state"},
+		ResponseSchema: `state_schema[CS2 v1]: [{"key":"score.ct"}]`,
 	})
 	for _, fragment := range []string{
 		"Continue the existing match chat session.",
-		"Active state schema:",
+		"Expected response schema:",
 		`state_schema[CS2 v1]: [{"key":"score.ct"}]`,
 	} {
 		if !strings.Contains(instruction, fragment) {

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -32,7 +32,6 @@ type StageRequest struct {
 	Chunk           ChunkRef
 	Prompt          prompts.PromptVersion
 	PreviousState   string
-	StateSchema     string
 	ResponseSchema  string
 	SendPrompt      bool
 	ScenarioFolder  string
@@ -294,8 +293,7 @@ func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (Chunk
 
 func (w *Worker) processStage(ctx context.Context, runID, streamerID string, chunk ChunkRef, activePrompt prompts.PromptVersion) (streamers.LLMDecision, error) {
 	previousState := w.resolvePreviousState(ctx, streamerID)
-	stateSchema := w.resolveTrackerConfig(ctx)
-	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt, PreviousState: previousState, StateSchema: stateSchema}, activePrompt)
+	result, err := w.classifyWithRetry(ctx, StageRequest{StreamerID: streamerID, Stage: activePrompt.Stage, Chunk: chunk, Prompt: activePrompt, PreviousState: previousState}, activePrompt)
 	if err != nil {
 		w.metrics.recordFailure(ctx, streamerID, activePrompt.Stage)
 		return streamers.LLMDecision{}, err
@@ -388,82 +386,7 @@ func (w *Worker) resolvePreviousState(ctx context.Context, streamerID string) st
 			return state
 		}
 	}
-	if initial := strings.TrimSpace(w.resolveInitialTrackerState(ctx)); initial != "" {
-		return initial
-	}
 	return defaultTrackerState()
-}
-
-func (w *Worker) resolveInitialTrackerState(ctx context.Context) string {
-	const gameSlug = "cs2"
-	if resolver, ok := w.prompts.(activeStateSchemaResolver); ok {
-		if item, err := resolver.GetActiveStateSchema(ctx, gameSlug); err == nil {
-			if state := strings.TrimSpace(item.InitialStateJSON); state != "" && state != "{}" {
-				return normalizeInitialStateTemplateJSON(state)
-			}
-		}
-	}
-	return ""
-}
-
-func normalizeInitialStateTemplateJSON(raw string) string {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return ""
-	}
-	var parsed any
-	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
-		return trimmed
-	}
-	normalized := normalizeTemplateValue(parsed)
-	body, err := json.Marshal(normalized)
-	if err != nil {
-		return trimmed
-	}
-	return strings.TrimSpace(string(body))
-}
-
-func normalizeTemplateValue(value any) any {
-	switch typed := value.(type) {
-	case map[string]any:
-		out := make(map[string]any, len(typed))
-		for key, nested := range typed {
-			out[key] = normalizeTemplateValue(nested)
-		}
-		return out
-	case []any:
-		out := make([]any, 0, len(typed))
-		for _, item := range typed {
-			out = append(out, normalizeTemplateValue(item))
-		}
-		return out
-	case string:
-		return resolveTemplateEnumString(typed)
-	default:
-		return value
-	}
-}
-
-func resolveTemplateEnumString(value string) string {
-	trimmed := strings.TrimSpace(value)
-	if !strings.Contains(trimmed, "|") {
-		return trimmed
-	}
-	parts := strings.Split(trimmed, "|")
-	candidate := ""
-	for _, part := range parts {
-		token := strings.TrimSpace(part)
-		if token == "" {
-			continue
-		}
-		if strings.EqualFold(token, "unknown") {
-			return "unknown"
-		}
-		if candidate == "" {
-			candidate = token
-		}
-	}
-	return candidate
 }
 
 func normalizeDecisionLabel(result StageClassification, updatedStateJSON string) string {
@@ -722,35 +645,8 @@ func sleepContext(ctx context.Context, delay time.Duration) error {
 	}
 }
 
-type activeStateSchemaResolver interface {
-	GetActiveStateSchema(ctx context.Context, gameSlug string) (prompts.StateSchemaVersion, error)
-}
-
 type llmModelConfigResolver interface {
 	GetLLMModelConfig(ctx context.Context, id string) (prompts.LLMModelConfig, error)
-}
-
-func (w *Worker) resolveTrackerConfig(ctx context.Context) string {
-	const gameSlug = "cs2"
-	var stateSchema string
-	if resolver, ok := w.prompts.(activeStateSchemaResolver); ok {
-		if item, err := resolver.GetActiveStateSchema(ctx, gameSlug); err == nil {
-			schemaPayload := compactJSON(item.Fields)
-			stateSchema = fmt.Sprintf("state_schema[%s v%d]: %s", item.Name, item.Version, schemaPayload)
-		}
-	}
-	return stateSchema
-}
-
-func compactJSON(value any) string {
-	if value == nil {
-		return ""
-	}
-	data, err := json.Marshal(value)
-	if err != nil {
-		return ""
-	}
-	return string(data)
 }
 
 func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID string, chunk ChunkRef, pkg prompts.ScenarioPackage) (streamers.LLMDecision, error) {
@@ -785,14 +681,12 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 			activePrompt.Model = strings.TrimSpace(cfg.Model)
 		}
 	}
-	stateSchema := w.resolveTrackerConfig(ctx)
 	result, err := w.classifyWithRetry(ctx, StageRequest{
 		StreamerID:      streamerID,
 		Stage:           step.ID,
 		Chunk:           chunk,
 		Prompt:          activePrompt,
 		PreviousState:   previousState,
-		StateSchema:     stateSchema,
 		ResponseSchema:  step.ResponseSchemaJSON,
 		SendPrompt:      entering,
 		ScenarioFolder:  step.Folder,

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -46,8 +46,6 @@ type fakePromptResolver struct {
 	prompts        []prompts.PromptVersion
 	scenario       prompts.ScenarioPackage
 	scenarioErr    error
-	activeSchema   prompts.StateSchemaVersion
-	schemaErr      error
 	llmModelConfig prompts.LLMModelConfig
 	llmConfigErr   error
 }
@@ -116,13 +114,6 @@ func (f fakePromptResolver) GetLLMModelConfig(_ context.Context, _ string) (prom
 		}
 	}
 	return prompts.LLMModelConfig{}, prompts.ErrLLMModelConfigNotFound
-}
-
-func (f fakePromptResolver) GetActiveStateSchema(_ context.Context, _ string) (prompts.StateSchemaVersion, error) {
-	if f.schemaErr != nil {
-		return prompts.StateSchemaVersion{}, f.schemaErr
-	}
-	return f.activeSchema, nil
 }
 
 type fakeDecisionStore struct {
@@ -585,65 +576,6 @@ func TestWorkerProcessStreamerPassesPersistedPreviousStateToTrackerStages(t *tes
 	}
 	if second.Label != "awaiting_changes" {
 		t.Fatalf("second label = %q, want awaiting_changes", second.Label)
-	}
-}
-
-func TestWorkerProcessStreamerUsesAdminProvidedInitialState(t *testing.T) {
-	decisions := &fakeDecisionStore{}
-	classifier := &flakyClassifier{result: StageClassification{Label: "state_updated", Confidence: 0.95, UpdatedStateJSON: `{"score_state":{"ct_score":1,"t_score":0}}`}}
-	worker := NewWorker(
-		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
-		classifier,
-		fakePromptResolver{
-			prompts:      []prompts.PromptVersion{{ID: "tracker-1", Stage: "match_update", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}},
-			activeSchema: prompts.StateSchemaVersion{InitialStateJSON: `{"session_status":{"value":"in_progress"},"score_state":{"ct_score":0,"t_score":0}}`},
-		},
-		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
-	)
-	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
-		t.Fatalf("ProcessStreamer() error = %v", err)
-	}
-	if len(decisions.items) != 1 {
-		t.Fatalf("recorded %d decisions, want 1", len(decisions.items))
-	}
-	if !strings.Contains(decisions.items[0].PreviousStateJSON, `"session_status":{"value":"in_progress"}`) {
-		t.Fatalf("previous state = %q", decisions.items[0].PreviousStateJSON)
-	}
-}
-
-func TestWorkerProcessStreamerNormalizesAdminInitialStateTemplate(t *testing.T) {
-	decisions := &fakeDecisionStore{}
-	classifier := &flakyClassifier{result: StageClassification{Label: "state_updated", Confidence: 0.95, UpdatedStateJSON: `{"score_state":{"ct_score":1,"t_score":0}}`}}
-	worker := NewWorker(
-		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
-		classifier,
-		fakePromptResolver{
-			prompts: []prompts.PromptVersion{{ID: "tracker-1", Stage: "match_update", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}},
-			activeSchema: prompts.StateSchemaVersion{InitialStateJSON: `{
-				"mode": "competitive | faceit | wingman | unknown",
-				"session_status": {
-					"value": "in_progress | likely_finished | confirmed_finished | likely_truncated | unknown"
-				},
-				"winner_state": {"winner_side":"CT | T | draw | unknown"}
-			}`},
-		},
-		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
-	)
-	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
-		t.Fatalf("ProcessStreamer() error = %v", err)
-	}
-	if len(decisions.items) != 1 {
-		t.Fatalf("recorded %d decisions, want 1", len(decisions.items))
-	}
-	previous := decisions.items[0].PreviousStateJSON
-	if !strings.Contains(previous, `"mode":"unknown"`) {
-		t.Fatalf("previous state mode was not normalized: %q", previous)
-	}
-	if !strings.Contains(previous, `"value":"unknown"`) {
-		t.Fatalf("previous state session_status was not normalized: %q", previous)
-	}
-	if !strings.Contains(previous, `"winner_side":"unknown"`) {
-		t.Fatalf("previous state winner_side was not normalized: %q", previous)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Simplify tracker prompt handling by relying on the prompt/step-provided `ResponseSchema` instead of fetching an admin-managed active state schema. 
- Remove legacy initial-state normalization and schema-resolver plumbing that duplicated schema logic and complicated the worker flow.

### Description

- Replaced usages of `StateSchema` with `ResponseSchema` in Gemini prompt construction and fingerprinting by referencing `input.ResponseSchema` in `internal/media/gemini.go` and related code. 
- Removed the `StateSchema` field from `StageRequest` and updated all call sites in `internal/media/worker.go` to stop computing or passing an externally-resolved active schema. 
- Deleted the `activeStateSchemaResolver` interface and helper functions `resolveTrackerConfig`, `resolveInitialTrackerState`, `normalizeInitialStateTemplateJSON`, `normalizeTemplateValue`, `resolveTemplateEnumString`, and `compactJSON` to remove admin initial-state handling. 
- Updated unit tests in `internal/media` to expect `ResponseSchema` usage and removed tests that validated admin-provided initial state behavior and normalization.

### Testing

- Ran the repository unit tests with `go test ./...` which exercised the updated `internal/media` package and amended tests, and they succeeded. 
- All modified tests in `internal/media` were updated and passed during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c91af55888832cbbbaa62090d3efc0)