### PR TITLE
Strict JSON decoding for scenario-package endpoints; ensure transitions serialize as empty array and avoid shared slices

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -727,7 +728,7 @@ func NewHandler(
 						return
 					}
 					var req scenarioPackageCreateRequest
-					if err := json.Unmarshal(body, &req); err != nil {
+					if err := decodeJSONStrict(body, &req); err != nil {
 						writeError(w, http.StatusBadRequest, "invalid request body")
 						return
 					}
@@ -813,7 +814,7 @@ func NewHandler(
 						return
 					}
 					var req scenarioPackageCreateRequest
-					if err := json.Unmarshal(body, &req); err != nil {
+					if err := decodeJSONStrict(body, &req); err != nil {
 						writeError(w, http.StatusBadRequest, "invalid request body")
 						return
 					}
@@ -891,4 +892,10 @@ func writeError(w http.ResponseWriter, status int, message string) {
 		"error":     message,
 		"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
 	})
+}
+
+func decodeJSONStrict(body []byte, out any) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(out)
 }

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -102,7 +102,6 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 			{
 				"id":                 "root_detect",
 				"name":               "Root detect",
-				"model":              "gemini-2.5-pro",
 				"gameSlug":           "global",
 				"promptTemplate":     "detect-v2",
 				"responseSchemaJson": "{}",
@@ -117,6 +116,31 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	handler.ServeHTTP(updateRes, updateReq)
 	if updateRes.Code != http.StatusOK {
 		t.Fatalf("scenario package update status = %d body=%s", updateRes.Code, updateRes.Body.String())
+	}
+
+	invalidBody, _ := json.Marshal(map[string]any{
+		"gameSlug":         "global",
+		"name":             "default graph invalid",
+		"llmModelConfigId": configID,
+		"steps": []map[string]any{
+			{
+				"id":                 "root_detect",
+				"name":               "Root detect",
+				"llmModelConfigId":   "step-level-not-allowed",
+				"gameSlug":           "global",
+				"promptTemplate":     "detect-v3",
+				"responseSchemaJson": "{}",
+				"initial":            true,
+				"order":              1,
+			},
+		},
+	})
+	invalidReq := httptest.NewRequest(http.MethodPut, "/api/admin/llm/scenario-packages/"+packageID, bytes.NewReader(invalidBody))
+	invalidReq.Header.Set("Authorization", "Bearer "+adminToken)
+	invalidRes := httptest.NewRecorder()
+	handler.ServeHTTP(invalidRes, invalidReq)
+	if invalidRes.Code != http.StatusBadRequest {
+		t.Fatalf("scenario package update with unknown step field status = %d body=%s", invalidRes.Code, invalidRes.Body.String())
 	}
 }
 

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -30,7 +30,7 @@ type ScenarioStep struct {
 	ResponseSchemaJSON string    `json:"responseSchemaJson"`
 	Initial            bool      `json:"initial"`
 	Order              int       `json:"order"`
-	CreatedAt          time.Time `json:"createdAt"`
+	CreatedAt          time.Time `json:"-"`
 }
 
 type ScenarioTransition struct {
@@ -139,7 +139,7 @@ func normalizeScenarioSteps(steps []ScenarioStep, fallbackGameSlug string, now t
 
 func normalizeScenarioTransitions(steps []ScenarioStep) []ScenarioTransition {
 	if len(steps) < 2 {
-		return nil
+		return []ScenarioTransition{}
 	}
 	ordered := make([]ScenarioStep, len(steps))
 	copy(ordered, steps)
@@ -160,6 +160,10 @@ func normalizeScenarioTransitions(steps []ScenarioStep) []ScenarioTransition {
 		})
 	}
 	return autowired
+}
+
+func cloneScenarioTransitions(transitions []ScenarioTransition) []ScenarioTransition {
+	return append([]ScenarioTransition{}, transitions...)
 }
 
 func (s *Service) ListScenarioPackages(ctx context.Context) []ScenarioPackage {
@@ -208,7 +212,7 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 			GameSlug:         gameSlug,
 			LLMModelConfigID: strings.TrimSpace(req.LLMModelConfigID),
 			Steps:            append([]ScenarioStep(nil), req.Steps...),
-			Transitions:      append([]ScenarioTransition(nil), normalizedTransitions...),
+			Transitions:      cloneScenarioTransitions(normalizedTransitions),
 			CreatedBy:        strings.TrimSpace(req.ActorID),
 			CreatedAt:        now,
 		}
@@ -230,7 +234,7 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 		GameSlug:         gameSlug,
 		LLMModelConfigID: strings.TrimSpace(req.LLMModelConfigID),
 		Steps:            append([]ScenarioStep(nil), req.Steps...),
-		Transitions:      append([]ScenarioTransition(nil), normalizedTransitions...),
+		Transitions:      cloneScenarioTransitions(normalizedTransitions),
 		CreatedBy:        strings.TrimSpace(req.ActorID),
 		CreatedAt:        now,
 	}
@@ -296,7 +300,7 @@ func (s *Service) UpdateScenarioPackage(ctx context.Context, id string, req Scen
 		current.GameSlug = targetGameSlug
 		current.LLMModelConfigID = strings.TrimSpace(req.LLMModelConfigID)
 		current.Steps = append([]ScenarioStep(nil), req.Steps...)
-		current.Transitions = append([]ScenarioTransition(nil), normalizedTransitions...)
+		current.Transitions = cloneScenarioTransitions(normalizedTransitions)
 		if current.GameSlug != previousGameSlug {
 			current.IsActive = false
 			current.ActivatedBy = ""
@@ -318,7 +322,7 @@ func (s *Service) UpdateScenarioPackage(ctx context.Context, id string, req Scen
 			updated.GameSlug = targetGameSlug
 			updated.LLMModelConfigID = strings.TrimSpace(req.LLMModelConfigID)
 			updated.Steps = append([]ScenarioStep(nil), req.Steps...)
-			updated.Transitions = append([]ScenarioTransition(nil), normalizedTransitions...)
+			updated.Transitions = cloneScenarioTransitions(normalizedTransitions)
 			if updated.GameSlug != gameSlug {
 				updated.IsActive = false
 				updated.ActivatedBy = ""

--- a/internal/prompts/scenario_flow_postgres.go
+++ b/internal/prompts/scenario_flow_postgres.go
@@ -270,6 +270,7 @@ func scanScenarioPackage(scanner scenarioPackageScanner) (ScenarioPackage, error
 			return ScenarioPackage{}, fmt.Errorf("unmarshal transitions_json: %w", err)
 		}
 	}
+	item.Transitions = cloneScenarioTransitions(item.Transitions)
 	if activatedAt.Valid {
 		item.ActivatedAt = activatedAt.Time
 	}

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -2,6 +2,7 @@ package prompts
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 )
 
@@ -256,6 +257,46 @@ func TestScenarioPackageCreateAutowiresTransitionsWhenMissing(t *testing.T) {
 	}
 	if !entered || step.ID != "step_b" {
 		t.Fatalf("expected auto transition to step_b, got entered=%v step=%s", entered, step.ID)
+	}
+}
+
+func TestScenarioPackageCreateReturnsEmptyTransitionArrayForSingleStep(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	config := mustCreateModelConfig(t, svc)
+	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "single step",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
+		Steps: []ScenarioStep{
+			{ID: "step_a", Name: "Step A", PromptTemplate: "a", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+	if item.Transitions == nil {
+		t.Fatalf("expected transitions to be empty array, got nil")
+	}
+	raw, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal scenario package: %v", err)
+	}
+	if string(raw) == "" {
+		t.Fatalf("unexpected empty json payload")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal scenario package: %v", err)
+	}
+	transitions, ok := parsed["transitions"].([]any)
+	if !ok {
+		t.Fatalf("expected transitions array in json, got %#v", parsed["transitions"])
+	}
+	if len(transitions) != 0 {
+		t.Fatalf("expected empty transitions array in json, got %#v", transitions)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Reject requests with unknown JSON fields on admin LLM scenario-package endpoints to catch client errors early by using strict decoding.
- Ensure scenario package transitions are consistently represented as an empty JSON array (not `null`) for single-step packages.
- Prevent accidental aliasing of transition slices by cloning them when constructing, returning, or scanning packages.

### Description
- Added `decodeJSONStrict` in `internal/app/router.go` and replaced `json.Unmarshal` with it for scenario package create/update handlers to enforce `DisallowUnknownFields()`.
- Updated imports and router tests in `internal/app/router_admin_llm_test.go` to expect a `400 Bad Request` when unknown step-level fields are submitted.
- Changed `ScenarioStep.CreatedAt` serialization tag to omit it from JSON, made `normalizeScenarioTransitions` return an empty slice for single-step packages, and introduced `cloneScenarioTransitions` in `internal/prompts/scenario_flow.go` to clone transition slices.
- Applied cloning when creating/updating packages and when scanning rows in `internal/prompts/scenario_flow_postgres.go`, and added a test `TestScenarioPackageCreateReturnsEmptyTransitionArrayForSingleStep` in `internal/prompts/scenario_flow_test.go` to validate JSON output.

### Testing
- Ran unit tests with `go test ./...` which include updated `TestAdminLLMScenarioPackageRoutes` and `TestScenarioPackageCreateReturnsEmptyTransitionArrayForSingleStep`, and they passed.
- Verified router-level tests that assert unknown JSON fields now return `400 Bad Request`, and those tests passed.
- Verified scenario package serialization tests to ensure `transitions` is an empty array (not `null`), and that test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbaf6a535c832cb5d0509f43a346fb)