### PR TITLE
Make Gemini classifier schema-driven and synthesize labels/confidence

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -115,9 +115,8 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 >
 > Legacy Gemini response coercion is disabled: tracker stages must return
 > strict JSON that matches the active step `responseSchemaJson` exactly.
-> Canonical fields like `updated_state`, `delta`, `next_needed_evidence`,
-> `hard_conflicts`, `final_outcome` are now schema-driven and only required
-> when present in the active step contract.
+> LLM response payload shape is fully defined by the active step
+> `responseSchemaJson`; extra keys are rejected by runtime.
 
 Update this table whenever you introduce a new configuration surface.
 

--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -20,12 +20,11 @@ import (
 )
 
 var (
-	ErrGeminiAPIKeyRequired    = errors.New("gemini api key is required")
-	ErrGeminiChunkRequired     = errors.New("gemini chunk reference is required")
-	ErrGeminiChunkTooLarge     = errors.New("gemini chunk exceeds inline upload limit")
-	ErrGeminiEmptyResponse     = errors.New("gemini returned empty response")
-	ErrGeminiInvalidConfidence = errors.New("gemini confidence must be between 0 and 1")
-	ErrGeminiUnsupportedMIME   = errors.New("gemini does not support the chunk mime type")
+	ErrGeminiAPIKeyRequired  = errors.New("gemini api key is required")
+	ErrGeminiChunkRequired   = errors.New("gemini chunk reference is required")
+	ErrGeminiChunkTooLarge   = errors.New("gemini chunk exceeds inline upload limit")
+	ErrGeminiEmptyResponse   = errors.New("gemini returned empty response")
+	ErrGeminiUnsupportedMIME = errors.New("gemini does not support the chunk mime type")
 )
 
 const geminiMaxOutputTokensLimit = 8192
@@ -181,9 +180,6 @@ type geminiUsageMetadata struct {
 }
 
 type geminiStageResponse struct {
-	Label              string          `json:"label"`
-	Confidence         float64         `json:"confidence"`
-	Summary            string          `json:"summary,omitempty"`
 	UpdatedState       json.RawMessage `json:"updated_state,omitempty"`
 	Delta              json.RawMessage `json:"delta,omitempty"`
 	NextNeededEvidence json.RawMessage `json:"next_needed_evidence,omitempty"`
@@ -279,42 +275,32 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 		return StageClassification{}, fmt.Errorf("%v; stage=%s streamer_id=%s session_key=%s prompt_id=%s force_bootstrap=%t", err, strings.TrimSpace(input.Stage), strings.TrimSpace(input.StreamerID), sessionKey, strings.TrimSpace(input.Prompt.ID), forceBootstrap)
 	}
 
-	parsed, err := parseGeminiStageResponse(rawText, input.Stage)
+	parsed, err := parseGeminiStageResponse(rawText)
 	if err != nil {
 		if errors.Is(err, ErrGeminiEmptyResponse) {
 			return StageClassification{}, fmt.Errorf("%v; stage=%s streamer_id=%s session_key=%s prompt_id=%s raw_text=%s", err, strings.TrimSpace(input.Stage), strings.TrimSpace(input.StreamerID), sessionKey, strings.TrimSpace(input.Prompt.ID), strconv.Quote(trimForLog(rawText, 512)))
 		}
 		return StageClassification{}, err
 	}
-	if parsed.Confidence < 0 || parsed.Confidence > 1 {
-		return StageClassification{}, ErrGeminiInvalidConfidence
-	}
 	if err := validateGeminiTrackerResponse(input.Stage, parsed); err != nil {
 		return StageClassification{}, err
 	}
 	c.storeSessionResponse(sessionKey, promptFingerprint, contents, payload, rawText)
 
-	label := strings.TrimSpace(parsed.Label)
-	if label == "" && len(parsed.UpdatedState) > 0 {
-		label = "state_updated"
-	}
-	if label == "" && strings.TrimSpace(parsed.FinalOutcome) != "" {
+	label := "state_updated"
+	if outcome := strings.TrimSpace(parsed.FinalOutcome); outcome != "" && !strings.EqualFold(outcome, "unknown") {
 		label = strings.TrimSpace(parsed.FinalOutcome)
-	}
-	confidence := parsed.Confidence
-	if confidence == 0 && (len(parsed.UpdatedState) > 0 || strings.TrimSpace(parsed.FinalOutcome) != "") {
-		confidence = 1
 	}
 	return StageClassification{
 		Label:             label,
-		Confidence:        confidence,
+		Confidence:        1,
 		RawResponse:       strings.TrimSpace(rawText),
 		RequestRef:        endpoint,
 		ResponseRef:       strconv.Itoa(resp.StatusCode),
 		TokensIn:          payload.UsageMetadata.PromptTokenCount,
 		TokensOut:         payload.UsageMetadata.CandidatesTokenCount,
 		Latency:           time.Since(started),
-		NormalizedOutcome: firstNonEmpty(strings.TrimSpace(parsed.FinalOutcome), label),
+		NormalizedOutcome: strings.TrimSpace(parsed.FinalOutcome),
 		UpdatedStateJSON:  marshalRawMessage(parsed.UpdatedState),
 		EvidenceDeltaJSON: marshalRawMessage(parsed.Delta),
 		NextEvidenceJSON:  marshalRawMessage(parsed.NextNeededEvidence),
@@ -407,10 +393,6 @@ Expected response schema:
 	if !isTrackerStage(input.Stage) {
 		return strings.TrimSpace(fmt.Sprintf(base+`
 Return ONLY valid JSON that matches the admin-managed JSON template from the prompt above.
-For detector stages, the JSON must include keys: label, confidence, summary.
-- label: short snake_case decision for this stage.
-- confidence: number between 0 and 1.
-- summary: short rationale.
 Do not include any keys that are not part of the admin-managed template.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.ResponseSchema)))
 	}
 	return strings.TrimSpace(fmt.Sprintf(base+`
@@ -592,41 +574,19 @@ func geminiBlockedSafetyCategories(ratings []geminiSafetyRating) []string {
 	return categories
 }
 
-func parseGeminiStageResponse(raw string, stage string) (geminiStageResponse, error) {
+func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {
 	cleaned := strings.TrimSpace(raw)
-	cleaned = strings.TrimPrefix(cleaned, "```json")
-	cleaned = strings.TrimPrefix(cleaned, "```")
-	cleaned = strings.TrimSuffix(cleaned, "```")
-	cleaned = strings.TrimSpace(cleaned)
 
 	var parsed geminiStageResponse
-	if err := json.Unmarshal([]byte(cleaned), &parsed); err == nil {
-		if hasGeminiResponsePayload(parsed) {
-			return parsed, nil
-		}
-	}
-
-	var generic map[string]any
-	if err := json.Unmarshal([]byte(cleaned), &generic); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(cleaned))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&parsed); err != nil {
 		return geminiStageResponse{}, fmt.Errorf("parse gemini stage response: %w", err)
 	}
-	parsed.Label = strings.TrimSpace(stringValue(generic["label"]))
-	parsed.Summary = strings.TrimSpace(stringValue(generic["summary"]))
-	switch value := generic["confidence"].(type) {
-	case float64:
-		parsed.Confidence = value
-	case string:
-		confidence, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
-		if err != nil {
-			return geminiStageResponse{}, fmt.Errorf("parse gemini confidence: %w", err)
-		}
-		parsed.Confidence = confidence
+	if decoder.More() {
+		return geminiStageResponse{}, fmt.Errorf("parse gemini stage response: unexpected trailing tokens")
 	}
-	parsed.UpdatedState = rawMessageFromGenericValue(generic["updated_state"])
-	parsed.Delta = rawMessageFromGenericValue(generic["delta"])
-	parsed.NextNeededEvidence = rawMessageFromGenericValue(generic["next_needed_evidence"])
-	parsed.HardConflicts = rawMessageFromGenericValue(generic["hard_conflicts"])
-	parsed.FinalOutcome = strings.TrimSpace(stringValue(generic["final_outcome"]))
+	parsed.FinalOutcome = strings.TrimSpace(parsed.FinalOutcome)
 	if !hasGeminiResponsePayload(parsed) {
 		return geminiStageResponse{}, ErrGeminiEmptyResponse
 	}
@@ -642,24 +602,11 @@ func trimForLog(value string, max int) string {
 }
 
 func hasGeminiResponsePayload(parsed geminiStageResponse) bool {
-	return strings.TrimSpace(parsed.Label) != "" ||
-		strings.TrimSpace(parsed.Summary) != "" ||
-		len(parsed.UpdatedState) > 0 ||
+	return len(parsed.UpdatedState) > 0 ||
 		len(parsed.Delta) > 0 ||
 		len(parsed.NextNeededEvidence) > 0 ||
 		len(parsed.HardConflicts) > 0 ||
 		strings.TrimSpace(parsed.FinalOutcome) != ""
-}
-
-func rawMessageFromGenericValue(value any) json.RawMessage {
-	if value == nil {
-		return nil
-	}
-	body, err := json.Marshal(value)
-	if err != nil {
-		return nil
-	}
-	return json.RawMessage(body)
 }
 
 func normalizeGeminiModel(model string) string {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -50,9 +50,9 @@ func TestGeminiStageClassifierClassify(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(`{
-                    "candidates": [{
-                        "content": {"parts": [{"text": "{\"label\":\"cs_detected\",\"confidence\":0.93,\"summary\":\"Counter-Strike HUD visible\"}"}]}
-                    }],
+	                    "candidates": [{
+	                        "content": {"parts": [{"text": "{\"updated_state\":{\"game\":\"cs2\"}}"}]}
+	                    }],
                     "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
                 }`)),
 			}, nil
@@ -78,11 +78,11 @@ func TestGeminiStageClassifierClassify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Classify() error = %v", err)
 	}
-	if result.Label != "cs_detected" {
-		t.Fatalf("expected label cs_detected, got %q", result.Label)
+	if result.Label != "state_updated" {
+		t.Fatalf("expected synthesized label state_updated, got %q", result.Label)
 	}
-	if result.Confidence != 0.93 {
-		t.Fatalf("expected confidence 0.93, got %v", result.Confidence)
+	if result.Confidence != 1 {
+		t.Fatalf("expected synthesized confidence 1, got %v", result.Confidence)
 	}
 	if result.TokensIn != 111 || result.TokensOut != 22 {
 		t.Fatalf("unexpected token usage: in=%d out=%d", result.TokensIn, result.TokensOut)
@@ -117,7 +117,7 @@ func TestGeminiStageClassifierReusesChatSessionWithoutResendingPrompt(t *testing
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(`{
                     "candidates": [{
-                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.93,\"updated_state\":{\"status\":\"live\"},\"delta\":[\"score_seen\"],\"next_needed_evidence\":[\"winner_banner\"],\"final_outcome\":\"unknown\"}"}]}
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"status\":\"live\"},\"delta\":[\"score_seen\"],\"next_needed_evidence\":[\"winner_banner\"],\"final_outcome\":\"unknown\"}"}]}
                     }],
                     "usageMetadata": {"promptTokenCount": 120, "candidatesTokenCount": 30, "totalTokenCount": 150}
                 }`)),
@@ -186,7 +186,7 @@ func TestGeminiStageClassifierSanitizesGenerationConfig(t *testing.T) {
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(`{
                     "candidates": [{
-                        "content": {"parts": [{"text": "{\"label\":\"cs_detected\",\"confidence\":0.93,\"summary\":\"Counter-Strike HUD visible\"}"}]}
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"game\":\"cs2\"}}"}]}
                     }],
                     "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 10}
                 }`)),
@@ -244,7 +244,7 @@ func TestGeminiStageClassifierRotatesChatWhenTokenBudgetReached(t *testing.T) {
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(`{
                     "candidates": [{
-                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.93,\"updated_state\":{\"status\":\"live\"},\"delta\":[\"score_seen\"],\"next_needed_evidence\":[\"winner_banner\"],\"final_outcome\":\"unknown\"}"}]}
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"status\":\"live\"},\"delta\":[\"score_seen\"],\"next_needed_evidence\":[\"winner_banner\"],\"final_outcome\":\"unknown\"}"}]}
                     }],
                     "usageMetadata": {"promptTokenCount": 120, "candidatesTokenCount": 30, "totalTokenCount": 150}
                 }`)),
@@ -310,7 +310,7 @@ func TestGeminiStageClassifierDoesNotResetSessionOnEmptyContinuationResponse(t *
 					Header:     make(http.Header),
 					Body: io.NopCloser(strings.NewReader(`{
                     "candidates": [{
-                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.93,\"updated_state\":{\"status\":\"live\"},\"delta\":[\"score_seen\"],\"next_needed_evidence\":[\"winner_banner\"],\"final_outcome\":\"unknown\"}"}]}
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"status\":\"live\"},\"delta\":[\"score_seen\"],\"next_needed_evidence\":[\"winner_banner\"],\"final_outcome\":\"unknown\"}"}]}
                     }],
                     "usageMetadata": {"promptTokenCount": 120, "candidatesTokenCount": 30, "totalTokenCount": 150}
                 }`)),
@@ -334,7 +334,7 @@ func TestGeminiStageClassifierDoesNotResetSessionOnEmptyContinuationResponse(t *
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(`{
                     "candidates": [{
-                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.88,\"updated_state\":{\"status\":\"live\"},\"delta\":[\"winner_seen\"],\"next_needed_evidence\":[],\"final_outcome\":\"win\"}"}]}
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"status\":\"live\"},\"delta\":[\"winner_seen\"],\"next_needed_evidence\":[],\"final_outcome\":\"win\"}"}]}
                     }],
                     "usageMetadata": {"promptTokenCount": 140, "candidatesTokenCount": 25, "totalTokenCount": 165}
                 }`)),
@@ -521,7 +521,7 @@ func TestGeminiStageClassifierAcceptsTrackerResponseWithoutLabel(t *testing.T) {
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(`{
                     "candidates": [{
-                        "content": {"parts": [{"text": "{\"confidence\":0.93,\"updated_state\":{\"status\":\"live\"},\"delta\":[\"score_seen\"],\"next_needed_evidence\":[\"winner_banner\"],\"final_outcome\":\"unknown\"}"}]}
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"status\":\"live\"},\"delta\":[\"score_seen\"],\"next_needed_evidence\":[\"winner_banner\"],\"final_outcome\":\"unknown\"}"}]}
                     }],
                     "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
                 }`)),
@@ -568,7 +568,7 @@ func TestGeminiStageClassifierAcceptsSchemaDrivenTrackerPayloadWithoutLegacyStat
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(`{
                     "candidates": [{
-                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.93}"}]}
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"status\":\"live\"}}"}]}
                     }],
                     "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
                 }`)),
@@ -591,8 +591,8 @@ func TestGeminiStageClassifierAcceptsSchemaDrivenTrackerPayloadWithoutLegacyStat
 	if result.Label != "state_updated" {
 		t.Fatalf("expected label from response, got %q", result.Label)
 	}
-	if strings.TrimSpace(result.UpdatedStateJSON) != "" {
-		t.Fatalf("expected no legacy updated_state coercion, got %q", result.UpdatedStateJSON)
+	if result.UpdatedStateJSON != `{"status":"live"}` {
+		t.Fatalf("expected updated_state to be passed through, got %q", result.UpdatedStateJSON)
 	}
 }
 
@@ -612,7 +612,7 @@ func TestGeminiStageClassifierDoesNotBackfillTrackerStartPayload(t *testing.T) {
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(`{
                     "candidates": [{
-                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.93}"}]}
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"status\":\"live\"}}"}]}
                     }],
                     "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
                 }`)),
@@ -632,8 +632,8 @@ func TestGeminiStageClassifierDoesNotBackfillTrackerStartPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected start stage payload without backfill to pass, got error %v", err)
 	}
-	if strings.TrimSpace(result.UpdatedStateJSON) != "" {
-		t.Fatalf("expected no updated_state fallback, got %q", result.UpdatedStateJSON)
+	if result.UpdatedStateJSON != `{"status":"live"}` {
+		t.Fatalf("expected updated_state to be preserved, got %q", result.UpdatedStateJSON)
 	}
 	if strings.TrimSpace(result.EvidenceDeltaJSON) != "" {
 		t.Fatalf("expected no delta fallback, got %q", result.EvidenceDeltaJSON)
@@ -662,7 +662,7 @@ func TestGeminiStageClassifierKeepsNullFinalOutcomeEmptyWhenSchemaOmitsFallback(
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(`{
                     "candidates": [{
-                        "content": {"parts": [{"text": "{\"label\":\"state_updated\",\"confidence\":0.93,\"updated_state\":{\"status\":\"live\"},\"delta\":[],\"next_needed_evidence\":[],\"final_outcome\":null}"}]}
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"status\":\"live\"},\"delta\":[],\"next_needed_evidence\":[],\"final_outcome\":null}"}]}
                     }],
                     "usageMetadata": {"promptTokenCount": 111, "candidatesTokenCount": 22}
                 }`)),
@@ -726,8 +726,8 @@ func TestGeminiStageClassifierDoesNotCoerceNonTrackerStatePayload(t *testing.T) 
 			TimeoutMS: 1000,
 		},
 	})
-	if err == nil || !strings.Contains(err.Error(), ErrGeminiEmptyResponse.Error()) {
-		t.Fatalf("expected empty response error for non-tracker stage, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("expected strict-schema unknown field error for non-tracker stage, got %v", err)
 	}
 }
 

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -384,7 +384,7 @@ func normalizeDecisionLabel(result StageClassification, updatedStateJSON string)
 }
 
 func normalizeStateSnapshot(previousState string, result StageClassification) string {
-	current := firstNonEmpty(strings.TrimSpace(result.UpdatedStateJSON), strings.TrimSpace(result.RawResponse))
+	current := strings.TrimSpace(result.UpdatedStateJSON)
 	if current == "" {
 		return strings.TrimSpace(previousState)
 	}

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -527,7 +527,7 @@ func TestWorkerProcessStreamerPassesPersistedPreviousStateToTrackerStages(t *tes
 	}
 }
 
-func TestWorkerProcessStreamerNormalizesLegacyStatePayloads(t *testing.T) {
+func TestWorkerProcessStreamerIgnoresRawResponseStatePayloads(t *testing.T) {
 	decisions := &fakeDecisionStore{}
 	worker := NewWorker(
 		fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}},
@@ -535,13 +535,13 @@ func TestWorkerProcessStreamerNormalizesLegacyStatePayloads(t *testing.T) {
 			"start": {
 				Confidence: 0.91,
 				RawResponse: `{
-					"state": {
-						"mode": {"value": "competitive", "confidence": 0.9},
-						"ct_score": {"value": 8, "confidence": 0.9},
-						"t_score": {"value": 5, "confidence": 0.9}
-					},
-					"final_outcome": "unknown"
-				}`,
+						"state": {
+							"mode": {"value": "competitive", "confidence": 0.9},
+							"ct_score": {"value": 8, "confidence": 0.9},
+							"t_score": {"value": 5, "confidence": 0.9}
+						},
+						"final_outcome": "unknown"
+					}`,
 			},
 		}},
 		fakePromptResolver{prompts: []prompts.PromptVersion{{ID: "tracker-1", Stage: "start", Position: 1, IsActive: true, MinConfidence: 0.5, Template: "update tracker state", Model: "gemini", MaxTokens: 100, TimeoutMS: 1000}}},
@@ -557,7 +557,7 @@ func TestWorkerProcessStreamerNormalizesLegacyStatePayloads(t *testing.T) {
 	if len(decisions.items) != 1 {
 		t.Fatalf("recorded %d decisions, want 1", len(decisions.items))
 	}
-	if got := decisions.items[0].UpdatedStateJSON; !strings.Contains(got, `"state":{"ct_score":8,"mode":"competitive","t_score":5}`) || !strings.Contains(got, `"final_outcome":"unknown"`) {
+	if got := decisions.items[0].UpdatedStateJSON; got != defaultTrackerState() {
 		t.Fatalf("updated state = %q", decisions.items[0].UpdatedStateJSON)
 	}
 }


### PR DESCRIPTION
### Motivation

- Enforce that LLM responses strictly follow the admin-managed `responseSchemaJson` so runtime behavior is deterministic and extra keys are rejected.
- Remove legacy freeform fields and heuristic coercion (like `label`, `confidence`, `summary`) to avoid accidental backfill and ambiguous normalization.
- Simplify downstream state handling by passing through schema-driven `updated_state` payloads and synthesizing labels/confidence where appropriate.

### Description

- Update the Gemini classifier to expect only schema-defined tracker fields by removing `Label`, `Confidence`, and `Summary` from `geminiStageResponse` and parsing responses with a `json.Decoder` using `DisallowUnknownFields()` and trailing-token checks.
- Synthesize decision metadata by defaulting `Label` to `state_updated` (or to a non-empty `final_outcome`) and setting `Confidence` to `1` instead of relying on parsed numeric confidence.
- Tighten prompt/instruction text to require strict JSON matching the admin-managed schema and disallow extraneous keys, and stop coercing legacy tracker fields from raw LLM text.
- Adjust worker normalization to use the explicit `updated_state` payload rather than trying to coerce state out of raw responses, and update tests to reflect the new strict-schema behavior.

### Testing

- Ran the media package unit tests (`go test ./internal/media`), including the updated `gemini_test.go`, and they passed.
- Ran the repository unit test suite (`go test ./...`) after updates to `worker_test.go`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca72a29724832c8eba60d1413d75a9)