### PR TITLE
Remove persisted previous state from Gemini prompts and simplify default tracker state

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -370,44 +370,10 @@ Use this admin-managed tracker prompt as the source of truth (including the expe
 %s
 Expected response schema:
 %s`
-	previousState := strings.TrimSpace(input.PreviousState)
-	if previousState == "" {
-		previousState = defaultTrackerState()
-	}
-	if !isTrackerStage(input.Stage) {
-		return strings.TrimSpace(fmt.Sprintf(base+`
-Return ONLY valid JSON that matches the admin-managed JSON template from the prompt above.
-Do not include any keys that are not part of the admin-managed template.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.ResponseSchema)))
-	}
 	return strings.TrimSpace(fmt.Sprintf(base+`
-Previous persisted tracker state JSON:
-%s
-
-You are a match state tracker for a single game session.
-
-Critical rule:
-The end of available video data is NOT the same as confirmed end of the match.
-
-Track two independent fields:
-- player_result.outcome = win | loss | draw | unknown
-- session_status.value = in_progress | likely_finished | confirmed_finished | likely_truncated | unknown
-
-Stage-specific behavior:
-- For match_update: update cumulative state using previous_state + new_chunk.
-- For close_current_session or match_finalize: no more chunks are currently available; do NOT assume the match finished and choose closure status only from accumulated evidence.
-
 Return ONLY valid JSON that matches the admin-managed JSON template from the prompt above.
 Do not add keys that are not present in the schema/template.
-
-Mandatory rules:
-1. Never infer match completion only because no more chunks are currently available.
-2. Never infer player victory/defeat from gameplay quality.
-3. If schema contains final outcome semantics, validate them only from strong terminal evidence (final banner, final scoreboard, explicit post-match UI, or repeated strong terminal signals).
-4. If schema contains completion flags and completion is not confirmed, keep them in an unknown/non-final state.
-5. If chunk stream appears cut during active gameplay, reflect likely truncation if such field exists in schema.
-6. Preserve previously confirmed evidence unless clearly contradicted.
-7. Record contradictions only in schema-approved conflict fields.
-8. Never emit narrative commentary outside JSON.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.ResponseSchema), previousState))
+Never emit narrative commentary outside JSON.`, input.Stage, strings.TrimSpace(input.StreamerID), formatChunkCapturedAt(input.Chunk.CapturedAt), formatChunkReference(input.Chunk.Reference), strings.TrimSpace(input.Prompt.Template), strings.TrimSpace(input.ResponseSchema)))
 }
 
 func buildGeminiContinuationInstruction(input StageRequest) string {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -152,7 +152,6 @@ func TestGeminiStageClassifierReusesChatSessionWithoutResendingPrompt(t *testing
 			Template: "Update the game state",
 			Model:    "gemini",
 		},
-		PreviousState:  `{"status":"discovering"}`,
 		ResponseSchema: strictTrackerResponseSchema,
 	}
 	if _, err := classifier.Classify(context.Background(), req); err != nil {
@@ -390,7 +389,6 @@ func TestGeminiStageClassifierRotatesChatWhenTokenBudgetReached(t *testing.T) {
 			Template: "Update the game state",
 			Model:    "gemini",
 		},
-		PreviousState:  `{"status":"discovering"}`,
 		ResponseSchema: strictTrackerResponseSchema,
 	}
 	if _, err := classifier.Classify(context.Background(), req); err != nil {
@@ -481,7 +479,6 @@ func TestGeminiStageClassifierDoesNotResetSessionOnEmptyContinuationResponse(t *
 			Template: "Update the game state",
 			Model:    "gemini",
 		},
-		PreviousState:  `{"status":"discovering"}`,
 		ResponseSchema: strictTrackerResponseSchema,
 	}
 	if _, err := classifier.Classify(context.Background(), req); err != nil {
@@ -593,9 +590,8 @@ func TestBuildGeminiInstructionUsesTrackerContract(t *testing.T) {
 	for _, fragment := range []string{
 		"Streamer ID: str-42",
 		"Chunk reference: /tmp/chunk.mp4",
-		"Previous persisted tracker state JSON:",
-		defaultTrackerState(),
 		"Do not add keys that are not present in the schema/template.",
+		"Never emit narrative commentary outside JSON.",
 		"Expected response schema:",
 		"state_schema[CS2 v1]",
 	} {

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -31,7 +31,6 @@ type StageRequest struct {
 	Stage           string
 	Chunk           ChunkRef
 	Prompt          prompts.PromptVersion
-	PreviousState   string
 	ResponseSchema  string
 	SendPrompt      bool
 	ScenarioFolder  string
@@ -255,7 +254,7 @@ func isTrackerStage(stage string) bool {
 }
 
 func defaultTrackerState() string {
-	return `{"session_type":"single_match_single_chat","game":"cs2","mode":"unknown","session_status":{"value":"unknown","confidence":0,"reason":null},"focus_player":{"name":null,"team_side":"unknown","team_label":"unknown","confidence":0},"score_state":{"ct_score":null,"t_score":null,"source":"unknown","confidence":0},"round_tracking":{"observed_round_wins_ct":0,"observed_round_wins_t":0,"observed_round_history":[],"confidence":0},"winner_state":{"winner_side":"unknown","winner_team_label":"unknown","source":"unknown","confidence":0},"player_result":{"outcome":"unknown","confidence":0,"reason":"match ending not confirmed","is_final":false},"terminal_evidence":{"final_banner_seen":false,"final_banner_text":null,"final_scoreboard_seen":false,"final_scoreboard_text":null,"post_match_ui_seen":false,"return_to_lobby_seen":false,"strong_terminal_signals":[],"weak_terminal_signals":[]},"supporting_evidence":[],"open_uncertainties":[],"hard_conflicts":[],"next_needed_evidence":["clear final screen","clear final scoreboard","clear player team confirmation"]}`
+	return `{}`
 }
 
 func (w *Worker) captureWithRetry(ctx context.Context, streamerID string) (ChunkRef, error) {
@@ -658,7 +657,6 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 		Stage:           step.ID,
 		Chunk:           chunk,
 		Prompt:          activePrompt,
-		PreviousState:   previousState,
 		ResponseSchema:  step.ResponseSchemaJSON,
 		SendPrompt:      entering,
 		ScenarioFolder:  step.Folder,


### PR DESCRIPTION
### Motivation
- Reduce prompt size and avoid re-sending persisted tracker JSON in Gemini requests by removing the `PreviousState` plumbing. 
- Simplify and decouple the tracker bootstrap behavior by removing the large inline tracker-rule block from the instruction builder. 
- Provide a minimal default tracker state to avoid shipping a large hardcoded JSON blob from the core library.

### Description
- Remove the `PreviousState` field from `StageRequest` and stop including previous-state JSON in `buildGeminiInstruction` outputs. 
- Strip the long tracker-specific rule block from `buildGeminiInstruction`, keeping only the admin-managed prompt, schema, and a short rule to return only JSON. 
- Replace the large hardcoded JSON returned by `defaultTrackerState()` with an empty JSON object (`{}`).
- Update call sites and unit tests (`internal/media/gemini_test.go`) to reflect the removed `PreviousState` usage and the new instruction text.

### Testing
- Updated unit tests in `internal/media` were run with `go test ./internal/media` and they passed. 
- Assertions in tests were adjusted to check for the new instruction fragments and the continuation behavior, and all modified tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca91992880832cbb8ef6107e12df84)