### PR TITLE
fix: align go.mod jsonschema dependency classification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.19.0
 	github.com/redis/go-redis/v9 v9.18.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.48.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.26.0
@@ -33,7 +34,6 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/otel/trace v1.26.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect


### PR DESCRIPTION
### Motivation
- CI verification `Verify go.mod / go.sum` was failing because `github.com/santhosh-tekuri/jsonschema/v5` was recorded only as an indirect dependency while the codebase imports it directly, causing `go mod tidy` to produce diffs.
- Checklist: [x] Promote `jsonschema` to a direct `require` to stop `go mod tidy` drift; [ ] Complete milestone M2.1 items from `docs/implementation_plan.md`; [ ] Align runtime behavior to `docs/llm_stream_orchestration_plan.md`.

### Description
- Updated `go.mod` to move `github.com/santhosh-tekuri/jsonschema/v5 v5.3.1` into the main `require` block, ran `go mod tidy`, and committed the change to eliminate the spurious diff.

### Testing
- Ran `go test ./...` and all package tests completed successfully.
- Ran `go mod tidy && git diff --exit-code go.mod go.sum` which returned no diffs, confirming the `go.mod`/`go.sum` drift is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca92870650832ca1f113072c2bcff0)