### PR TITLE
Expose full LLM request/response history in streamer status API

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -194,7 +194,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/streamers` – returns streamer catalog with optional `query` and `page` filters.
 - `POST /api/streamers` – submits a Twitch streamer nickname for moderation/validation, then immediately starts the per-streamer Streamlink analysis scheduler when background orchestration is configured.
 - When Streamlink reports that a Twitch URL has no playable streams (for example, the stream ended or is offline), the scheduler treats that cycle as a graceful skip instead of a hard worker failure and retries on the next 10-second window.
-- `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM match-session / state-tracker status for a streamer.
+- `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM match-session / state-tracker status for a streamer, including full chronological LLM call history (`history`) with request/response payloads per decision.
 - `DELETE /api/streamers/{streamerId}/tracking` – stops the active Streamlink/LLM tracking loop for a streamer and returns the updated `stopped` status so the client can disable the tracking button immediately.
 - Decision history REST endpoints were removed as part of scenario-graph v2 cleanup; `/api/streamers/{streamerId}/status` remains the supported read model.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1023,7 +1023,7 @@ components:
 
     LLMStatus:
       type: object
-      required: [streamerId, state, latestByStage]
+      required: [streamerId, state, latestByStage, history]
       properties:
         streamerId:
           type: string
@@ -1046,6 +1046,11 @@ components:
           format: date-time
         latestByStage:
           type: array
+          items:
+            $ref: '#/components/schemas/LLMDecision'
+        history:
+          type: array
+          description: Full chronological LLM decision history for the streamer, including per-call request/response payloads.
           items:
             $ref: '#/components/schemas/LLMDecision'
 
@@ -1086,6 +1091,12 @@ components:
           type: string
         responseRef:
           type: string
+        requestPayload:
+          type: string
+          description: JSON payload sent to the upstream LLM provider for this decision.
+        responsePayload:
+          type: string
+          description: Raw HTTP response body returned by the upstream LLM provider.
         rawResponse:
           type: string
           description: Raw strict-JSON payload returned by the active scenario step.

--- a/internal/app/router_streamers_status_test.go
+++ b/internal/app/router_streamers_status_test.go
@@ -64,6 +64,10 @@ func TestStreamerStatusReturnsAggregatedLLMState(t *testing.T) {
 	if !ok || len(latestByStage) != 2 {
 		t.Fatalf("expected two latest stage snapshots, got %#v", got["latestByStage"])
 	}
+	history, ok := got["history"].([]any)
+	if !ok || len(history) != 2 {
+		t.Fatalf("expected full history with two decisions, got %#v", got["history"])
+	}
 }
 
 func TestStreamerStatusReturnsIdleWhenNoDecisionsYet(t *testing.T) {
@@ -96,6 +100,10 @@ func TestStreamerStatusReturnsIdleWhenNoDecisionsYet(t *testing.T) {
 	}
 	if got["state"] != "idle" {
 		t.Fatalf("expected idle state, got %#v", got)
+	}
+	history, ok := got["history"].([]any)
+	if !ok || len(history) != 0 {
+		t.Fatalf("expected empty history in idle status, got %#v", got["history"])
 	}
 }
 

--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -286,6 +286,8 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 		RawResponse:      strings.TrimSpace(rawText),
 		RequestRef:       endpoint,
 		ResponseRef:      strconv.Itoa(resp.StatusCode),
+		RequestPayload:   string(bodyBytes),
+		ResponsePayload:  string(responseBody),
 		TokensIn:         payload.UsageMetadata.PromptTokenCount,
 		TokensOut:        payload.UsageMetadata.CandidatesTokenCount,
 		Latency:          time.Since(started),

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -50,6 +50,8 @@ type StageClassification struct {
 	RawResponse       string
 	RequestRef        string
 	ResponseRef       string
+	RequestPayload    string
+	ResponsePayload   string
 	TokensIn          int
 	TokensOut         int
 	Latency           time.Duration
@@ -323,6 +325,8 @@ func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.Pr
 		ChunkRef:          chunk.Reference,
 		RequestRef:        result.RequestRef,
 		ResponseRef:       result.ResponseRef,
+		RequestPayload:    result.RequestPayload,
+		ResponsePayload:   result.ResponsePayload,
 		RawResponse:       result.RawResponse,
 		TokensIn:          result.TokensIn,
 		TokensOut:         result.TokensOut,

--- a/internal/streamers/model.go
+++ b/internal/streamers/model.go
@@ -36,6 +36,8 @@ type LLMDecision struct {
 	ChunkRef           string  `json:"chunkRef,omitempty"`
 	RequestRef         string  `json:"requestRef,omitempty"`
 	ResponseRef        string  `json:"responseRef,omitempty"`
+	RequestPayload     string  `json:"requestPayload,omitempty"`
+	ResponsePayload    string  `json:"responsePayload,omitempty"`
 	RawResponse        string  `json:"rawResponse,omitempty"`
 	TokensIn           int     `json:"tokensIn,omitempty"`
 	TokensOut          int     `json:"tokensOut,omitempty"`
@@ -61,6 +63,7 @@ type LLMStatus struct {
 	DetectedGameKey   string        `json:"detectedGameKey,omitempty"`
 	UpdatedAt         string        `json:"updatedAt,omitempty"`
 	LatestByStage     []LLMDecision `json:"latestByStage"`
+	History           []LLMDecision `json:"history"`
 }
 
 type RecordDecisionRequest struct {
@@ -79,6 +82,8 @@ type RecordDecisionRequest struct {
 	ChunkCapturedAt    time.Time
 	RequestRef         string
 	ResponseRef        string
+	RequestPayload     string
+	ResponsePayload    string
 	RawResponse        string
 	TokensIn           int
 	TokensOut          int

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -320,6 +320,8 @@ func (s *Service) RecordLLMDecision(ctx context.Context, req RecordDecisionReque
 		ChunkRef:           strings.TrimSpace(req.ChunkRef),
 		RequestRef:         strings.TrimSpace(req.RequestRef),
 		ResponseRef:        strings.TrimSpace(req.ResponseRef),
+		RequestPayload:     strings.TrimSpace(req.RequestPayload),
+		ResponsePayload:    strings.TrimSpace(req.ResponsePayload),
 		RawResponse:        strings.TrimSpace(req.RawResponse),
 		TokensIn:           req.TokensIn,
 		TokensOut:          req.TokensOut,
@@ -411,7 +413,7 @@ func (s *Service) ListLLMDecisions(ctx context.Context, streamerID string, limit
 
 func (s *Service) GetLLMStatus(ctx context.Context, streamerID string) LLMStatus {
 	key := strings.TrimSpace(streamerID)
-	status := LLMStatus{StreamerID: key, State: "idle", LatestByStage: []LLMDecision{}}
+	status := LLMStatus{StreamerID: key, State: "idle", LatestByStage: []LLMDecision{}, History: []LLMDecision{}}
 	if key == "" {
 		return status
 	}
@@ -445,6 +447,7 @@ func (s *Service) GetLLMStatus(ctx context.Context, streamerID string) LLMStatus
 	if len(items) == 0 {
 		return status
 	}
+	status.History = items
 
 	latest := items[len(items)-1]
 	status.CurrentRunID = latest.RunID

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -106,6 +106,8 @@ func TestRecordAndListLLMDecisions(t *testing.T) {
 		ChunkRef:           "streamlink://str-1/123",
 		RequestRef:         "gemini-request-1",
 		ResponseRef:        "gemini-response-1",
+		RequestPayload:     "{\"contents\":[{\"role\":\"user\"}]}",
+		ResponsePayload:    "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"{}\"}]}}]}",
 		RawResponse:        "{\"label\":\"competitive\"}",
 		TokensIn:           144,
 		TokensOut:          27,
@@ -125,7 +127,7 @@ func TestRecordAndListLLMDecisions(t *testing.T) {
 	if items[0].ID != second.ID {
 		t.Fatalf("expected latest decision first, got %s", items[0].ID)
 	}
-	if items[0].PromptVersionID != "prompt-2" || items[0].ChunkRef == "" || items[0].LatencyMS != 180 || items[0].RequestRef == "" || items[0].TransitionToStep != "wait_for_result" {
+	if items[0].PromptVersionID != "prompt-2" || items[0].ChunkRef == "" || items[0].LatencyMS != 180 || items[0].RequestRef == "" || items[0].RequestPayload == "" || items[0].ResponsePayload == "" || items[0].TransitionToStep != "wait_for_result" {
 		t.Fatalf("expected metadata to be persisted, got %#v", items[0])
 	}
 	if items[0].ID == "" || items[0].ID[:4] != "llm_" {


### PR DESCRIPTION
### Motivation
- Improve observability and debugging for the LLM-driven stream analysis loop by making every upstream LLM request and response visible through the streamer status read model. 
- The change aligns the runtime read-model with the scenario-graph v2 intent to treat the full LLM JSON payloads as scenario-owned state and to make LLM cycles auditable. 

### Description
- Added `requestPayload` and `responsePayload` to the stage/classifier result and threaded them through the worker so each `RecordDecisionRequest` includes the serialized upstream request and raw HTTP response. 
- Persisted the new fields in the domain model `LLMDecision` and in `RecordDecisionRequest`, and included `history []LLMDecision` in `LLMStatus` returned by `GetLLMStatus`. 
- Propagated the payloads in the Gemini classifier (`GeminiStageClassifier`) so `StageClassification` now contains `RequestPayload` and `ResponsePayload`, and the worker stores them when calling `RecordLLMDecision`. 
- Updated API contract and docs: `docs/openapi.yaml` and `docs/local_setup.md` now document the `history` field and the new decision payload fields, and tests were adjusted to assert the presence of history and payload metadata. 

### Testing
- Ran unit tests: `go test ./internal/streamers ./internal/media ./internal/app` and all suites passed (`ok` for each package). 
- Updated and executed status-related tests (`internal/app/router_streamers_status_test.go` and `internal/streamers/service_test.go`) to assert `history` and payload persistence and they succeeded. 
- Checklist aligned with implementation plan (M2.1 / `docs/llm_stream_orchestration_plan.md`):
  - [x] Expand streamer read-model to include full chronological LLM decision history (`history`).
  - [x] Persist per-call LLM request/response payloads so each decision is auditable.
  - [ ] Add filtering/pagination for `history` to avoid large responses in production.
  - [ ] Add masking or redaction for sensitive content in payloads when exposing to clients.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbda711f00832ca236dc8c6519ed00)