### PR TITLE
Enforce scenario-owned strict JSON responses for Gemini stages and remove legacy tracker coercion

### DIFF
--- a/docs/llm_stream_orchestration_plan.md
+++ b/docs/llm_stream_orchestration_plan.md
@@ -37,6 +37,8 @@ Current orchestration uses only the model below:
 - Worker keeps compact persisted state per streamer/session.
 - Transition evaluation happens each cycle from current step + current state.
 - If no transition matches, worker stays on the same step.
+- Backend must not rely on any hardcoded response keys; the only valid payload
+  contract is the active step `responseSchemaJson`.
 
 ## Admin UX requirements
 - Scenario tree grouped by `gameSlug` and `folder` path.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -113,10 +113,12 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 > active scenario step and sends chunk metadata/media with strict-JSON contract
 > expectations derived from that step.
 >
-> Legacy Gemini response coercion is disabled: tracker stages must return
+> Legacy Gemini response coercion is disabled: every stage must return
 > strict JSON that matches the active step `responseSchemaJson` exactly.
-> LLM response payload shape is fully defined by the active step
-> `responseSchemaJson`; extra keys are rejected by runtime.
+> Runtime no longer expects hardcoded tracker fields (`updated_state`, `delta`,
+> `next_needed_evidence`, `hard_conflicts`, `final_outcome`) as a built-in
+> contract. The full LLM JSON payload is treated as scenario-owned state data.
+> Extra keys outside the scenario schema are rejected by runtime.
 
 Update this table whenever you introduce a new configuration surface.
 

--- a/docs/migrations_plan.md
+++ b/docs/migrations_plan.md
@@ -12,7 +12,9 @@
 > `migrations/0007_remove_streamer_llm_decision_history.up.sql`,
 > `migrations/0007_remove_streamer_llm_decision_history.down.sql`,
 > `migrations/0008_llm_model_configs_and_scenario_binding.up.sql`, and
-> `migrations/0008_llm_model_configs_and_scenario_binding.down.sql`.
+> `migrations/0008_llm_model_configs_and_scenario_binding.down.sql`,
+> `migrations/0009_remove_legacy_tracker_response_fields.up.sql`, and
+> `migrations/0009_remove_legacy_tracker_response_fields.down.sql`.
 >
 > Legacy duplicate-version migration files were removed so `golang-migrate`
 > sees a single `*.up.sql` and `*.down.sql` pair per version.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1009,16 +1009,16 @@ components:
           type: string
         updatedStateJson:
           type: string
-          description: Canonical tracker `updated_state` JSON snapshot persisted after this step.
+          description: Scenario-defined strict-JSON payload returned by the active step and persisted as current state snapshot.
         evidenceDeltaJson:
           type: string
-          description: Canonical tracker `delta` JSON payload persisted after this step.
+          description: Deprecated legacy field retained for backward compatibility; new runtime does not require a dedicated delta key.
         conflictsJson:
           type: string
-          description: Canonical tracker `hard_conflicts` JSON payload persisted after this step.
+          description: Deprecated legacy field retained for backward compatibility; new runtime does not require a dedicated conflicts key.
         finalOutcome:
           type: string
-          description: Canonical tracker `final_outcome` value (`win|loss|draw|unknown`).
+          description: Deprecated legacy field retained for backward compatibility; scenario schema defines any terminal outcome semantics.
         createdAt:
           type: string
           format: date-time

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/otel/trace v1.26.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -13,10 +13,13 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
 var (
@@ -24,6 +27,7 @@ var (
 	ErrGeminiChunkRequired   = errors.New("gemini chunk reference is required")
 	ErrGeminiChunkTooLarge   = errors.New("gemini chunk exceeds inline upload limit")
 	ErrGeminiEmptyResponse   = errors.New("gemini returned empty response")
+	ErrGeminiSchemaRequired  = errors.New("gemini response schema is required")
 	ErrGeminiUnsupportedMIME = errors.New("gemini does not support the chunk mime type")
 )
 
@@ -179,14 +183,6 @@ type geminiUsageMetadata struct {
 	TotalTokenCount      int `json:"totalTokenCount"`
 }
 
-type geminiStageResponse struct {
-	UpdatedState       json.RawMessage `json:"updated_state,omitempty"`
-	Delta              json.RawMessage `json:"delta,omitempty"`
-	NextNeededEvidence json.RawMessage `json:"next_needed_evidence,omitempty"`
-	HardConflicts      json.RawMessage `json:"hard_conflicts,omitempty"`
-	FinalOutcome       string          `json:"final_outcome,omitempty"`
-}
-
 func (c *GeminiStageClassifier) Classify(ctx context.Context, input StageRequest) (StageClassification, error) {
 	return c.classify(ctx, input, false)
 }
@@ -275,37 +271,25 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 		return StageClassification{}, fmt.Errorf("%v; stage=%s streamer_id=%s session_key=%s prompt_id=%s force_bootstrap=%t", err, strings.TrimSpace(input.Stage), strings.TrimSpace(input.StreamerID), sessionKey, strings.TrimSpace(input.Prompt.ID), forceBootstrap)
 	}
 
-	parsed, err := parseGeminiStageResponse(rawText)
+	parsedPayload, err := parseGeminiStageResponse(rawText, input.ResponseSchema)
 	if err != nil {
 		if errors.Is(err, ErrGeminiEmptyResponse) {
 			return StageClassification{}, fmt.Errorf("%v; stage=%s streamer_id=%s session_key=%s prompt_id=%s raw_text=%s", err, strings.TrimSpace(input.Stage), strings.TrimSpace(input.StreamerID), sessionKey, strings.TrimSpace(input.Prompt.ID), strconv.Quote(trimForLog(rawText, 512)))
 		}
 		return StageClassification{}, err
 	}
-	if err := validateGeminiTrackerResponse(input.Stage, parsed); err != nil {
-		return StageClassification{}, err
-	}
 	c.storeSessionResponse(sessionKey, promptFingerprint, contents, payload, rawText)
 
-	label := "state_updated"
-	if outcome := strings.TrimSpace(parsed.FinalOutcome); outcome != "" && !strings.EqualFold(outcome, "unknown") {
-		label = strings.TrimSpace(parsed.FinalOutcome)
-	}
 	return StageClassification{
-		Label:             label,
-		Confidence:        1,
-		RawResponse:       strings.TrimSpace(rawText),
-		RequestRef:        endpoint,
-		ResponseRef:       strconv.Itoa(resp.StatusCode),
-		TokensIn:          payload.UsageMetadata.PromptTokenCount,
-		TokensOut:         payload.UsageMetadata.CandidatesTokenCount,
-		Latency:           time.Since(started),
-		NormalizedOutcome: strings.TrimSpace(parsed.FinalOutcome),
-		UpdatedStateJSON:  marshalRawMessage(parsed.UpdatedState),
-		EvidenceDeltaJSON: marshalRawMessage(parsed.Delta),
-		NextEvidenceJSON:  marshalRawMessage(parsed.NextNeededEvidence),
-		ConflictsJSON:     marshalRawMessage(parsed.HardConflicts),
-		FinalOutcome:      strings.TrimSpace(parsed.FinalOutcome),
+		Label:            "state_updated",
+		Confidence:       1,
+		RawResponse:      strings.TrimSpace(rawText),
+		RequestRef:       endpoint,
+		ResponseRef:      strconv.Itoa(resp.StatusCode),
+		TokensIn:         payload.UsageMetadata.PromptTokenCount,
+		TokensOut:        payload.UsageMetadata.CandidatesTokenCount,
+		Latency:          time.Since(started),
+		UpdatedStateJSON: parsedPayload,
 	}, nil
 }
 
@@ -574,23 +558,121 @@ func geminiBlockedSafetyCategories(ratings []geminiSafetyRating) []string {
 	return categories
 }
 
-func parseGeminiStageResponse(raw string) (geminiStageResponse, error) {
+func parseGeminiStageResponse(raw, responseSchema string) (string, error) {
 	cleaned := strings.TrimSpace(raw)
+	if cleaned == "" {
+		return "", ErrGeminiEmptyResponse
+	}
+	if strings.TrimSpace(responseSchema) == "" {
+		return "", ErrGeminiSchemaRequired
+	}
 
-	var parsed geminiStageResponse
+	if err := validateGeminiResponseSchema(cleaned, responseSchema); err != nil {
+		return "", err
+	}
+
+	var payload any
 	decoder := json.NewDecoder(strings.NewReader(cleaned))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&parsed); err != nil {
-		return geminiStageResponse{}, fmt.Errorf("parse gemini stage response: %w", err)
+	if err := decoder.Decode(&payload); err != nil {
+		return "", fmt.Errorf("parse gemini stage response: %w", err)
 	}
 	if decoder.More() {
-		return geminiStageResponse{}, fmt.Errorf("parse gemini stage response: unexpected trailing tokens")
+		return "", fmt.Errorf("parse gemini stage response: unexpected trailing tokens")
 	}
-	parsed.FinalOutcome = strings.TrimSpace(parsed.FinalOutcome)
-	if !hasGeminiResponsePayload(parsed) {
-		return geminiStageResponse{}, ErrGeminiEmptyResponse
+	normalized, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("normalize gemini stage response: %w", err)
 	}
-	return parsed, nil
+	cleaned = strings.TrimSpace(string(normalized))
+	if cleaned == "" || cleaned == "null" {
+		return "", ErrGeminiEmptyResponse
+	}
+	return cleaned, nil
+}
+
+func validateGeminiResponseSchema(responseRaw, responseSchema string) error {
+	schemaRaw := strings.TrimSpace(responseSchema)
+	if schemaRaw == "" {
+		return nil
+	}
+
+	var schemaDoc any
+	if err := json.Unmarshal([]byte(schemaRaw), &schemaDoc); err != nil {
+		return fmt.Errorf("invalid responseSchemaJson: %w", err)
+	}
+	normalizedSchema := normalizeResponseSchema(schemaDoc)
+	schemaBody, err := json.Marshal(normalizedSchema)
+	if err != nil {
+		return fmt.Errorf("marshal response schema: %w", err)
+	}
+
+	var payload any
+	if err := json.Unmarshal([]byte(responseRaw), &payload); err != nil {
+		return fmt.Errorf("parse gemini stage response: %w", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	const schemaURL = "inmemory://response-schema.json"
+	if err := compiler.AddResource(schemaURL, strings.NewReader(string(schemaBody))); err != nil {
+		return fmt.Errorf("load response schema: %w", err)
+	}
+	compiled, err := compiler.Compile(schemaURL)
+	if err != nil {
+		return fmt.Errorf("compile response schema: %w", err)
+	}
+	if err := compiled.Validate(payload); err != nil {
+		return fmt.Errorf("gemini response does not match responseSchemaJson: %w", err)
+	}
+	return nil
+}
+
+func normalizeResponseSchema(schemaDoc any) any {
+	object, ok := schemaDoc.(map[string]any)
+	if !ok {
+		return schemaDoc
+	}
+	if _, hasType := object["type"]; hasType {
+		return schemaDoc
+	}
+	return templateValueToSchema(schemaDoc)
+}
+
+func templateValueToSchema(value any) map[string]any {
+	switch typed := value.(type) {
+	case map[string]any:
+		properties := make(map[string]any, len(typed))
+		required := make([]string, 0, len(typed))
+		for key, item := range typed {
+			properties[key] = templateValueToSchema(item)
+			required = append(required, key)
+		}
+		sort.Strings(required)
+		return map[string]any{
+			"type":                 "object",
+			"properties":           properties,
+			"required":             required,
+			"additionalProperties": false,
+		}
+	case []any:
+		schema := map[string]any{"type": "array"}
+		if len(typed) > 0 {
+			schema["items"] = templateValueToSchema(typed[0])
+		}
+		return schema
+	case string:
+		return map[string]any{"type": "string"}
+	case bool:
+		return map[string]any{"type": "boolean"}
+	case nil:
+		return map[string]any{"type": "null"}
+	case float64:
+		if float64(int64(typed)) == typed {
+			return map[string]any{"type": "integer"}
+		}
+		return map[string]any{"type": "number"}
+	default:
+		return map[string]any{}
+	}
 }
 
 func trimForLog(value string, max int) string {
@@ -599,14 +681,6 @@ func trimForLog(value string, max int) string {
 		return trimmed
 	}
 	return trimmed[:max] + "..."
-}
-
-func hasGeminiResponsePayload(parsed geminiStageResponse) bool {
-	return len(parsed.UpdatedState) > 0 ||
-		len(parsed.Delta) > 0 ||
-		len(parsed.NextNeededEvidence) > 0 ||
-		len(parsed.HardConflicts) > 0 ||
-		strings.TrimSpace(parsed.FinalOutcome) != ""
 }
 
 func normalizeGeminiModel(model string) string {
@@ -624,26 +698,4 @@ func validateGeminiMIMEType(mimeType string) error {
 	default:
 		return fmt.Errorf("%w: %s (convert Streamlink .ts chunks to a supported format such as video/mp4 before calling Gemini)", ErrGeminiUnsupportedMIME, mimeType)
 	}
-}
-
-func marshalRawMessage(value json.RawMessage) string {
-	trimmed := strings.TrimSpace(string(value))
-	if trimmed == "" || trimmed == "null" {
-		return ""
-	}
-	return trimmed
-}
-
-func validateGeminiTrackerResponse(stage string, parsed geminiStageResponse) error {
-	if !isTrackerStage(stage) {
-		return nil
-	}
-	if strings.TrimSpace(parsed.FinalOutcome) != "" {
-		switch strings.TrimSpace(parsed.FinalOutcome) {
-		case "win", "loss", "draw", "unknown":
-		default:
-			return fmt.Errorf("gemini tracker response for %s has invalid final_outcome %q", strings.TrimSpace(stage), parsed.FinalOutcome)
-		}
-	}
-	return nil
 }

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -20,6 +20,19 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+const strictTrackerResponseSchema = `{
+	"type":"object",
+	"additionalProperties": false,
+	"required":["updated_state"],
+	"properties":{
+		"updated_state":{"type":"object"},
+		"delta":{"type":["array","object","null"]},
+		"next_needed_evidence":{"type":["array","object","null"]},
+		"hard_conflicts":{"type":["array","object","null"]},
+		"final_outcome":{"type":["string","null"]}
+	}
+}`
+
 func TestNewGeminiStageClassifierRequiresAPIKey(t *testing.T) {
 	if _, err := NewGeminiStageClassifier(GeminiClassifierConfig{}); err == nil {
 		t.Fatal("expected missing api key error")
@@ -74,6 +87,7 @@ func TestGeminiStageClassifierClassify(t *testing.T) {
 			MaxTokens:   128,
 			TimeoutMS:   1000,
 		},
+		ResponseSchema: strictTrackerResponseSchema,
 	})
 	if err != nil {
 		t.Fatalf("Classify() error = %v", err)
@@ -138,7 +152,8 @@ func TestGeminiStageClassifierReusesChatSessionWithoutResendingPrompt(t *testing
 			Template: "Update the game state",
 			Model:    "gemini",
 		},
-		PreviousState: `{"status":"discovering"}`,
+		PreviousState:  `{"status":"discovering"}`,
+		ResponseSchema: strictTrackerResponseSchema,
 	}
 	if _, err := classifier.Classify(context.Background(), req); err != nil {
 		t.Fatalf("first Classify() error = %v", err)
@@ -209,6 +224,7 @@ func TestGeminiStageClassifierSanitizesGenerationConfig(t *testing.T) {
 			MaxTokens:   geminiMaxOutputTokensLimit + 1,
 			TimeoutMS:   1000,
 		},
+		ResponseSchema: strictTrackerResponseSchema,
 	})
 	if err != nil {
 		t.Fatalf("Classify() error = %v", err)
@@ -218,6 +234,115 @@ func TestGeminiStageClassifierSanitizesGenerationConfig(t *testing.T) {
 	}
 	if strings.Contains(gotBody, `"maxOutputTokens":`) {
 		t.Fatalf("expected oversized maxOutputTokens to be omitted from generation config: %s", gotBody)
+	}
+}
+
+func TestGeminiStageClassifierValidatesResponseAgainstJSONSchema(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"game\":\"cs2\"},\"delta\":[],\"next_needed_evidence\":[],\"hard_conflicts\":[],\"final_outcome\":\"unknown\",\"unexpected\":true}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 8}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	_, err = classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "match_update",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt: prompts.PromptVersion{
+			Stage:    "match_update",
+			Template: "Update the game state",
+			Model:    "gemini",
+		},
+		ResponseSchema: `{
+            "type":"object",
+            "additionalProperties": false,
+            "required":["updated_state","delta","next_needed_evidence","hard_conflicts","final_outcome"],
+            "properties":{
+                "updated_state":{"type":"object"},
+                "delta":{"type":"array"},
+                "next_needed_evidence":{"type":"array"},
+                "hard_conflicts":{"type":"array"},
+                "final_outcome":{"type":"string"}
+            }
+        }`,
+	})
+	if err == nil {
+		t.Fatal("expected schema validation error for unexpected key")
+	}
+	if !strings.Contains(err.Error(), "responseSchemaJson") {
+		t.Fatalf("expected schema validation error details, got %v", err)
+	}
+}
+
+func TestGeminiStageClassifierValidatesResponseAgainstTemplateContract(t *testing.T) {
+	dir := t.TempDir()
+	chunkPath := filepath.Join(dir, "chunk.mp4")
+	if err := os.WriteFile(chunkPath, []byte("fake transport stream"), 0o644); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+
+	classifier, err := NewGeminiStageClassifier(GeminiClassifierConfig{
+		APIKey:  "gemini-key",
+		BaseURL: "https://gemini.test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"updated_state\":{\"game\":\"cs2\"},\"delta\":[],\"next_needed_evidence\":[],\"hard_conflicts\":[],\"final_outcome\":\"unknown\"}"}]}
+                    }],
+                    "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 8}
+                }`)),
+			}, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiStageClassifier() error = %v", err)
+	}
+
+	result, err := classifier.Classify(context.Background(), StageRequest{
+		StreamerID: "str-1",
+		Stage:      "match_update",
+		Chunk:      ChunkRef{Reference: chunkPath},
+		Prompt: prompts.PromptVersion{
+			Stage:    "match_update",
+			Template: "Update the game state",
+			Model:    "gemini",
+		},
+		ResponseSchema: `{
+            "updated_state": {"game": ""},
+            "delta": [],
+            "next_needed_evidence": [],
+            "hard_conflicts": [],
+            "final_outcome": ""
+        }`,
+	})
+	if err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+	if result.FinalOutcome != "" {
+		t.Fatalf("expected final outcome to remain empty without dedicated extraction, got %q", result.FinalOutcome)
 	}
 }
 
@@ -265,7 +390,8 @@ func TestGeminiStageClassifierRotatesChatWhenTokenBudgetReached(t *testing.T) {
 			Template: "Update the game state",
 			Model:    "gemini",
 		},
-		PreviousState: `{"status":"discovering"}`,
+		PreviousState:  `{"status":"discovering"}`,
+		ResponseSchema: strictTrackerResponseSchema,
 	}
 	if _, err := classifier.Classify(context.Background(), req); err != nil {
 		t.Fatalf("first Classify() error = %v", err)
@@ -355,7 +481,8 @@ func TestGeminiStageClassifierDoesNotResetSessionOnEmptyContinuationResponse(t *
 			Template: "Update the game state",
 			Model:    "gemini",
 		},
-		PreviousState: `{"status":"discovering"}`,
+		PreviousState:  `{"status":"discovering"}`,
+		ResponseSchema: strictTrackerResponseSchema,
 	}
 	if _, err := classifier.Classify(context.Background(), req); err != nil {
 		t.Fatalf("first Classify() error = %v", err)
@@ -373,8 +500,8 @@ func TestGeminiStageClassifierDoesNotResetSessionOnEmptyContinuationResponse(t *
 	if err != nil {
 		t.Fatalf("third Classify() error = %v", err)
 	}
-	if result.FinalOutcome != "win" {
-		t.Fatalf("expected recovered outcome win, got %q", result.FinalOutcome)
+	if result.FinalOutcome != "" {
+		t.Fatalf("expected recovered outcome to remain empty without dedicated extraction, got %q", result.FinalOutcome)
 	}
 	if len(requestBodies) != 3 {
 		t.Fatalf("expected 3 requests, got %d", len(requestBodies))
@@ -533,10 +660,11 @@ func TestGeminiStageClassifierAcceptsTrackerResponseWithoutLabel(t *testing.T) {
 	}
 
 	result, err := classifier.Classify(context.Background(), StageRequest{
-		StreamerID: "str-1",
-		Stage:      "match_update",
-		Chunk:      ChunkRef{Reference: chunkPath},
-		Prompt:     prompts.PromptVersion{Stage: "match_update", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+		StreamerID:     "str-1",
+		Stage:          "match_update",
+		Chunk:          ChunkRef{Reference: chunkPath},
+		Prompt:         prompts.PromptVersion{Stage: "match_update", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+		ResponseSchema: strictTrackerResponseSchema,
 	})
 	if err != nil {
 		t.Fatalf("Classify() error = %v", err)
@@ -544,11 +672,11 @@ func TestGeminiStageClassifierAcceptsTrackerResponseWithoutLabel(t *testing.T) {
 	if result.Label != "state_updated" {
 		t.Fatalf("expected synthesized label state_updated, got %q", result.Label)
 	}
-	if result.UpdatedStateJSON != `{"status":"live"}` {
-		t.Fatalf("expected updated state payload, got %s", result.UpdatedStateJSON)
+	if result.UpdatedStateJSON != `{"delta":["score_seen"],"final_outcome":"unknown","next_needed_evidence":["winner_banner"],"updated_state":{"status":"live"}}` {
+		t.Fatalf("expected scenario-defined payload, got %s", result.UpdatedStateJSON)
 	}
-	if result.FinalOutcome != "unknown" {
-		t.Fatalf("expected final outcome unknown, got %q", result.FinalOutcome)
+	if result.FinalOutcome != "" {
+		t.Fatalf("expected final outcome to stay empty without dedicated extraction, got %q", result.FinalOutcome)
 	}
 }
 
@@ -580,10 +708,11 @@ func TestGeminiStageClassifierAcceptsSchemaDrivenTrackerPayloadWithoutLegacyStat
 	}
 
 	result, err := classifier.Classify(context.Background(), StageRequest{
-		StreamerID: "str-1",
-		Stage:      "match_update",
-		Chunk:      ChunkRef{Reference: chunkPath},
-		Prompt:     prompts.PromptVersion{Stage: "match_update", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+		StreamerID:     "str-1",
+		Stage:          "match_update",
+		Chunk:          ChunkRef{Reference: chunkPath},
+		Prompt:         prompts.PromptVersion{Stage: "match_update", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+		ResponseSchema: strictTrackerResponseSchema,
 	})
 	if err != nil {
 		t.Fatalf("expected schema-driven tracker payload to pass, got %v", err)
@@ -591,8 +720,8 @@ func TestGeminiStageClassifierAcceptsSchemaDrivenTrackerPayloadWithoutLegacyStat
 	if result.Label != "state_updated" {
 		t.Fatalf("expected label from response, got %q", result.Label)
 	}
-	if result.UpdatedStateJSON != `{"status":"live"}` {
-		t.Fatalf("expected updated_state to be passed through, got %q", result.UpdatedStateJSON)
+	if result.UpdatedStateJSON != `{"updated_state":{"status":"live"}}` {
+		t.Fatalf("expected scenario-defined payload to pass through, got %q", result.UpdatedStateJSON)
 	}
 }
 
@@ -624,16 +753,17 @@ func TestGeminiStageClassifierDoesNotBackfillTrackerStartPayload(t *testing.T) {
 	}
 
 	result, err := classifier.Classify(context.Background(), StageRequest{
-		StreamerID: "str-1",
-		Stage:      "Start",
-		Chunk:      ChunkRef{Reference: chunkPath},
-		Prompt:     prompts.PromptVersion{Stage: "Start", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+		StreamerID:     "str-1",
+		Stage:          "Start",
+		Chunk:          ChunkRef{Reference: chunkPath},
+		Prompt:         prompts.PromptVersion{Stage: "Start", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+		ResponseSchema: strictTrackerResponseSchema,
 	})
 	if err != nil {
 		t.Fatalf("expected start stage payload without backfill to pass, got error %v", err)
 	}
-	if result.UpdatedStateJSON != `{"status":"live"}` {
-		t.Fatalf("expected updated_state to be preserved, got %q", result.UpdatedStateJSON)
+	if result.UpdatedStateJSON != `{"updated_state":{"status":"live"}}` {
+		t.Fatalf("expected scenario-defined payload to be preserved, got %q", result.UpdatedStateJSON)
 	}
 	if strings.TrimSpace(result.EvidenceDeltaJSON) != "" {
 		t.Fatalf("expected no delta fallback, got %q", result.EvidenceDeltaJSON)
@@ -674,10 +804,11 @@ func TestGeminiStageClassifierKeepsNullFinalOutcomeEmptyWhenSchemaOmitsFallback(
 	}
 
 	result, err := classifier.Classify(context.Background(), StageRequest{
-		StreamerID: "str-1",
-		Stage:      "Start",
-		Chunk:      ChunkRef{Reference: chunkPath},
-		Prompt:     prompts.PromptVersion{Stage: "Start", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+		StreamerID:     "str-1",
+		Stage:          "Start",
+		Chunk:          ChunkRef{Reference: chunkPath},
+		Prompt:         prompts.PromptVersion{Stage: "Start", Template: "Update the game state", Model: "gemini", MaxTokens: 128, TimeoutMS: 1000},
+		ResponseSchema: strictTrackerResponseSchema,
 	})
 	if err != nil {
 		t.Fatalf("expected null final_outcome to pass without normalization, got error %v", err)
@@ -725,9 +856,10 @@ func TestGeminiStageClassifierDoesNotCoerceNonTrackerStatePayload(t *testing.T) 
 			MaxTokens: 128,
 			TimeoutMS: 1000,
 		},
+		ResponseSchema: strictTrackerResponseSchema,
 	})
-	if err == nil || !strings.Contains(err.Error(), "unknown field") {
-		t.Fatalf("expected strict-schema unknown field error for non-tracker stage, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "does not match responseSchemaJson") {
+		t.Fatalf("expected schema validation error for non-tracker stage, got %v", err)
 	}
 }
 
@@ -847,16 +979,14 @@ func TestGeminiStageClassifierReportsEmptyParsedPayloadDiagnostics(t *testing.T)
 			MaxTokens: 128,
 			TimeoutMS: 1000,
 		},
+		ResponseSchema: strictTrackerResponseSchema,
 	})
 	if err == nil {
 		t.Fatal("expected parsed empty response diagnostics error")
 	}
 	for _, fragment := range []string{
-		ErrGeminiEmptyResponse.Error(),
-		"stage=Start",
-		"streamer_id=str-1",
-		"prompt_id=prompt-start",
-		`raw_text="{}"`,
+		"does not match responseSchemaJson",
+		"missing properties: 'updated_state'",
 	} {
 		if !strings.Contains(err.Error(), fragment) {
 			t.Fatalf("expected error to contain %q, got %v", fragment, err)

--- a/migrations/0009_remove_legacy_tracker_response_fields.down.sql
+++ b/migrations/0009_remove_legacy_tracker_response_fields.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE IF EXISTS streamer_llm_decisions ADD COLUMN IF NOT EXISTS previous_state_json TEXT;
+ALTER TABLE IF EXISTS streamer_llm_decisions ADD COLUMN IF NOT EXISTS evidence_delta_json TEXT;
+ALTER TABLE IF EXISTS streamer_llm_decisions ADD COLUMN IF NOT EXISTS conflicts_json TEXT;
+ALTER TABLE IF EXISTS streamer_llm_decisions ADD COLUMN IF NOT EXISTS final_outcome TEXT;

--- a/migrations/0009_remove_legacy_tracker_response_fields.up.sql
+++ b/migrations/0009_remove_legacy_tracker_response_fields.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE IF EXISTS streamer_llm_decisions DROP COLUMN IF EXISTS previous_state_json;
+ALTER TABLE IF EXISTS streamer_llm_decisions DROP COLUMN IF EXISTS evidence_delta_json;
+ALTER TABLE IF EXISTS streamer_llm_decisions DROP COLUMN IF EXISTS conflicts_json;
+ALTER TABLE IF EXISTS streamer_llm_decisions DROP COLUMN IF EXISTS final_outcome;


### PR DESCRIPTION
### Motivation
- Move tracker runtime to scenario-driven contracts by requiring every LLM stage to return strict JSON that matches the active step `responseSchemaJson` instead of relying on hardcoded tracker fields.
- Prevent backend coupling to legacy keys (`updated_state`, `delta`, `next_needed_evidence`, `hard_conflicts`, `final_outcome`) and treat the full LLM payload as scenario-owned state.
- Prepare schema-driven orchestration and admin-managed scenario packages while cleaning up DB and API surfaces that assumed legacy tracker payloads.

### Description
- Implement JSON Schema validation for Gemini stage responses using `github.com/santhosh-tekuri/jsonschema/v5` and add `validateGeminiResponseSchema`, `normalizeResponseSchema`, and `templateValueToSchema` helpers to accept both explicit schemas and template-style shortcut schemas.
- Modify `parseGeminiStageResponse` to require a non-empty `responseSchema` and to return a normalized strict-JSON string payload after validation; remove legacy tracker-specific parsing/coercion and related typed fields.
- Change classification output to persist the full scenario-defined payload in `UpdatedStateJSON` and stop backfilling or extracting the old legacy fields (legacy fields are deprecated in API docs and docs updated accordingly).
- Add DB migrations `0009_remove_legacy_tracker_response_fields.up.sql`/`.down.sql` to drop legacy columns and update `migrations_plan.md`, `local_setup.md`, and `openapi.yaml` to reflect the new contract and deprecations.
- Update and extend unit tests in `internal/media/gemini_test.go` to assert schema validation, template-to-schema behavior, normalized payload persistence, and various continuation/rotation behaviors.

### Testing
- Ran unit tests for the media package with `go test ./internal/media` which exercise the new schema validation and parsing code, and they passed.
- Ran the repository unit test suite with `go test ./...` to ensure no regressions across packages, and it completed successfully.
- Added targeted tests `TestGeminiStageClassifierValidatesResponseAgainstJSONSchema` and `TestGeminiStageClassifierValidatesResponseAgainstTemplateContract` that verify schema rejection of unexpected keys and acceptance of template-derived schemas; both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7a82602c832cbe004122e58f15b9)