### PR TITLE
Add metadata_json to llm_model_configs and ensure scenario packages reference model config

### DIFF
--- a/migrations/0008_llm_model_configs_and_scenario_binding.up.sql
+++ b/migrations/0008_llm_model_configs_and_scenario_binding.up.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS llm_model_configs (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
     model TEXT NOT NULL,
+    metadata_json TEXT NOT NULL DEFAULT '',
     temperature DOUBLE PRECISION NOT NULL,
     max_tokens INTEGER NOT NULL,
     timeout_ms INTEGER NOT NULL,


### PR DESCRIPTION
### Motivation
- Provide a flexible JSON metadata field for LLM model configurations and ensure scenario packages can be bound to a model config for routing and configuration purposes.

### Description
- Add `metadata_json TEXT NOT NULL DEFAULT ''` to the `llm_model_configs` table in the migration and ensure `llm_scenario_packages` has an `llm_model_config_id TEXT NOT NULL DEFAULT ''` column with an index `idx_llm_scenario_packages_model_config` to enable scenario-to-model bindings.

### Testing
- No automated tests were run as part of this migration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cac93c44d4832c807d654614339920)