### PR TITLE
Remove per-step `model` and require package-level `llmModelConfigId` for scenarios

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1207,13 +1207,11 @@ components:
               nullable: true
     ScenarioStep:
       type: object
-      required: [id, name, model, promptTemplate, responseSchemaJson, initial, order]
+      required: [id, name, promptTemplate, responseSchemaJson, initial, order]
       properties:
         id:
           type: string
         name:
-          type: string
-        model:
           type: string
         gameSlug:
           type: string
@@ -1246,7 +1244,7 @@ components:
           minimum: 1
     ScenarioPackageCreateRequest:
       type: object
-      required: [gameSlug, name, steps]
+      required: [gameSlug, name, llmModelConfigId, steps]
       properties:
         gameSlug:
           type: string

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -61,7 +61,6 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 		steps = append(steps, prompts.ScenarioStep{
 			ID:                 step.ID,
 			Name:               step.Name,
-			Model:              step.Model,
 			GameSlug:           step.GameSlug,
 			Folder:             step.Folder,
 			EntryCondition:     step.EntryCondition,
@@ -100,7 +99,6 @@ type gameUpsertRequest struct {
 type scenarioStepRequest struct {
 	ID                 string `json:"id"`
 	Name               string `json:"name"`
-	Model              string `json:"model"`
 	GameSlug           string `json:"gameSlug"`
 	Folder             string `json:"folder"`
 	EntryCondition     string `json:"entryCondition"`

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -646,14 +646,14 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 			return streamers.LLMDecision{}, err
 		}
 	}
-	model := strings.TrimSpace(step.Model)
-	if model == "" && strings.TrimSpace(pkg.LLMModelConfigID) != "" {
-		config, err := w.prompts.GetLLMModelConfig(ctx, pkg.LLMModelConfigID)
-		if err != nil {
-			return streamers.LLMDecision{}, err
-		}
-		model = strings.TrimSpace(config.Model)
+	if strings.TrimSpace(pkg.LLMModelConfigID) == "" {
+		return streamers.LLMDecision{}, prompts.ErrInvalidScenarioModelRef
 	}
+	config, err := w.prompts.GetLLMModelConfig(ctx, pkg.LLMModelConfigID)
+	if err != nil {
+		return streamers.LLMDecision{}, err
+	}
+	model := strings.TrimSpace(config.Model)
 	activePrompt := prompts.PromptVersion{
 		ID:       step.ID,
 		Stage:    step.ID,

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -71,7 +71,6 @@ func (f fakePromptResolver) GetActiveScenarioPackage(_ context.Context, _ string
 		steps = append(steps, prompts.ScenarioStep{
 			ID:                 stepID,
 			Name:               stepID,
-			Model:              firstNonEmpty(prompt.Model, "gemini-2.0-flash"),
 			PromptTemplate:     prompt.Template,
 			ResponseSchemaJSON: "{}",
 			Initial:            i == 0,
@@ -243,9 +242,10 @@ func TestWorkerProcessStreamerResetsToInitialStepWhenLatestStepMissingInActivePa
 			"root_detect": {Label: "cs2_detected", Confidence: 0.99, UpdatedStateJSON: `{"game":"cs2"}`},
 		}},
 		fakePromptResolver{scenario: prompts.ScenarioPackage{
-			ID:       "scenario-v2",
-			GameSlug: "global",
-			Name:     "v2",
+			ID:               "scenario-v2",
+			GameSlug:         "global",
+			Name:             "v2",
+			LLMModelConfigID: "cfg-test",
 			Steps: []prompts.ScenarioStep{
 				{ID: "root_detect", Name: "Root detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
 				{ID: "cs2_mode", Name: "CS2 mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
@@ -254,7 +254,7 @@ func TestWorkerProcessStreamerResetsToInitialStepWhenLatestStepMissingInActivePa
 				{FromStepID: "root_detect", ToStepID: "cs2_mode", Condition: `$.game == "cs2"`, Priority: 1},
 			},
 			IsActive: true,
-		}},
+		}, llmModelConfig: prompts.LLMModelConfig{ID: "cfg-test", Model: "gemini-2.5-flash"}},
 		&InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5},
 	)
 

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -12,18 +12,17 @@ import (
 )
 
 var (
-	ErrScenarioPackageNotFound  = errors.New("scenario package not found")
-	ErrScenarioStepNotFound     = errors.New("scenario step not found")
-	ErrInvalidScenarioPackage   = errors.New("scenario package must contain at least one step")
-	ErrInvalidScenarioStepID    = errors.New("scenario step id must not be empty")
-	ErrInvalidScenarioStepModel = errors.New("scenario step model must not be empty when package model config is not set")
-	ErrInvalidScenarioName      = errors.New("scenario package name must not be empty")
+	ErrScenarioPackageNotFound = errors.New("scenario package not found")
+	ErrScenarioStepNotFound    = errors.New("scenario step not found")
+	ErrInvalidScenarioPackage  = errors.New("scenario package must contain at least one step")
+	ErrInvalidScenarioStepID   = errors.New("scenario step id must not be empty")
+	ErrInvalidScenarioModelRef = errors.New("scenario package llmModelConfigId must not be empty")
+	ErrInvalidScenarioName     = errors.New("scenario package name must not be empty")
 )
 
 type ScenarioStep struct {
 	ID                 string    `json:"id"`
 	Name               string    `json:"name"`
-	Model              string    `json:"model"`
 	GameSlug           string    `json:"gameSlug"`
 	Folder             string    `json:"folder"`
 	EntryCondition     string    `json:"entryCondition,omitempty"`
@@ -104,18 +103,17 @@ func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) erro
 	if strings.TrimSpace(req.Name) == "" {
 		return ErrInvalidScenarioName
 	}
+	if strings.TrimSpace(req.LLMModelConfigID) == "" {
+		return ErrInvalidScenarioModelRef
+	}
 	if len(req.Steps) == 0 {
 		return ErrInvalidScenarioPackage
 	}
 	seenSteps := make(map[string]struct{}, len(req.Steps))
-	hasPackageModel := strings.TrimSpace(req.LLMModelConfigID) != ""
 	for _, step := range req.Steps {
 		id := strings.TrimSpace(step.ID)
 		if id == "" {
 			return ErrInvalidScenarioStepID
-		}
-		if strings.TrimSpace(step.Model) == "" && !hasPackageModel {
-			return ErrInvalidScenarioStepModel
 		}
 		seenSteps[id] = struct{}{}
 	}
@@ -135,7 +133,6 @@ func normalizeScenarioSteps(steps []ScenarioStep, fallbackGameSlug string, now t
 		if strings.TrimSpace(normalized[i].GameSlug) == "" {
 			normalized[i].GameSlug = fallbackGameSlug
 		}
-		normalized[i].Model = strings.TrimSpace(normalized[i].Model)
 	}
 	return normalized
 }

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -5,18 +5,33 @@ import (
 	"testing"
 )
 
+func mustCreateModelConfig(t *testing.T, svc *Service) LLMModelConfig {
+	t.Helper()
+	cfg, err := svc.CreateLLMModelConfig(context.Background(), LLMModelConfigUpsertRequest{
+		Name:    "default",
+		Model:   "gemini-2.5-flash",
+		ActorID: "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("create llm config: %v", err)
+	}
+	return cfg
+}
+
 func TestScenarioPackageResolveStep(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService()
+	config := mustCreateModelConfig(t, svc)
 	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:     "cs2 flow",
-		GameSlug: "global",
-		ActorID:  "admin-1",
+		Name:             "cs2 flow",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
 		Steps: []ScenarioStep{
-			{ID: "game_detect", Name: "Game detect", Model: "gemini-2.5-flash", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-			{ID: "cs2_mode", Name: "CS2 mode", Model: "gemini-2.5-flash", Folder: "cs2", EntryCondition: "game == cs2", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
-			{ID: "cs2_faceit", Name: "Faceit", Model: "gemini-2.5-flash", Folder: "cs2/faceit", EntryCondition: "mode == faceit", PromptTemplate: "faceit", ResponseSchemaJSON: `{}`, Order: 3},
+			{ID: "game_detect", Name: "Game detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "cs2_mode", Name: "CS2 mode", Folder: "cs2", EntryCondition: "game == cs2", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
+			{ID: "cs2_faceit", Name: "Faceit", Folder: "cs2/faceit", EntryCondition: "mode == faceit", PromptTemplate: "faceit", ResponseSchemaJSON: `{}`, Order: 3},
 		},
 	})
 	if err != nil {
@@ -154,12 +169,14 @@ func TestScenarioPackageUpdateAcrossGameDeactivatesAndNormalizesSteps(t *testing
 	t.Parallel()
 
 	svc := NewService()
+	config := mustCreateModelConfig(t, svc)
 	created, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:     "global flow",
-		GameSlug: "global",
-		ActorID:  "admin-1",
+		Name:             "global flow",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
 		Steps: []ScenarioStep{
-			{ID: "root_detect", Name: "Root", Model: "gemini-2.5-flash", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true},
+			{ID: "root_detect", Name: "Root", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true},
 		},
 	})
 	if err != nil {
@@ -170,11 +187,12 @@ func TestScenarioPackageUpdateAcrossGameDeactivatesAndNormalizesSteps(t *testing
 	}
 
 	updated, err := svc.UpdateScenarioPackage(context.Background(), created.ID, ScenarioPackageCreateRequest{
-		Name:     "cs2 flow",
-		GameSlug: "cs2",
-		ActorID:  "admin-1",
+		Name:             "cs2 flow",
+		GameSlug:         "cs2",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
 		Steps: []ScenarioStep{
-			{ID: "cs2_mode", Name: "Mode", Model: "gemini-2.5-flash", PromptTemplate: "mode", ResponseSchemaJSON: `{}`},
+			{ID: "cs2_mode", Name: "Mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`},
 		},
 	})
 	if err != nil {
@@ -198,14 +216,16 @@ func TestScenarioPackageCreateAutowiresTransitionsWhenMissing(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService()
+	config := mustCreateModelConfig(t, svc)
 	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:     "auto transitions",
-		GameSlug: "global",
-		ActorID:  "admin-1",
+		Name:             "auto transitions",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
 		Steps: []ScenarioStep{
-			{ID: "step_a", Name: "Step A", Model: "gemini-2.5-flash", PromptTemplate: "a", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-			{ID: "step_b", Name: "Step B", Model: "gemini-2.5-flash", PromptTemplate: "b", ResponseSchemaJSON: `{}`, EntryCondition: "mode == faceit", Order: 2},
-			{ID: "step_c", Name: "Step C", Model: "gemini-2.5-flash", PromptTemplate: "c", ResponseSchemaJSON: `{}`, Order: 3},
+			{ID: "step_a", Name: "Step A", PromptTemplate: "a", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "step_b", Name: "Step B", PromptTemplate: "b", ResponseSchemaJSON: `{}`, EntryCondition: "mode == faceit", Order: 2},
+			{ID: "step_c", Name: "Step C", PromptTemplate: "c", ResponseSchemaJSON: `{}`, Order: 3},
 		},
 	})
 	if err != nil {
@@ -239,7 +259,7 @@ func TestScenarioPackageCreateAutowiresTransitionsWhenMissing(t *testing.T) {
 	}
 }
 
-func TestScenarioPackageCreateRequiresStepModelWithoutPackageModelConfig(t *testing.T) {
+func TestScenarioPackageCreateRequiresPackageModelConfig(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService()
@@ -252,53 +272,31 @@ func TestScenarioPackageCreateRequiresStepModelWithoutPackageModelConfig(t *test
 		},
 	})
 	if err == nil {
-		t.Fatalf("expected missing scenario step model validation error")
+		t.Fatalf("expected missing scenario package model config validation error")
 	}
-	if err != ErrInvalidScenarioStepModel {
-		t.Fatalf("expected ErrInvalidScenarioStepModel, got %v", err)
-	}
-
-	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:     "config configured",
-		GameSlug: "global",
-		ActorID:  "admin-1",
-		Steps: []ScenarioStep{
-			{ID: "step_custom_model", Name: "Custom model", Model: "gemini-2.5-pro", PromptTemplate: "b", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-		},
-	})
-	if err != nil {
-		t.Fatalf("create scenario package: %v", err)
-	}
-	if got := item.Steps[0].Model; got != "gemini-2.5-pro" {
-		t.Fatalf("expected scenario step model to be preserved, got %q", got)
+	if err != ErrInvalidScenarioModelRef {
+		t.Fatalf("expected ErrInvalidScenarioModelRef, got %v", err)
 	}
 }
 
-func TestScenarioPackageCreateAllowsMissingStepModelWhenPackageConfigIsSet(t *testing.T) {
+func TestScenarioPackageCreateDoesNotUseStepModel(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService()
-	config, err := svc.CreateLLMModelConfig(context.Background(), LLMModelConfigUpsertRequest{
-		Name:    "default",
-		Model:   "gemini-2.5-flash",
-		ActorID: "admin-1",
-	})
-	if err != nil {
-		t.Fatalf("create llm config: %v", err)
-	}
+	config := mustCreateModelConfig(t, svc)
 	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:             "config driven",
+		Name:             "config configured",
 		GameSlug:         "global",
 		ActorID:          "admin-1",
 		LLMModelConfigID: config.ID,
 		Steps: []ScenarioStep{
-			{ID: "step_package_default", Name: "Package default", PromptTemplate: "b", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "step_custom_model", Name: "Custom model", PromptTemplate: "b", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
 		},
 	})
 	if err != nil {
 		t.Fatalf("create scenario package: %v", err)
 	}
-	if got := item.Steps[0].Model; got != "" {
-		t.Fatalf("expected scenario step model to remain empty and resolve from package config at runtime, got %q", got)
+	if item.LLMModelConfigID != config.ID {
+		t.Fatalf("expected package model config ID %q, got %q", config.ID, item.LLMModelConfigID)
 	}
 }

--- a/migrations/0011_drop_scenario_step_model_field.down.sql
+++ b/migrations/0011_drop_scenario_step_model_field.down.sql
@@ -1,0 +1,1 @@
+-- no-op: removed redundant step-level `model` key from steps_json.

--- a/migrations/0011_drop_scenario_step_model_field.up.sql
+++ b/migrations/0011_drop_scenario_step_model_field.up.sql
@@ -1,0 +1,10 @@
+UPDATE llm_scenario_packages
+SET steps_json = COALESCE((
+    SELECT jsonb_agg(step - 'model')
+    FROM jsonb_array_elements(steps_json) AS step
+), '[]'::jsonb)
+WHERE EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(steps_json) AS step
+    WHERE step ? 'model'
+);


### PR DESCRIPTION
### Motivation
- Remove redundant per-step model selection so scenario model choice is centralized at the package level and to avoid inconsistent runtime/model lookups.
- Strip the legacy step-level `model` from stored `steps_json` in the DB to prevent stale/duplicated data.

### Description
- Removed the `Model` field from `ScenarioStep` and from HTTP request mapping so steps no longer accept or expose a per-step `model` value (`internal/prompts`, `internal/app`).
- Made `llmModelConfigId` required in `ScenarioPackageCreateRequest` validation and API schema, and updated OpenAPI (`docs/openapi.yaml`) accordingly.
- Updated the worker runtime to always resolve the model from the package-level `LLMModelConfigID` and return a validation error if it is missing (`internal/media/worker.go`).
- Added a migration `0011_drop_scenario_step_model_field` that removes the `model` key from `llm_scenario_packages.steps_json` for existing rows, and updated/adjusted tests to the new behavior.

### Testing
- Ran unit tests with `go test ./internal/prompts ./internal/media ./internal/app` and they all passed.
- Ensured code formatting with `gofmt` and updated tests to reflect the package-level model behavior.
- Checklist (aligned with `docs/implementation_plan.md` M2.1 and `docs/llm_stream_orchestration_plan.md`):
  - [x] centralize model selection at package level (remove step-level model)
  - [x] update runtime to resolve model from `llmModelConfigId` and fail fast when missing
  - [x] provide DB migration to remove redundant `model` keys from `steps_json`
  - [ ] run full `go test ./...` in CI and apply migration on staging/production environments

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbad3a1fd4832ca5f23decf9e6e658)