### PR TITLE
Persist scenario-packages in PostgreSQL and add Postgres-backed store

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -207,7 +207,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/admin/llm/scenario-packages` / `POST /api/admin/llm/scenario-packages` – admin CRUD for scenario graph packages defined by ordered `steps` (no manual transition payload required) with per-game versioning and activation. Steps can define per-step `model`, or inherit model from `llmModelConfigId` at package level. Backend auto-links steps by ascending `order` and applies the target step `entryCondition` as the generated transition condition.
 - `GET /api/admin/llm/scenario-packages/{id}/graph` – returns a UI-ready visual graph payload (`nodes + edges + groups`) for scenario-graph editors/renderers.
 - Legacy prompt-version/state-schema/rule-set admin surfaces are removed from runtime; scenario-packages + model-configs are the supported LLM control surfaces.
-- Current implementation keeps scenario-packages in process memory; persistence across restarts is intentionally not provided in this branch.
+- Scenario-packages are persisted in PostgreSQL table `llm_scenario_packages` when DB is configured; when DB config is missing the service falls back to in-memory storage.
 
 When database connection fields are unset the server falls back to the in-memory
 repository for user profiles. This is useful for quick smoke tests but bypasses

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -166,6 +166,12 @@ func normalizeScenarioTransitions(steps []ScenarioStep) []ScenarioTransition {
 }
 
 func (s *Service) ListScenarioPackages(ctx context.Context) []ScenarioPackage {
+	if s.scenarioStore != nil {
+		items, err := s.scenarioStore.List(ctx)
+		if err == nil {
+			return items
+		}
+	}
 	_ = ctx
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -199,6 +205,18 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 			return ScenarioPackage{}, err
 		}
 	}
+	if s.scenarioStore != nil {
+		item := ScenarioPackage{
+			Name:             strings.TrimSpace(req.Name),
+			GameSlug:         gameSlug,
+			LLMModelConfigID: strings.TrimSpace(req.LLMModelConfigID),
+			Steps:            append([]ScenarioStep(nil), req.Steps...),
+			Transitions:      append([]ScenarioTransition(nil), normalizedTransitions...),
+			CreatedBy:        strings.TrimSpace(req.ActorID),
+			CreatedAt:        now,
+		}
+		return s.scenarioStore.Create(ctx, item)
+	}
 	_ = ctx
 
 	s.mu.Lock()
@@ -229,6 +247,13 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 }
 
 func (s *Service) GetScenarioPackage(ctx context.Context, id string) (ScenarioPackage, error) {
+	if s.scenarioStore != nil {
+		lookup := strings.TrimSpace(id)
+		if lookup == "" {
+			return ScenarioPackage{}, ErrScenarioPackageNotFound
+		}
+		return s.scenarioStore.GetByID(ctx, lookup)
+	}
 	_ = ctx
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -259,6 +284,28 @@ func (s *Service) UpdateScenarioPackage(ctx context.Context, id string, req Scen
 		if _, err := s.GetLLMModelConfig(ctx, req.LLMModelConfigID); err != nil {
 			return ScenarioPackage{}, err
 		}
+	}
+	if s.scenarioStore != nil {
+		lookup := strings.TrimSpace(id)
+		if lookup == "" {
+			return ScenarioPackage{}, ErrScenarioPackageNotFound
+		}
+		current, err := s.scenarioStore.GetByID(ctx, lookup)
+		if err != nil {
+			return ScenarioPackage{}, err
+		}
+		previousGameSlug := current.GameSlug
+		current.Name = strings.TrimSpace(req.Name)
+		current.GameSlug = targetGameSlug
+		current.LLMModelConfigID = strings.TrimSpace(req.LLMModelConfigID)
+		current.Steps = append([]ScenarioStep(nil), req.Steps...)
+		current.Transitions = append([]ScenarioTransition(nil), normalizedTransitions...)
+		if current.GameSlug != previousGameSlug {
+			current.IsActive = false
+			current.ActivatedBy = ""
+			current.ActivatedAt = time.Time{}
+		}
+		return s.scenarioStore.Update(ctx, current)
 	}
 	_ = ctx
 	s.mu.Lock()
@@ -294,6 +341,13 @@ func (s *Service) UpdateScenarioPackage(ctx context.Context, id string, req Scen
 }
 
 func (s *Service) DeleteScenarioPackage(ctx context.Context, id string) error {
+	if s.scenarioStore != nil {
+		lookup := strings.TrimSpace(id)
+		if lookup == "" {
+			return ErrScenarioPackageNotFound
+		}
+		return s.scenarioStore.Delete(ctx, lookup)
+	}
 	_ = ctx
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -314,6 +368,13 @@ func (s *Service) DeleteScenarioPackage(ctx context.Context, id string) error {
 }
 
 func (s *Service) ActivateScenarioPackage(ctx context.Context, id, actorID string) (ScenarioPackage, error) {
+	if s.scenarioStore != nil {
+		lookup := strings.TrimSpace(id)
+		if lookup == "" {
+			return ScenarioPackage{}, ErrScenarioPackageNotFound
+		}
+		return s.scenarioStore.SetActive(ctx, lookup, strings.TrimSpace(actorID), time.Now().UTC())
+	}
 	_ = ctx
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -344,6 +405,13 @@ func (s *Service) ActivateScenarioPackage(ctx context.Context, id, actorID strin
 }
 
 func (s *Service) GetActiveScenarioPackage(ctx context.Context, gameSlug string) (ScenarioPackage, error) {
+	if s.scenarioStore != nil {
+		key := strings.TrimSpace(gameSlug)
+		if key == "" {
+			key = "global"
+		}
+		return s.scenarioStore.GetActiveByGameSlug(ctx, key)
+	}
 	_ = ctx
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/prompts/scenario_flow_postgres.go
+++ b/internal/prompts/scenario_flow_postgres.go
@@ -1,0 +1,289 @@
+package prompts
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type scenarioPackageStore interface {
+	List(context.Context) ([]ScenarioPackage, error)
+	Create(context.Context, ScenarioPackage) (ScenarioPackage, error)
+	Update(context.Context, ScenarioPackage) (ScenarioPackage, error)
+	Delete(context.Context, string) error
+	SetActive(context.Context, string, string, time.Time) (ScenarioPackage, error)
+	GetByID(context.Context, string) (ScenarioPackage, error)
+	GetActiveByGameSlug(context.Context, string) (ScenarioPackage, error)
+}
+
+type PostgresScenarioPackageStore struct {
+	db *sql.DB
+}
+
+func NewPostgresScenarioPackageStore(db *sql.DB) *PostgresScenarioPackageStore {
+	return &PostgresScenarioPackageStore{db: db}
+}
+
+func (s *PostgresScenarioPackageStore) List(ctx context.Context) ([]ScenarioPackage, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, name, version, game_slug, llm_model_config_id, is_active,
+       steps_json, transitions_json, created_by, activated_by, created_at, activated_at
+FROM llm_scenario_packages
+ORDER BY game_slug ASC, version DESC, created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	items := make([]ScenarioPackage, 0)
+	for rows.Next() {
+		item, err := scanScenarioPackage(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (s *PostgresScenarioPackageStore) Create(ctx context.Context, item ScenarioPackage) (ScenarioPackage, error) {
+	if item.ID == "" {
+		item.ID = "scenario-pkg-" + uuid.NewString()
+	}
+	if strings.TrimSpace(item.GameSlug) == "" {
+		item.GameSlug = "global"
+	}
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = time.Now().UTC()
+	}
+
+	var version int
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(version), 0) + 1 FROM llm_scenario_packages WHERE game_slug = $1`, item.GameSlug).Scan(&version); err != nil {
+		return ScenarioPackage{}, err
+	}
+	item.Version = version
+
+	var hasAny bool
+	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM llm_scenario_packages WHERE game_slug = $1)`, item.GameSlug).Scan(&hasAny); err != nil {
+		return ScenarioPackage{}, err
+	}
+	if !hasAny {
+		item.IsActive = true
+		item.ActivatedBy = item.CreatedBy
+		item.ActivatedAt = item.CreatedAt
+	}
+
+	stepsJSON, transitionsJSON, err := encodeScenarioPackagePayload(item)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO llm_scenario_packages (
+	id, game_slug, name, version, llm_model_config_id,
+	steps_json, transitions_json, is_active,
+	created_by, activated_by, created_at, activated_at
+)
+VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9, $10, $11, $12)`,
+		item.ID, item.GameSlug, item.Name, item.Version, item.LLMModelConfigID,
+		stepsJSON, transitionsJSON, item.IsActive,
+		item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt),
+	)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	return item, nil
+}
+
+func (s *PostgresScenarioPackageStore) Update(ctx context.Context, item ScenarioPackage) (ScenarioPackage, error) {
+	stepsJSON, transitionsJSON, err := encodeScenarioPackagePayload(item)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+
+	res, err := s.db.ExecContext(ctx, `
+UPDATE llm_scenario_packages
+SET game_slug = $2,
+	name = $3,
+	llm_model_config_id = $4,
+	steps_json = $5::jsonb,
+	transitions_json = $6::jsonb,
+	is_active = $7,
+	activated_by = $8,
+	activated_at = $9
+WHERE id = $1`,
+		item.ID, item.GameSlug, item.Name, item.LLMModelConfigID, stepsJSON, transitionsJSON,
+		item.IsActive, item.ActivatedBy, nullableTime(item.ActivatedAt),
+	)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	if affected, _ := res.RowsAffected(); affected == 0 {
+		return ScenarioPackage{}, ErrScenarioPackageNotFound
+	}
+	return s.GetByID(ctx, item.ID)
+}
+
+func (s *PostgresScenarioPackageStore) Delete(ctx context.Context, id string) error {
+	item, err := s.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	res, err := tx.ExecContext(ctx, `DELETE FROM llm_scenario_packages WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	if affected, _ := res.RowsAffected(); affected == 0 {
+		return ErrScenarioPackageNotFound
+	}
+
+	if item.IsActive {
+		var replacementID string
+		err = tx.QueryRowContext(ctx, `
+SELECT id
+FROM llm_scenario_packages
+WHERE game_slug = $1
+ORDER BY version DESC, created_at DESC, id DESC
+LIMIT 1`, item.GameSlug).Scan(&replacementID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if replacementID != "" {
+			now := time.Now().UTC()
+			if _, err := tx.ExecContext(ctx, `UPDATE llm_scenario_packages SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1`, replacementID, item.ActivatedBy, now); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *PostgresScenarioPackageStore) SetActive(ctx context.Context, id string, actorID string, now time.Time) (ScenarioPackage, error) {
+	item, err := s.GetByID(ctx, id)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(ctx, `UPDATE llm_scenario_packages SET is_active = FALSE WHERE game_slug = $1 AND is_active = TRUE`, item.GameSlug); err != nil {
+		return ScenarioPackage{}, err
+	}
+	res, err := tx.ExecContext(ctx, `UPDATE llm_scenario_packages SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1`, id, actorID, now)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	if affected, _ := res.RowsAffected(); affected == 0 {
+		return ScenarioPackage{}, ErrScenarioPackageNotFound
+	}
+
+	if err := tx.Commit(); err != nil {
+		return ScenarioPackage{}, err
+	}
+	return s.GetByID(ctx, id)
+}
+
+func (s *PostgresScenarioPackageStore) GetByID(ctx context.Context, id string) (ScenarioPackage, error) {
+	row := s.db.QueryRowContext(ctx, `
+SELECT id, name, version, game_slug, llm_model_config_id, is_active,
+       steps_json, transitions_json, created_by, activated_by, created_at, activated_at
+FROM llm_scenario_packages
+WHERE id = $1`, id)
+	item, err := scanScenarioPackage(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ScenarioPackage{}, ErrScenarioPackageNotFound
+	}
+	return item, err
+}
+
+func (s *PostgresScenarioPackageStore) GetActiveByGameSlug(ctx context.Context, gameSlug string) (ScenarioPackage, error) {
+	row := s.db.QueryRowContext(ctx, `
+SELECT id, name, version, game_slug, llm_model_config_id, is_active,
+       steps_json, transitions_json, created_by, activated_by, created_at, activated_at
+FROM llm_scenario_packages
+WHERE game_slug = $1 AND is_active = TRUE
+LIMIT 1`, gameSlug)
+	item, err := scanScenarioPackage(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ScenarioPackage{}, ErrScenarioPackageNotFound
+	}
+	return item, err
+}
+
+type scenarioPackageScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanScenarioPackage(scanner scenarioPackageScanner) (ScenarioPackage, error) {
+	var item ScenarioPackage
+	var activatedAt sql.NullTime
+	var stepsRaw []byte
+	var transitionsRaw []byte
+	err := scanner.Scan(
+		&item.ID,
+		&item.Name,
+		&item.Version,
+		&item.GameSlug,
+		&item.LLMModelConfigID,
+		&item.IsActive,
+		&stepsRaw,
+		&transitionsRaw,
+		&item.CreatedBy,
+		&item.ActivatedBy,
+		&item.CreatedAt,
+		&activatedAt,
+	)
+	if err != nil {
+		return ScenarioPackage{}, err
+	}
+	if len(stepsRaw) > 0 {
+		if err := json.Unmarshal(stepsRaw, &item.Steps); err != nil {
+			return ScenarioPackage{}, fmt.Errorf("unmarshal steps_json: %w", err)
+		}
+	}
+	if len(transitionsRaw) > 0 {
+		if err := json.Unmarshal(transitionsRaw, &item.Transitions); err != nil {
+			return ScenarioPackage{}, fmt.Errorf("unmarshal transitions_json: %w", err)
+		}
+	}
+	if activatedAt.Valid {
+		item.ActivatedAt = activatedAt.Time
+	}
+	return item, nil
+}
+
+func encodeScenarioPackagePayload(item ScenarioPackage) ([]byte, []byte, error) {
+	stepsJSON, err := json.Marshal(item.Steps)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal steps: %w", err)
+	}
+	transitionsJSON, err := json.Marshal(item.Transitions)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal transitions: %w", err)
+	}
+	return stepsJSON, transitionsJSON, nil
+}

--- a/internal/prompts/scenario_flow_postgres_test.go
+++ b/internal/prompts/scenario_flow_postgres_test.go
@@ -1,0 +1,112 @@
+package prompts
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPostgresScenarioPackageStoreCreate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresScenarioPackageStore(db)
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(version), 0) + 1 FROM llm_scenario_packages WHERE game_slug = $1`)).
+		WithArgs("global").
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (SELECT 1 FROM llm_scenario_packages WHERE game_slug = $1)`)).
+		WithArgs("global").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectExec(regexp.QuoteMeta(`
+INSERT INTO llm_scenario_packages (
+	id, game_slug, name, version, llm_model_config_id,
+	steps_json, transitions_json, is_active,
+	created_by, activated_by, created_at, activated_at
+)
+VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9, $10, $11, $12)`)).
+		WithArgs(
+			sqlmock.AnyArg(),
+			"global",
+			"pkg",
+			1,
+			"",
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			true,
+			"admin",
+			"admin",
+			now,
+			now,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	item, err := store.Create(context.Background(), ScenarioPackage{
+		Name:      "pkg",
+		GameSlug:  "global",
+		CreatedBy: "admin",
+		CreatedAt: now,
+		Steps: []ScenarioStep{{
+			ID:    "s1",
+			Order: 1,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+	if !item.IsActive {
+		t.Fatalf("expected first package to be active")
+	}
+	if item.Version != 1 {
+		t.Fatalf("expected version 1, got %d", item.Version)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestPostgresScenarioPackageStoreGetActiveByGameSlug(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresScenarioPackageStore(db)
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	steps := `[{"id":"s1","name":"step-1","order":1}]`
+	transitions := `[]`
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, name, version, game_slug, llm_model_config_id, is_active,
+       steps_json, transitions_json, created_by, activated_by, created_at, activated_at
+FROM llm_scenario_packages
+WHERE game_slug = $1 AND is_active = TRUE
+LIMIT 1`)).
+		WithArgs("global").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "version", "game_slug", "llm_model_config_id", "is_active",
+			"steps_json", "transitions_json", "created_by", "activated_by", "created_at", "activated_at",
+		}).AddRow("scenario-pkg-1", "pkg", 2, "global", "", true, []byte(steps), []byte(transitions), "admin", "admin", now, now))
+
+	item, err := store.GetActiveByGameSlug(context.Background(), "global")
+	if err != nil {
+		t.Fatalf("store.GetActiveByGameSlug: %v", err)
+	}
+	if item.ID != "scenario-pkg-1" {
+		t.Fatalf("unexpected id: %s", item.ID)
+	}
+	if len(item.Steps) != 1 || item.Steps[0].ID != "s1" {
+		t.Fatalf("unexpected decoded steps: %#v", item.Steps)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/internal/prompts/service.go
+++ b/internal/prompts/service.go
@@ -13,6 +13,7 @@ type Service struct {
 	scenarioPackages map[string][]ScenarioPackage
 	modelConfigs     map[string]LLMModelConfig
 	modelConfigStore modelConfigStore
+	scenarioStore    scenarioPackageStore
 }
 
 func NewService() *Service {
@@ -26,6 +27,7 @@ func NewPostgresService(db *sql.DB) *Service {
 	svc := NewService()
 	if db != nil {
 		svc.modelConfigStore = NewPostgresModelConfigStore(db)
+		svc.scenarioStore = NewPostgresScenarioPackageStore(db)
 	}
 	return svc
 }


### PR DESCRIPTION
### Motivation

- Provide durable persistence for scenario-packages across restarts by storing them in a PostgreSQL table instead of keeping them only in memory.
- Keep an in-memory fallback when DB configuration is absent so local smoke tests remain simple.
- Wire DB-backed persistence into the existing `Service` so runtime flows transparently use the store when available.

### Description

- Add a Postgres-backed implementation `PostgresScenarioPackageStore` in `internal/prompts/scenario_flow_postgres.go` that implements listing, create, update, delete, set-active, and retrieval by ID/game slug using `llm_scenario_packages` JSON columns and transactional semantics.
- Update the prompts service (`internal/prompts/service.go`) to initialize `scenarioStore` via `NewPostgresService(db)` and to delegate scenario-package operations to the store when present in `internal/prompts/scenario_flow.go`.
- Update behavior to auto-version packages on create, promote first package to active, ensure activation toggles other rows, and pick a replacement active package on delete when needed.
- Update docs (`docs/local_setup.md`) to document that scenario-packages are persisted to PostgreSQL when DB is configured and that the service falls back to in-memory storage otherwise.

### Testing

- Add unit tests `TestPostgresScenarioPackageStoreCreate` and `TestPostgresScenarioPackageStoreGetActiveByGameSlug` in `internal/prompts/scenario_flow_postgres_test.go` using `sqlmock` to validate create/versioning/activation and active-package retrieval behavior, and they passed locally.
- Ran the prompts package tests with `go test ./internal/prompts` and observed successful results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf7864f18832c818b927dd19ae750)