### PR TITLE
Expose static `videoData` placeholder for LLM decisions and remove `chunkRef` from API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1085,8 +1085,9 @@ components:
           type: integer
         timeoutMs:
           type: integer
-        chunkRef:
+        videoData:
           type: string
+          description: Static placeholder string `video-data` returned for each decision entry.
         requestRef:
           type: string
         responseRef:

--- a/internal/app/router_streamers_status_test.go
+++ b/internal/app/router_streamers_status_test.go
@@ -68,6 +68,16 @@ func TestStreamerStatusReturnsAggregatedLLMState(t *testing.T) {
 	if !ok || len(history) != 2 {
 		t.Fatalf("expected full history with two decisions, got %#v", got["history"])
 	}
+	firstDecision, ok := history[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected first history decision object, got %#v", history[0])
+	}
+	if firstDecision["videoData"] != "video-data" {
+		t.Fatalf("expected videoData placeholder, got %#v", firstDecision["videoData"])
+	}
+	if _, exists := firstDecision["chunkRef"]; exists {
+		t.Fatalf("did not expect chunkRef in API response, got %#v", firstDecision["chunkRef"])
+	}
 }
 
 func TestStreamerStatusReturnsIdleWhenNoDecisionsYet(t *testing.T) {

--- a/internal/streamers/model.go
+++ b/internal/streamers/model.go
@@ -33,7 +33,7 @@ type LLMDecision struct {
 	Temperature        float64 `json:"temperature,omitempty"`
 	MaxTokens          int     `json:"maxTokens,omitempty"`
 	TimeoutMS          int     `json:"timeoutMs,omitempty"`
-	ChunkRef           string  `json:"chunkRef,omitempty"`
+	ChunkRef           string  `json:"videoData,omitempty"`
 	RequestRef         string  `json:"requestRef,omitempty"`
 	ResponseRef        string  `json:"responseRef,omitempty"`
 	RequestPayload     string  `json:"requestPayload,omitempty"`

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -447,9 +447,10 @@ func (s *Service) GetLLMStatus(ctx context.Context, streamerID string) LLMStatus
 	if len(items) == 0 {
 		return status
 	}
-	status.History = items
+	publicItems := statusDecisionsWithStaticVideoData(items)
+	status.History = publicItems
 
-	latest := items[len(items)-1]
+	latest := publicItems[len(publicItems)-1]
 	status.CurrentRunID = latest.RunID
 	status.CurrentStage = latest.Stage
 	status.CurrentLabel = latest.Label
@@ -458,12 +459,12 @@ func (s *Service) GetLLMStatus(ctx context.Context, streamerID string) LLMStatus
 		status.UpdatedAt = latest.CreatedAt
 		status.State = "active"
 	}
-	status.DetectedGameKey = inferDetectedGameKey(items)
+	status.DetectedGameKey = inferDetectedGameKey(publicItems)
 
 	orderedStages := make([]string, 0)
 	seenStages := make(map[string]struct{})
 	latestByStage := make(map[string]LLMDecision)
-	for _, item := range items {
+	for _, item := range publicItems {
 		if _, exists := seenStages[item.Stage]; !exists {
 			orderedStages = append(orderedStages, item.Stage)
 			seenStages[item.Stage] = struct{}{}
@@ -477,6 +478,18 @@ func (s *Service) GetLLMStatus(ctx context.Context, streamerID string) LLMStatus
 	}
 	status.LatestByStage = ordered
 	return status
+}
+
+func statusDecisionsWithStaticVideoData(items []LLMDecision) []LLMDecision {
+	if len(items) == 0 {
+		return []LLMDecision{}
+	}
+	result := make([]LLMDecision, 0, len(items))
+	for _, item := range items {
+		item.ChunkRef = "video-data"
+		result = append(result, item)
+	}
+	return result
 }
 
 func (s *Service) MarkAnalysisActive(streamerID string) {

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -237,4 +237,10 @@ func TestRecordLLMDecisionAllowsCustomStageAndStatusIncludesIt(t *testing.T) {
 	if status.LatestByStage[0].Stage != "ranked_mode" {
 		t.Fatalf("stage = %q, want ranked_mode", status.LatestByStage[0].Stage)
 	}
+	if status.LatestByStage[0].ChunkRef != "video-data" {
+		t.Fatalf("videoData = %q, want video-data", status.LatestByStage[0].ChunkRef)
+	}
+	if status.History[0].ChunkRef != "video-data" {
+		t.Fatalf("history videoData = %q, want video-data", status.History[0].ChunkRef)
+	}
 }


### PR DESCRIPTION
### Motivation

- Provide a stable API field for video content references by returning a static placeholder instead of exposing internal chunk references.
- Align the service responses and OpenAPI schema so consumers see `videoData` with a known placeholder value.
- Ensure aggregated LLM status and history use the public placeholder when constructing API responses.

### Description

- Updated the OpenAPI spec to replace `chunkRef` with `videoData` and added a description that it is a static placeholder string `video-data`.
- Changed the `LLMDecision` JSON tag for the ChunkRef field to `videoData` so outgoing JSON uses the new name (`videoData`).
- Added `statusDecisionsWithStaticVideoData` which injects the static `"video-data"` value into decisions and used it when building `status.History`, `LatestByStage`, and other derived fields.
- Updated service logic to operate on the publicized decision list and adjusted tests to assert the presence of the `video-data` placeholder and absence of the old `chunkRef` key in API responses.

### Testing

- Ran unit tests covering streamer status and LLM decision handling including `TestGetLLMStatusAggregatesLatestStageSnapshots` and `TestRecordLLMDecisionAllowsCustomStageAndStatusIncludesIt`, and they passed.
- Exercised HTTP handler tests `TestStreamerStatusReturnsAggregatedLLMState` and `TestStreamerStatusReturnsIdleWhenNoDecisionsYet`, and they passed when asserting the `videoData` placeholder behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccfc1ce970832cb1508132a39affa1)