### PR TITLE
Ensure metadata_json column exists for LLM model configs and add unit tests

### DIFF
--- a/internal/prompts/llm_model_config_postgres.go
+++ b/internal/prompts/llm_model_config_postgres.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
 )
 
 type PostgresModelConfigStore struct {
-	db *sql.DB
+	db         *sql.DB
+	schemaOnce sync.Once
+	schemaErr  error
 }
 
 func NewPostgresModelConfigStore(db *sql.DB) *PostgresModelConfigStore {
@@ -18,6 +21,9 @@ func NewPostgresModelConfigStore(db *sql.DB) *PostgresModelConfigStore {
 }
 
 func (s *PostgresModelConfigStore) List(ctx context.Context) ([]LLMModelConfig, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return nil, err
+	}
 	rows, err := s.db.QueryContext(ctx, `
 SELECT id, name, model, COALESCE(metadata_json, ''), temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at
 FROM llm_model_configs
@@ -42,6 +48,9 @@ ORDER BY created_at DESC, id DESC`)
 }
 
 func (s *PostgresModelConfigStore) Create(ctx context.Context, item LLMModelConfig) (LLMModelConfig, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return LLMModelConfig{}, err
+	}
 	if item.ID == "" {
 		item.ID = "llm-model-cfg-" + uuid.NewString()
 	}
@@ -70,6 +79,9 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
 }
 
 func (s *PostgresModelConfigStore) Update(ctx context.Context, item LLMModelConfig) (LLMModelConfig, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return LLMModelConfig{}, err
+	}
 	res, err := s.db.ExecContext(ctx, `
 UPDATE llm_model_configs
 SET name = $2, model = $3, metadata_json = $4, temperature = $5, max_tokens = $6, timeout_ms = $7,
@@ -88,6 +100,9 @@ WHERE id = $1`,
 }
 
 func (s *PostgresModelConfigStore) Delete(ctx context.Context, id string) error {
+	if err := s.ensureSchema(ctx); err != nil {
+		return err
+	}
 	res, err := s.db.ExecContext(ctx, `DELETE FROM llm_model_configs WHERE id = $1`, id)
 	if err != nil {
 		return err
@@ -99,6 +114,9 @@ func (s *PostgresModelConfigStore) Delete(ctx context.Context, id string) error 
 }
 
 func (s *PostgresModelConfigStore) SetActive(ctx context.Context, id string, actorID string, now time.Time) (LLMModelConfig, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return LLMModelConfig{}, err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return LLMModelConfig{}, err
@@ -124,6 +142,9 @@ func (s *PostgresModelConfigStore) SetActive(ctx context.Context, id string, act
 }
 
 func (s *PostgresModelConfigStore) GetByID(ctx context.Context, id string) (LLMModelConfig, error) {
+	if err := s.ensureSchema(ctx); err != nil {
+		return LLMModelConfig{}, err
+	}
 	row := s.db.QueryRowContext(ctx, `
 SELECT id, name, model, COALESCE(metadata_json, ''), temperature, max_tokens, timeout_ms, retry_count, backoff_ms, cooldown_ms, min_confidence, is_active, created_by, activated_by, created_at, activated_at
 FROM llm_model_configs
@@ -160,4 +181,13 @@ func nullableTime(value time.Time) any {
 		return nil
 	}
 	return value
+}
+
+func (s *PostgresModelConfigStore) ensureSchema(ctx context.Context) error {
+	s.schemaOnce.Do(func() {
+		_, s.schemaErr = s.db.ExecContext(ctx, `
+ALTER TABLE llm_model_configs
+	ADD COLUMN IF NOT EXISTS metadata_json TEXT NOT NULL DEFAULT ''`)
+	})
+	return s.schemaErr
 }

--- a/internal/prompts/llm_model_config_postgres_test.go
+++ b/internal/prompts/llm_model_config_postgres_test.go
@@ -1,0 +1,72 @@
+package prompts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPostgresModelConfigStoreListEnsuresMetadataColumn(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresModelConfigStore(db)
+
+	mock.ExpectExec("ALTER TABLE llm_model_configs").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "model", "metadata_json", "temperature", "max_tokens", "timeout_ms",
+		"retry_count", "backoff_ms", "cooldown_ms", "min_confidence", "is_active",
+		"created_by", "activated_by", "created_at", "activated_at",
+	})
+	mock.ExpectQuery("SELECT id, name, model, COALESCE\\(metadata_json, ''\\)").
+		WillReturnRows(rows)
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected no items, got %d", len(items))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected mock expectations: %v", err)
+	}
+}
+
+func TestPostgresModelConfigStoreEnsureSchemaRunsOnce(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresModelConfigStore(db)
+
+	mock.ExpectExec("ALTER TABLE llm_model_configs").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	query := "SELECT id, name, model, COALESCE\\(metadata_json, ''\\)"
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "model", "metadata_json", "temperature", "max_tokens", "timeout_ms",
+		"retry_count", "backoff_ms", "cooldown_ms", "min_confidence", "is_active",
+		"created_by", "activated_by", "created_at", "activated_at",
+	})
+	mock.ExpectQuery(query).WillReturnRows(rows)
+	mock.ExpectQuery(query).WillReturnRows(rows)
+
+	if _, err := store.List(context.Background()); err != nil {
+		t.Fatalf("first list failed: %v", err)
+	}
+	if _, err := store.List(context.Background()); err != nil {
+		t.Fatalf("second list failed: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected mock expectations: %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation

- Ensure older Postgres databases that lack the new `metadata_json` column continue to work by automatically adding the column if missing at runtime.

### Description

- Added `schemaOnce sync.Once` and `schemaErr error` to `PostgresModelConfigStore` and a new `ensureSchema(ctx)` helper that runs `ALTER TABLE ... ADD COLUMN IF NOT EXISTS metadata_json TEXT NOT NULL DEFAULT ''` once per store.
- Invoked `ensureSchema(ctx)` at the start of `List`, `Create`, `Update`, `Delete`, `SetActive`, and `GetByID` to guarantee the column exists before queries run.
- Imported `sync` and added `ensureSchema` implementation to the file `internal/prompts/llm_model_config_postgres.go`.
- Added unit tests `internal/prompts/llm_model_config_postgres_test.go` using `sqlmock` to verify the `ALTER TABLE` is executed and that `ensureSchema` runs only once per store instance.

### Testing

- Added `TestPostgresModelConfigStoreListEnsuresMetadataColumn` which expects the `ALTER TABLE` exec then a `SELECT` and it passed.
- Added `TestPostgresModelConfigStoreEnsureSchemaRunsOnce` which asserts the schema alteration runs only once across multiple `List` calls and it passed.
- Ran `go test ./internal/prompts -run TestPostgresModelConfigStore` to validate the new tests and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cacf656f50832cbca6d58e332a92c4)