### PR TITLE
Make Gemini tracker responses schema-driven and remove legacy backfills

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -114,8 +114,10 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 > expectations derived from that step.
 >
 > Legacy Gemini response coercion is disabled: tracker stages must return
-> canonical JSON fields (`updated_state`, `delta`, `next_needed_evidence`,
-> `hard_conflicts`, `final_outcome`) exactly as defined by the active step.
+> strict JSON that matches the active step `responseSchemaJson` exactly.
+> Canonical fields like `updated_state`, `delta`, `next_needed_evidence`,
+> `hard_conflicts`, `final_outcome` are now schema-driven and only required
+> when present in the active step contract.
 
 Update this table whenever you introduce a new configuration surface.
 

--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -286,7 +286,6 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 		}
 		return StageClassification{}, err
 	}
-	parsed = normalizeGeminiTrackerResponse(input, parsed)
 	if parsed.Confidence < 0 || parsed.Confidence > 1 {
 		return StageClassification{}, ErrGeminiInvalidConfidence
 	}
@@ -432,25 +431,16 @@ Stage-specific behavior:
 - For close_current_session or match_finalize: no more chunks are currently available; do NOT assume the match finished and choose closure status only from accumulated evidence.
 
 Return ONLY valid JSON that matches the admin-managed JSON template from the prompt above.
-Tracker responses must keep this required structure:
-{
-  "label": "state_updated | closure_evaluated | unknown",
-  "confidence": 0.0,
-  "updated_state": {},
-  "delta": [],
-  "next_needed_evidence": [],
-  "hard_conflicts": [],
-  "final_outcome": "win | loss | draw | unknown"
-}
+Do not add keys that are not present in the schema/template.
 
 Mandatory rules:
 1. Never infer match completion only because no more chunks are currently available.
 2. Never infer player victory/defeat from gameplay quality.
-3. Treat final outcome as validated ONLY when strong terminal evidence exists (final banner, final scoreboard, explicit post-match UI, or repeated strong terminal signals).
-4. If completion is not confirmed, keep player_result.is_final=false and final_outcome=unknown.
-5. If chunk stream appears cut during active gameplay, prefer session_status=likely_truncated.
+3. If schema contains final outcome semantics, validate them only from strong terminal evidence (final banner, final scoreboard, explicit post-match UI, or repeated strong terminal signals).
+4. If schema contains completion flags and completion is not confirmed, keep them in an unknown/non-final state.
+5. If chunk stream appears cut during active gameplay, reflect likely truncation if such field exists in schema.
 6. Preserve previously confirmed evidence unless clearly contradicted.
-7. Store contradictions in hard_conflicts instead of silently overwriting facts.
+7. Record contradictions only in schema-approved conflict fields.
 8. Never emit narrative commentary outside JSON.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.ResponseSchema), previousState))
 }
 
@@ -464,9 +454,9 @@ Expected response schema:
 %s
 Do not repeat full state snapshots from earlier turns.
 Use only the expected response schema for this request and keep payload compact.
-Return ONLY concrete changes discovered in this chunk and keep delta minimal.
-If there are no concrete changes, return updated_state with the current known state and an empty delta.
-Return JSON that matches the admin-managed JSON template and include only changed fields when possible.
+Return ONLY concrete changes discovered in this chunk when the schema supports delta-style updates.
+If there are no concrete changes, return a schema-valid "no changes" response.
+Return JSON that matches the admin-managed JSON template exactly.
 Return ONLY valid JSON using the same schema as before.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.ResponseSchema)))
 }
 
@@ -652,7 +642,13 @@ func trimForLog(value string, max int) string {
 }
 
 func hasGeminiResponsePayload(parsed geminiStageResponse) bool {
-	return strings.TrimSpace(parsed.Label) != "" || len(parsed.UpdatedState) > 0 || strings.TrimSpace(parsed.FinalOutcome) != ""
+	return strings.TrimSpace(parsed.Label) != "" ||
+		strings.TrimSpace(parsed.Summary) != "" ||
+		len(parsed.UpdatedState) > 0 ||
+		len(parsed.Delta) > 0 ||
+		len(parsed.NextNeededEvidence) > 0 ||
+		len(parsed.HardConflicts) > 0 ||
+		strings.TrimSpace(parsed.FinalOutcome) != ""
 }
 
 func rawMessageFromGenericValue(value any) json.RawMessage {
@@ -695,15 +691,6 @@ func validateGeminiTrackerResponse(stage string, parsed geminiStageResponse) err
 	if !isTrackerStage(stage) {
 		return nil
 	}
-	if len(parsed.UpdatedState) == 0 || strings.TrimSpace(string(parsed.UpdatedState)) == "null" {
-		return fmt.Errorf("gemini tracker response for %s must include updated_state", strings.TrimSpace(stage))
-	}
-	if len(parsed.Delta) == 0 || strings.TrimSpace(string(parsed.Delta)) == "null" {
-		return fmt.Errorf("gemini tracker response for %s must include delta", strings.TrimSpace(stage))
-	}
-	if len(parsed.NextNeededEvidence) == 0 || strings.TrimSpace(string(parsed.NextNeededEvidence)) == "null" {
-		return fmt.Errorf("gemini tracker response for %s must include next_needed_evidence", strings.TrimSpace(stage))
-	}
 	if strings.TrimSpace(parsed.FinalOutcome) != "" {
 		switch strings.TrimSpace(parsed.FinalOutcome) {
 		case "win", "loss", "draw", "unknown":
@@ -712,36 +699,4 @@ func validateGeminiTrackerResponse(stage string, parsed geminiStageResponse) err
 		}
 	}
 	return nil
-}
-
-func normalizeGeminiTrackerResponse(input StageRequest, parsed geminiStageResponse) geminiStageResponse {
-	if !isTrackerStage(input.Stage) || !isTrackerStartStage(input.Stage) {
-		return parsed
-	}
-	if len(parsed.UpdatedState) == 0 || strings.TrimSpace(string(parsed.UpdatedState)) == "null" {
-		fallbackState := strings.TrimSpace(input.PreviousState)
-		if fallbackState == "" {
-			fallbackState = defaultTrackerState()
-		}
-		parsed.UpdatedState = json.RawMessage(fallbackState)
-	}
-	if len(parsed.Delta) == 0 || strings.TrimSpace(string(parsed.Delta)) == "null" {
-		parsed.Delta = json.RawMessage("[]")
-	}
-	if len(parsed.NextNeededEvidence) == 0 || strings.TrimSpace(string(parsed.NextNeededEvidence)) == "null" {
-		parsed.NextNeededEvidence = json.RawMessage("[]")
-	}
-	if strings.TrimSpace(parsed.FinalOutcome) == "" {
-		parsed.FinalOutcome = "unknown"
-	}
-	return parsed
-}
-
-func isTrackerStartStage(stage string) bool {
-	switch strings.TrimSpace(strings.ToLower(stage)) {
-	case trackerStageDiscovery, "start", "discovery", "bootstrap", "initialize":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -468,8 +468,7 @@ func TestBuildGeminiInstructionUsesTrackerContract(t *testing.T) {
 		"Chunk reference: /tmp/chunk.mp4",
 		"Previous persisted tracker state JSON:",
 		defaultTrackerState(),
-		"updated_state",
-		"next_needed_evidence",
+		"Do not add keys that are not present in the schema/template.",
 		"Expected response schema:",
 		"state_schema[CS2 v1]",
 	} {
@@ -553,7 +552,7 @@ func TestGeminiStageClassifierAcceptsTrackerResponseWithoutLabel(t *testing.T) {
 	}
 }
 
-func TestGeminiStageClassifierRejectsTrackerResponseWithoutStatePayload(t *testing.T) {
+func TestGeminiStageClassifierAcceptsSchemaDrivenTrackerPayloadWithoutLegacyStateFields(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.mp4")
 	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
@@ -580,18 +579,24 @@ func TestGeminiStageClassifierRejectsTrackerResponseWithoutStatePayload(t *testi
 		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
 	}
 
-	_, err = classifier.Classify(context.Background(), StageRequest{
+	result, err := classifier.Classify(context.Background(), StageRequest{
 		StreamerID: "str-1",
 		Stage:      "match_update",
 		Chunk:      ChunkRef{Reference: chunkPath},
 		Prompt:     prompts.PromptVersion{Stage: "match_update", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
 	})
-	if err == nil || !strings.Contains(err.Error(), "updated_state") {
-		t.Fatalf("expected missing updated_state error, got %v", err)
+	if err != nil {
+		t.Fatalf("expected schema-driven tracker payload to pass, got %v", err)
+	}
+	if result.Label != "state_updated" {
+		t.Fatalf("expected label from response, got %q", result.Label)
+	}
+	if strings.TrimSpace(result.UpdatedStateJSON) != "" {
+		t.Fatalf("expected no legacy updated_state coercion, got %q", result.UpdatedStateJSON)
 	}
 }
 
-func TestGeminiStageClassifierBackfillsTrackerStartPayload(t *testing.T) {
+func TestGeminiStageClassifierDoesNotBackfillTrackerStartPayload(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.mp4")
 	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
@@ -625,23 +630,23 @@ func TestGeminiStageClassifierBackfillsTrackerStartPayload(t *testing.T) {
 		Prompt:     prompts.PromptVersion{Stage: "Start", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
 	})
 	if err != nil {
-		t.Fatalf("expected start stage fallback payload, got error %v", err)
+		t.Fatalf("expected start stage payload without backfill to pass, got error %v", err)
 	}
-	if strings.TrimSpace(result.UpdatedStateJSON) == "" {
-		t.Fatalf("expected updated_state fallback, got empty value")
+	if strings.TrimSpace(result.UpdatedStateJSON) != "" {
+		t.Fatalf("expected no updated_state fallback, got %q", result.UpdatedStateJSON)
 	}
-	if strings.TrimSpace(result.EvidenceDeltaJSON) != "[]" {
-		t.Fatalf("expected empty delta fallback, got %q", result.EvidenceDeltaJSON)
+	if strings.TrimSpace(result.EvidenceDeltaJSON) != "" {
+		t.Fatalf("expected no delta fallback, got %q", result.EvidenceDeltaJSON)
 	}
-	if strings.TrimSpace(result.NextEvidenceJSON) != "[]" {
-		t.Fatalf("expected empty next_needed_evidence fallback, got %q", result.NextEvidenceJSON)
+	if strings.TrimSpace(result.NextEvidenceJSON) != "" {
+		t.Fatalf("expected no next_needed_evidence fallback, got %q", result.NextEvidenceJSON)
 	}
-	if strings.TrimSpace(result.FinalOutcome) != "unknown" {
-		t.Fatalf("expected unknown final_outcome fallback, got %q", result.FinalOutcome)
+	if strings.TrimSpace(result.FinalOutcome) != "" {
+		t.Fatalf("expected no final_outcome fallback, got %q", result.FinalOutcome)
 	}
 }
 
-func TestGeminiStageClassifierBackfillsTrackerStartPayloadWithNullFinalOutcome(t *testing.T) {
+func TestGeminiStageClassifierKeepsNullFinalOutcomeEmptyWhenSchemaOmitsFallback(t *testing.T) {
 	dir := t.TempDir()
 	chunkPath := filepath.Join(dir, "chunk.mp4")
 	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
@@ -675,10 +680,10 @@ func TestGeminiStageClassifierBackfillsTrackerStartPayloadWithNullFinalOutcome(t
 		Prompt:     prompts.PromptVersion{Stage: "Start", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
 	})
 	if err != nil {
-		t.Fatalf("expected null final_outcome to be normalized, got error %v", err)
+		t.Fatalf("expected null final_outcome to pass without normalization, got error %v", err)
 	}
-	if strings.TrimSpace(result.FinalOutcome) != "unknown" {
-		t.Fatalf("expected unknown final_outcome fallback, got %q", result.FinalOutcome)
+	if strings.TrimSpace(result.FinalOutcome) != "" {
+		t.Fatalf("expected empty final_outcome when model returns null, got %q", result.FinalOutcome)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Move tracker behavior to be strictly driven by the admin-managed response schema instead of relying on legacy, hard-coded tracker fields and automatic backfills. 
- Ensure prompts and runtime behavior do not silently coerce or synthesize `updated_state`/`delta`/`next_needed_evidence`/`final_outcome`, so model responses are validated against the active step contract.

### Description
- Update instruction text generation in `internal/media/gemini.go` (both initial and continuation prompts) and docs (`docs/local_setup.md`) to require responses that match the active step `responseSchemaJson` exactly and to forbid adding keys not present in the schema. 
- Remove legacy normalization/backfill logic by deleting `normalizeGeminiTrackerResponse` and related `isTrackerStartStage` helpers so the classifier no longer injects fallback `updated_state`, `delta`, `next_needed_evidence`, or `final_outcome`. 
- Relax validation to be schema-driven by stopping enforcement of mandatory legacy fields inside `validateGeminiTrackerResponse`, while preserving final outcome value checks and tightening payload-detection via an expanded `hasGeminiResponsePayload`. 
- Adjust ancillary logic to treat `summary`, `delta`, `next_needed_evidence`, and `hard_conflicts` as valid payload indicators and to preserve `null`/empty final outcome when the schema omits fallback semantics.

### Testing
- Updated and run unit tests in `internal/media` that exercise the Gemini tracker classifier behavior, including schema-driven acceptance and absence of legacy backfills; all modified tests passed. 
- Ran `go test ./internal/media` to verify classifier behavior changes; the test suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6f9807c4832c8f93046a5ef51ccb)