### PR TITLE
Validate scenario entry conditions during package creation

### DIFF
--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -16,6 +16,7 @@ var (
 	ErrScenarioStepNotFound    = errors.New("scenario step not found")
 	ErrInvalidScenarioPackage  = errors.New("scenario package must contain at least one step")
 	ErrInvalidScenarioStepID   = errors.New("scenario step id must not be empty")
+	ErrInvalidScenarioCondition = errors.New("scenario step entry condition is invalid")
 	ErrInvalidScenarioModelRef = errors.New("scenario package llmModelConfigId must not be empty")
 	ErrInvalidScenarioName     = errors.New("scenario package name must not be empty")
 )
@@ -114,6 +115,9 @@ func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) erro
 		id := strings.TrimSpace(step.ID)
 		if id == "" {
 			return ErrInvalidScenarioStepID
+		}
+		if err := validateScenarioCondition(step.EntryCondition); err != nil {
+			return fmt.Errorf("%w: step %s: %v", ErrInvalidScenarioCondition, id, err)
 		}
 		seenSteps[id] = struct{}{}
 	}
@@ -673,4 +677,9 @@ func lookupJSONPath(payload map[string]any, path string) (any, bool) {
 		}
 	}
 	return current, true
+}
+
+func validateScenarioCondition(condition string) error {
+	_, err := evaluateCondition(condition, map[string]any{})
+	return err
 }

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -3,6 +3,7 @@ package prompts
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 )
 
@@ -367,6 +368,29 @@ func TestScenarioPackageCreateRequiresPackageModelConfig(t *testing.T) {
 	}
 	if err != ErrInvalidScenarioModelRef {
 		t.Fatalf("expected ErrInvalidScenarioModelRef, got %v", err)
+	}
+}
+
+func TestScenarioPackageCreateRejectsInvalidEntryCondition(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	config := mustCreateModelConfig(t, svc)
+	_, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "invalid entry condition",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
+		Steps: []ScenarioStep{
+			{ID: "root_detect", Name: "Root detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "matchmaking_5v5", Name: "Matchmaking 5v5", EntryCondition: "matchmaking-5vs5", PromptTemplate: "score", ResponseSchemaJSON: `{}`, Order: 2},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected invalid entry condition validation error")
+	}
+	if !errors.Is(err, ErrInvalidScenarioCondition) {
+		t.Fatalf("expected ErrInvalidScenarioCondition, got %v", err)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- The worker pipeline could get stuck on a step when an invalid `EntryCondition` (for example a bare token like `matchmaking-5vs5`) was auto-wired into transitions but never matched at runtime, producing repeated `state_updated` events. 
- Admins needed immediate feedback when creating/updating scenario packages so misconfigured transitions are caught early and do not silently break orchestration.

### Description
- Added a new error `ErrInvalidScenarioCondition` and a `validateScenarioCondition` helper that reuses `evaluateCondition` to validate `ScenarioStep.EntryCondition` syntax. 
- Integrated validation into `ValidateScenarioPackageCreateRequest` so invalid entry conditions cause package creation to fail with a clear error. 
- Added unit test `TestScenarioPackageCreateRejectsInvalidEntryCondition` to assert that a package with a malformed entry condition is rejected. 
- Checklist aligned with implementation docs: `[x]` validate entry conditions on package create (M2.1 / scenario-graph v2), `[ ]` add UI-level validation in the scenario editor, `[ ]` add e2e API test for admin route error propagation. 

### Testing
- Ran unit tests for the prompts package with `go test ./internal/prompts`, which succeeded (`ok`).
- The change touches `internal/prompts/scenario_flow.go` and `internal/prompts/scenario_flow_test.go` and the new test is passing in CI-local run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd140a70c0832ca2aac240e368902b)