### PR TITLE
Sanitize Gemini request payloads to mask video bytes

### DIFF
--- a/internal/media/gemini.go
+++ b/internal/media/gemini.go
@@ -286,7 +286,7 @@ func (c *GeminiStageClassifier) classify(ctx context.Context, input StageRequest
 		RawResponse:      strings.TrimSpace(rawText),
 		RequestRef:       endpoint,
 		ResponseRef:      strconv.Itoa(resp.StatusCode),
-		RequestPayload:   string(bodyBytes),
+		RequestPayload:   sanitizeGeminiRequestPayload(requestBody),
 		ResponsePayload:  string(responseBody),
 		TokensIn:         payload.UsageMetadata.PromptTokenCount,
 		TokensOut:        payload.UsageMetadata.CandidatesTokenCount,
@@ -306,6 +306,35 @@ func sanitizeGeminiGenerationConfig(temperature float64, maxTokens int) geminiGe
 		cfg.MaxOutputTokens = maxTokens
 	}
 	return cfg
+}
+
+func sanitizeGeminiRequestPayload(request geminiGenerateContentRequest) string {
+	safe := geminiGenerateContentRequest{
+		GenerationConfig: request.GenerationConfig,
+		Contents:         make([]geminiContent, 0, len(request.Contents)),
+	}
+	for _, content := range request.Contents {
+		safeContent := geminiContent{
+			Role:  content.Role,
+			Parts: make([]geminiPart, 0, len(content.Parts)),
+		}
+		for _, part := range content.Parts {
+			safePart := geminiPart{Text: part.Text}
+			if part.InlineData != nil {
+				safePart.InlineData = &geminiInlineData{
+					MimeType: part.InlineData.MimeType,
+					Data:     "video data",
+				}
+			}
+			safeContent.Parts = append(safeContent.Parts, safePart)
+		}
+		safe.Contents = append(safe.Contents, safeContent)
+	}
+	payload, err := json.Marshal(safe)
+	if err != nil {
+		return ""
+	}
+	return string(payload)
 }
 
 func geminiSessionKey(input StageRequest) string {

--- a/internal/media/gemini_test.go
+++ b/internal/media/gemini_test.go
@@ -1,6 +1,7 @@
 package media
 
 import (
+	"encoding/base64"
 	"context"
 	"fmt"
 	"io"
@@ -106,6 +107,12 @@ func TestGeminiStageClassifierClassify(t *testing.T) {
 	}
 	if !strings.Contains(gotBody, "Detect the game being played") {
 		t.Fatalf("expected prompt template in request body: %s", gotBody)
+	}
+	if !strings.Contains(result.RequestPayload, `"data":"video data"`) {
+		t.Fatalf("expected sanitized video data placeholder in request payload: %s", result.RequestPayload)
+	}
+	if strings.Contains(result.RequestPayload, base64.StdEncoding.EncodeToString([]byte("fake transport stream"))) {
+		t.Fatalf("request payload should not include base64 video bytes: %s", result.RequestPayload)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Prevent storing/exposing raw inline video bytes in LLM diagnostic payloads by replacing inline chunk data with a safe placeholder, reducing privacy and payload-size risks.
- Preserve diagnostic context (MIME type and prompt text) while ensuring `requestPayload` does not contain base64 video data visible via streamer history/status endpoints.

### Description
- Replace `StageClassification.RequestPayload` serialization for Gemini calls with `sanitizeGeminiRequestPayload` that keeps `GenerationConfig` and per-part metadata but replaces `inlineData.data` with the string `"video data"`.
- Implemented `sanitizeGeminiRequestPayload` in `internal/media/gemini.go` and wired it into the Gemini classifier result path.
- Added assertions to `internal/media/gemini_test.go` to verify the sanitized payload includes the placeholder and does not contain the original base64 video bytes.
- Left actual outbound Gemini requests unchanged so the real chunk bytes continue to be sent to the upstream classifier while only the persisted/returned copy is masked.

### Testing
- Ran `go test ./internal/media` and the package tests passed (`ok github.com/funpot/funpot-go-core/internal/media`).
- Updated unit tests assert that `RequestPayload` contains `"data":"video data"` and does not contain the base64-encoded chunk, and these assertions succeeded.
- Checklist aligned to `docs/implementation_plan.md` M2.1 and `docs/llm_stream_orchestration_plan.md`: [x] mask request payload video bytes; [x] preserve runtime behavior (real bytes still sent to Gemini); [ ] update docs/openapi or public contract notes to reflect masking; [ ] follow-up M2.1 items outside masking scope.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd012308a8832cb4fdcc66476ac217)