### PR TITLE
Support shorthand entry-condition transitions in scenario flow

### DIFF
--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -633,6 +634,12 @@ func evaluateCondition(condition string, payload map[string]any) (bool, error) {
 			return !strings.EqualFold(leftValue, rightValue), nil
 		}
 	}
+	if isScenarioConditionShorthandLiteral(expr) {
+		if modeRaw, ok := payload["mode"]; ok {
+			return strings.EqualFold(fmt.Sprint(modeRaw), expr), nil
+		}
+		return false, nil
+	}
 	return false, fmt.Errorf("unsupported condition: %s", expr)
 }
 
@@ -680,6 +687,20 @@ func lookupJSONPath(payload map[string]any, path string) (any, bool) {
 }
 
 func validateScenarioCondition(condition string) error {
-	_, err := evaluateCondition(condition, map[string]any{})
+	expr := strings.TrimSpace(condition)
+	if isScenarioConditionShorthandLiteral(expr) {
+		return nil
+	}
+	_, err := evaluateCondition(expr, map[string]any{})
 	return err
+}
+
+var scenarioConditionLiteralPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+func isScenarioConditionShorthandLiteral(expr string) bool {
+	clean := strings.TrimSpace(expr)
+	if clean == "" {
+		return false
+	}
+	return scenarioConditionLiteralPattern.MatchString(clean)
 }

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -115,6 +115,7 @@ func TestEvaluateCondition(t *testing.T) {
 		{name: "exists jsonpath root", expr: "exists($.nested.value)", want: true},
 		{name: "exists", expr: "exists(nested.value)", want: true},
 		{name: "not_exists", expr: "not_exists(nested.missing)", want: true},
+		{name: "shorthand mode literal", expr: "faceit", want: true},
 	}
 
 	for _, tc := range cases {
@@ -128,6 +129,13 @@ func TestEvaluateCondition(t *testing.T) {
 				t.Fatalf("evaluateCondition(%q)=%v, want %v", tc.expr, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestValidateScenarioConditionAllowsShorthandLiteral(t *testing.T) {
+	t.Parallel()
+	if err := validateScenarioCondition("matchmaking-5vs5"); err != nil {
+		t.Fatalf("expected shorthand entry condition to be accepted: %v", err)
 	}
 }
 
@@ -383,7 +391,7 @@ func TestScenarioPackageCreateRejectsInvalidEntryCondition(t *testing.T) {
 		LLMModelConfigID: config.ID,
 		Steps: []ScenarioStep{
 			{ID: "root_detect", Name: "Root detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
-			{ID: "matchmaking_5v5", Name: "Matchmaking 5v5", EntryCondition: "matchmaking-5vs5", PromptTemplate: "score", ResponseSchemaJSON: `{}`, Order: 2},
+			{ID: "matchmaking_5v5", Name: "Matchmaking 5v5", EntryCondition: "mode >< matchmaking-5vs5", PromptTemplate: "score", ResponseSchemaJSON: `{}`, Order: 2},
 		},
 	})
 	if err == nil {


### PR DESCRIPTION
### Motivation
- Admin-defined scenario graphs use shorthand literal entry conditions (e.g. `matchmaking-5vs5`) to represent mode sub-steps and those literals were previously treated as unsupported conditions, causing workers to remain on the parent step and not advance. 
- The change ensures the runtime honors these shorthand literals by mapping them to `mode == <literal>` semantics so transitions like `cs2_mode -> matchmaking-5vs5` can occur.

### Description
- Added shorthand literal handling in `evaluateCondition` so bare identifiers (alphanumeric, `_` or `-`) are treated as `mode == <literal>` when evaluating transitions. (updated `internal/prompts/scenario_flow.go`).
- Updated `validateScenarioCondition` to accept these shorthand literals during scenario package validation so admin UI configs are not rejected. (updated `internal/prompts/scenario_flow.go`).
- Introduced `isScenarioConditionShorthandLiteral` and a regex pattern to identify allowed shorthand literals. (updated `internal/prompts/scenario_flow.go`).
- Added and adjusted unit tests to cover shorthand evaluation and validation and to preserve rejection of truly invalid conditions (updated `internal/prompts/scenario_flow_test.go`).

Checklist (aligned to docs/implementation_plan.md M2.1 and docs/llm_stream_orchestration_plan.md):
- [x] Implement runtime support for shorthand entryCondition literals mapped to `mode` comparisons. 
- [x] Accept shorthand literals during scenario package validation. 
- [x] Add unit tests for shorthand behavior. 
- [ ] Run end-to-end verification of active scenario packages through the admin UI and live worker pipeline. 
- [ ] Add extra diagnostics in the status/read model for transition skip reasons.

### Testing
- Ran unit tests for the prompts package with `go test ./internal/prompts`, which passed: `ok github.com/funpot/funpot-go-core/internal/prompts`.
- Updated tests include `TestEvaluateCondition` (adds shorthand literal case) and `TestValidateScenarioConditionAllowsShorthandLiteral`, and `TestScenarioPackageCreateRejectsInvalidEntryCondition` (ensures invalid syntax still fails).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce69078e54832cb9b46a1b6640789b)