### PR TITLE
Normalize JSONPath roots in scenario transition conditions

### DIFF
--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -641,7 +641,11 @@ func parseJSONMap(raw string) map[string]any {
 }
 
 func lookupJSONPath(payload map[string]any, path string) (any, bool) {
-	parts := strings.Split(strings.TrimSpace(path), ".")
+	cleanPath := strings.TrimSpace(path)
+	cleanPath = strings.TrimPrefix(cleanPath, "$.")
+	cleanPath = strings.TrimPrefix(cleanPath, "$")
+	cleanPath = strings.TrimPrefix(cleanPath, ".")
+	parts := strings.Split(cleanPath, ".")
 	var current any = payload
 	for _, part := range parts {
 		part = strings.TrimSpace(part)

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -107,7 +107,9 @@ func TestEvaluateCondition(t *testing.T) {
 		want bool
 	}{
 		{name: "equals", expr: "game == cs2", want: true},
+		{name: "equals jsonpath root", expr: "$.game == cs2", want: true},
 		{name: "not equals", expr: "mode != premier", want: true},
+		{name: "exists jsonpath root", expr: "exists($.nested.value)", want: true},
 		{name: "exists", expr: "exists(nested.value)", want: true},
 		{name: "not_exists", expr: "not_exists(nested.missing)", want: true},
 	}


### PR DESCRIPTION
### Motivation
- Admin-defined scenario transition conditions often use JSONPath root notation (for example `$.game == cs2`) and the path resolver previously treated `$` as a literal key, causing expected transitions (e.g., `root_detect -> cs2_mode`) to not fire.

### Description
- Strip leading `$.`, leading `$`, and leading `.` in `lookupJSONPath` before splitting the path so both `game` and `$.game` style expressions resolve identically.
- Add unit tests in `internal/prompts/scenario_flow_test.go` to cover `$.game == cs2` and `exists($.nested.value)` forms so JSONPath-root conditions are exercised.
- No API or database schema changes were made.

### Testing
- Ran `go test ./internal/prompts ./internal/media` and both packages passed successfully.
- Checklist aligned with `docs/implementation_plan.md` milestone M2.1 and `docs/llm_stream_orchestration_plan.md`:
  - [x] Fix scenario transition evaluation for JSONPath-root (`$.field`) conditions so admin-defined transitions can trigger correctly.
  - [x] Add unit test coverage for JSONPath-root condition forms in `evaluateCondition`.
  - [ ] Add integration tests that exercise full worker flow (`step -> LLM state update -> transition`) across scenario packages on staging.
  - [ ] Verify behavior with live streamer data on a staging environment and monitor for regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd0a59b638832c94c1bdfd029e5823)