### PR TITLE
Add explicit scenario transitions with validation and admin API support

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -71,11 +71,21 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 			Order:              step.Order,
 		})
 	}
+	transitions := make([]prompts.ScenarioTransition, 0, len(req.Transitions))
+	for _, transition := range req.Transitions {
+		transitions = append(transitions, prompts.ScenarioTransition{
+			FromStepID: transition.FromStepID,
+			ToStepID:   transition.ToStepID,
+			Condition:  transition.Condition,
+			Priority:   transition.Priority,
+		})
+	}
 	return prompts.ScenarioPackageCreateRequest{
 		Name:             req.Name,
 		GameSlug:         req.GameSlug,
 		LLMModelConfigID: req.LLMModelConfigID,
 		Steps:            steps,
+		Transitions:      transitions,
 		ActorID:          actorID,
 	}
 }
@@ -109,11 +119,19 @@ type scenarioStepRequest struct {
 	Order              int    `json:"order"`
 }
 
+type scenarioTransitionRequest struct {
+	FromStepID string `json:"fromStepId"`
+	ToStepID   string `json:"toStepId"`
+	Condition  string `json:"condition"`
+	Priority   int    `json:"priority"`
+}
+
 type scenarioPackageCreateRequest struct {
-	Name             string                `json:"name"`
-	GameSlug         string                `json:"gameSlug"`
-	LLMModelConfigID string                `json:"llmModelConfigId"`
-	Steps            []scenarioStepRequest `json:"steps"`
+	Name             string                      `json:"name"`
+	GameSlug         string                      `json:"gameSlug"`
+	LLMModelConfigID string                      `json:"llmModelConfigId"`
+	Steps            []scenarioStepRequest       `json:"steps"`
+	Transitions      []scenarioTransitionRequest `json:"transitions"`
 }
 
 type llmModelConfigUpsertRequest struct {

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -77,6 +77,14 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"order":              2,
 			},
 		},
+		"transitions": []map[string]any{
+			{
+				"fromStepId": "root_detect",
+				"toStepId":   "cs2_mode",
+				"condition":  "game = cs2",
+				"priority":   3,
+			},
+		},
 	})
 	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/scenario-packages", bytes.NewReader(createBody))
 	createReq.Header.Set("Authorization", "Bearer "+adminToken)
@@ -92,6 +100,10 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	packageID, _ := created["id"].(string)
 	if packageID == "" {
 		t.Fatalf("expected created scenario package id, got %#v", created)
+	}
+	transitions, ok := created["transitions"].([]any)
+	if !ok || len(transitions) != 1 {
+		t.Fatalf("expected explicit transitions in response, got %#v", created["transitions"])
 	}
 
 	updateBody, _ := json.Marshal(map[string]any{

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -98,6 +98,7 @@ type ScenarioPackageCreateRequest struct {
 	GameSlug         string
 	LLMModelConfigID string
 	Steps            []ScenarioStep
+	Transitions      []ScenarioTransition
 	ActorID          string
 }
 
@@ -122,6 +123,22 @@ func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) erro
 		}
 		seenSteps[id] = struct{}{}
 	}
+	for _, transition := range req.Transitions {
+		from := strings.TrimSpace(transition.FromStepID)
+		to := strings.TrimSpace(transition.ToStepID)
+		if from == "" || to == "" {
+			return ErrInvalidScenarioStepID
+		}
+		if _, ok := seenSteps[from]; !ok {
+			return fmt.Errorf("%w: unknown transition fromStepId %s", ErrInvalidScenarioStepID, from)
+		}
+		if _, ok := seenSteps[to]; !ok {
+			return fmt.Errorf("%w: unknown transition toStepId %s", ErrInvalidScenarioStepID, to)
+		}
+		if err := validateScenarioCondition(transition.Condition); err != nil {
+			return fmt.Errorf("%w: transition %s -> %s: %v", ErrInvalidScenarioCondition, from, to, err)
+		}
+	}
 	return nil
 }
 
@@ -142,7 +159,23 @@ func normalizeScenarioSteps(steps []ScenarioStep, fallbackGameSlug string, now t
 	return normalized
 }
 
-func normalizeScenarioTransitions(steps []ScenarioStep) []ScenarioTransition {
+func normalizeScenarioTransitions(steps []ScenarioStep, transitions []ScenarioTransition) []ScenarioTransition {
+	if len(transitions) > 0 {
+		normalized := make([]ScenarioTransition, 0, len(transitions))
+		for _, tr := range transitions {
+			normalizedTransition := ScenarioTransition{
+				FromStepID: strings.TrimSpace(tr.FromStepID),
+				ToStepID:   strings.TrimSpace(tr.ToStepID),
+				Condition:  strings.TrimSpace(tr.Condition),
+				Priority:   tr.Priority,
+			}
+			if normalizedTransition.Priority <= 0 {
+				normalizedTransition.Priority = 1
+			}
+			normalized = append(normalized, normalizedTransition)
+		}
+		return normalized
+	}
 	if len(steps) < 2 {
 		return []ScenarioTransition{}
 	}
@@ -204,7 +237,7 @@ func (s *Service) CreateScenarioPackage(ctx context.Context, req ScenarioPackage
 	}
 	now := time.Now().UTC()
 	normalizedSteps := normalizeScenarioSteps(req.Steps, gameSlug, now)
-	normalizedTransitions := normalizeScenarioTransitions(normalizedSteps)
+	normalizedTransitions := normalizeScenarioTransitions(normalizedSteps, req.Transitions)
 	req.Steps = normalizedSteps
 	if strings.TrimSpace(req.LLMModelConfigID) != "" {
 		if _, err := s.GetLLMModelConfig(ctx, req.LLMModelConfigID); err != nil {
@@ -284,7 +317,7 @@ func (s *Service) UpdateScenarioPackage(ctx context.Context, id string, req Scen
 	}
 	now := time.Now().UTC()
 	normalizedSteps := normalizeScenarioSteps(req.Steps, targetGameSlug, now)
-	normalizedTransitions := normalizeScenarioTransitions(normalizedSteps)
+	normalizedTransitions := normalizeScenarioTransitions(normalizedSteps, req.Transitions)
 	req.Steps = normalizedSteps
 	if strings.TrimSpace(req.LLMModelConfigID) != "" {
 		if _, err := s.GetLLMModelConfig(ctx, req.LLMModelConfigID); err != nil {

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -328,6 +328,67 @@ func TestScenarioPackageCreateAutowiresTransitionsWhenMissing(t *testing.T) {
 	}
 }
 
+func TestScenarioPackageCreateUsesExplicitTransitionsForGraphRouting(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	config := mustCreateModelConfig(t, svc)
+	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "graph transitions",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
+		Steps: []ScenarioStep{
+			{ID: "step_a", Name: "Step A", PromptTemplate: "a", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "step_b", Name: "Step B", PromptTemplate: "b", ResponseSchemaJSON: `{}`, Order: 2},
+			{ID: "step_c", Name: "Step C", PromptTemplate: "c", ResponseSchemaJSON: `{}`, Order: 3},
+		},
+		Transitions: []ScenarioTransition{
+			{FromStepID: "step_a", ToStepID: "step_b", Condition: "mode = matchmaking-5vs5", Priority: 1},
+			{FromStepID: "step_a", ToStepID: "step_c", Condition: "ct_score >= 12 | t_score >= 12", Priority: 5},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+	if len(item.Transitions) != 2 {
+		t.Fatalf("expected explicit transition graph to be preserved, got %#v", item.Transitions)
+	}
+
+	step, entered, err := item.ResolveStep("step_a", `{"ct_score":8,"t_score":12,"mode":"matchmaking-5vs5"}`)
+	if err != nil {
+		t.Fatalf("resolve explicit graph transition: %v", err)
+	}
+	if !entered || step.ID != "step_c" {
+		t.Fatalf("expected explicit graph routing to step_c, got entered=%v step=%s", entered, step.ID)
+	}
+}
+
+func TestScenarioPackageCreateRejectsTransitionWithUnknownStep(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	config := mustCreateModelConfig(t, svc)
+	_, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "invalid transition",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
+		Steps: []ScenarioStep{
+			{ID: "step_a", Name: "Step A", PromptTemplate: "a", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+		},
+		Transitions: []ScenarioTransition{
+			{FromStepID: "step_a", ToStepID: "step_missing", Condition: "mode = matchmaking-5vs5", Priority: 1},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected validation error for transition to unknown step")
+	}
+	if !errors.Is(err, ErrInvalidScenarioStepID) {
+		t.Fatalf("expected ErrInvalidScenarioStepID, got %v", err)
+	}
+}
+
 func TestScenarioPackageCreateReturnsEmptyTransitionArrayForSingleStep(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Motivation
- Allow scenario packages to declare explicit graph transitions between steps instead of only autowiring sequential transitions.
- Ensure transitions are validated (known step IDs and valid conditions) and normalized (trimmed fields, default priority).
- Surface transitions through the admin API so clients can create and inspect graphs.

### Description
- Added `scenarioTransitionRequest` and `Transitions` to the router request type and mapped incoming transitions into `prompts.ScenarioTransition` in `scenarioPackageRequestToCreateRequest`.
- Extended `ScenarioPackageCreateRequest` to include `Transitions` and updated `ValidateScenarioPackageCreateRequest` to validate `FromStepID`, `ToStepID` and transition conditions.
- Reworked `normalizeScenarioTransitions` to accept explicit transitions (normalizing fields and applying default priority) and retained autowiring logic when no explicit transitions are provided.
- Updated `Service.CreateScenarioPackage` and `Service.UpdateScenarioPackage` to use normalized transitions, and added/updated tests exercising explicit transition handling and validation.

### Testing
- Ran unit tests for the prompts package and admin router, including `TestScenarioPackageCreateUsesExplicitTransitionsForGraphRouting`, `TestScenarioPackageCreateRejectsTransitionWithUnknownStep`, `TestScenarioPackageCreateAutowiresTransitionsWhenMissing`, and the admin LLM scenario package route test, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4f959d3c8832caea7238bf47bba10)