### PR TITLE
Favor higher-priority scenario transitions and add unit test

### DIFF
--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -481,7 +481,7 @@ func (p ScenarioPackage) ResolveStep(currentStepID, stateJSON string) (ScenarioS
 			transitions = append(transitions, item)
 		}
 	}
-	sort.Slice(transitions, func(i, j int) bool { return transitions[i].Priority < transitions[j].Priority })
+	sort.Slice(transitions, func(i, j int) bool { return transitions[i].Priority > transitions[j].Priority })
 	for _, tr := range transitions {
 		ok, err := evaluateCondition(tr.Condition, state)
 		if err != nil || !ok {

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -98,6 +98,33 @@ func TestScenarioPackageResolveStepFallsBackToFirstInitialWhenNoConditionMatches
 	}
 }
 
+func TestScenarioPackageResolveStepUsesHighestPriorityTransition(t *testing.T) {
+	t.Parallel()
+
+	pkg := ScenarioPackage{
+		ID:       "pkg-1",
+		Name:     "priority flow",
+		GameSlug: "global",
+		Steps: []ScenarioStep{
+			{ID: "step_a", Name: "Step A", Initial: true, Order: 1},
+			{ID: "step_b", Name: "Step B", Order: 2},
+			{ID: "step_c", Name: "Step C", Order: 3},
+		},
+		Transitions: []ScenarioTransition{
+			{FromStepID: "step_a", ToStepID: "step_b", Condition: "mode=matchmaking-5vs5", Priority: 1},
+			{FromStepID: "step_a", ToStepID: "step_c", Condition: "ct_score >= 12 | t_score >= 12", Priority: 5},
+		},
+	}
+
+	step, entered, err := pkg.ResolveStep("step_a", `{"ct_score":8,"t_score":12,"mode":"matchmaking-5vs5"}`)
+	if err != nil {
+		t.Fatalf("resolve priority transition: %v", err)
+	}
+	if !entered || step.ID != "step_c" {
+		t.Fatalf("expected transition to step_c by highest priority, got entered=%v step=%s", entered, step.ID)
+	}
+}
+
 func TestEvaluateCondition(t *testing.T) {
 	t.Parallel()
 	payload := map[string]any{"game": "cs2", "mode": "faceit", "nested": map[string]any{"value": "x"}}


### PR DESCRIPTION
### Motivation

- Ensure scenario transition selection prefers transitions with higher numeric `Priority` so the most important transition fires when multiple conditions match.
- Add a unit test to prevent regressions and document the expected behavior.

### Description

- Reverse the transition sort order in `ResolveStep` by changing the comparator to sort descending on `Priority` so higher values come first.
- Add `TestScenarioPackageResolveStepUsesHighestPriorityTransition` in `internal/prompts/scenario_flow_test.go` which verifies that the transition with the highest `Priority` is chosen when multiple transition conditions match.

### Testing

- Ran the package unit tests with `go test ./internal/prompts` and the suite including `TestScenarioPackageResolveStepUsesHighestPriorityTransition` passed.
- Verified the new test `TestScenarioPackageResolveStepUsesHighestPriorityTransition` succeeds and prevents reverting to the previous lower-priority behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ef804e78832c969927aab89ada83)