### PR TITLE
Finalize Bunny chunk uploads on tracking stop and include streamer username in remote path

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -118,6 +118,7 @@ func main() {
 		configurableCapture.SetLogger(logger.Named("stream_capture"))
 	}
 
+	chunkPublisher := buildChunkPublisher(cfg, streamersService)
 	streamWorker := media.NewWorker(
 		streamCapture,
 		buildStageClassifier(logger, cfg),
@@ -125,7 +126,7 @@ func main() {
 		&media.InMemoryRunStore{},
 		streamersService,
 		media.NewInMemoryLocker(),
-		media.WorkerConfig{LockTTL: streamWorkerLockTTL(cfg), MinConfidence: 0.5, ChunkPublisher: buildChunkPublisher(cfg)},
+		media.WorkerConfig{LockTTL: streamWorkerLockTTL(cfg), MinConfidence: 0.5, ChunkPublisher: chunkPublisher},
 	)
 	streamWorker.SetLogger(logger.Named("stream_worker"))
 	streamScheduler := media.NewScheduler(streamWorker, streamProcessInterval(cfg))
@@ -135,6 +136,12 @@ func main() {
 		return streamScheduler.Start(streamerID)
 	})
 	streamersService.SetTrackingStopHook(func(_ context.Context, streamerID string) error {
+		if finalizer, ok := chunkPublisher.(streamChunkFinalizer); ok {
+			if err := finalizer.Finalize(context.Background(), streamerID, time.Now().UTC()); err != nil {
+				logger.Error("failed to finalize stream video on manual tracking stop", zap.String("streamerID", streamerID), zap.Error(err))
+				return err
+			}
+		}
 		streamScheduler.Stop(streamerID)
 		return nil
 	})
@@ -255,7 +262,7 @@ func streamWorkerLockTTL(cfg config.Config) time.Duration {
 	return interval + 5*time.Second
 }
 
-func buildChunkPublisher(cfg config.Config) media.ChunkPublisher {
+func buildChunkPublisher(cfg config.Config, streamersService *streamers.Service) media.ChunkPublisher {
 	if cfg.Streamlink.BunnyLibraryID == "" || cfg.Streamlink.BunnyAPIKey == "" {
 		return nil
 	}
@@ -266,7 +273,17 @@ func buildChunkPublisher(cfg config.Config) media.ChunkPublisher {
 		BaseURL:        cfg.Streamlink.BunnyBaseURL,
 		LibraryID:      cfg.Streamlink.BunnyLibraryID,
 		APIKey:         cfg.Streamlink.BunnyAPIKey,
+		UsernameResolver: func(ctx context.Context, streamerID string) (string, error) {
+			if streamersService == nil {
+				return "", nil
+			}
+			return streamersService.ResolveStreamlinkChannel(ctx, streamerID)
+		},
 	})
+}
+
+type streamChunkFinalizer interface {
+	Finalize(ctx context.Context, streamerID string, capturedAt time.Time) error
 }
 
 func newLogger(level string) (*zap.Logger, error) {

--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -21,14 +21,15 @@ const (
 )
 
 type BunnyChunkPublisherConfig struct {
-	OutputDir      string
-	FFmpegBinary   string
-	Runner         StreamlinkCommandRunner
-	AggregateCount int
-	BaseURL        string
-	LibraryID      string
-	APIKey         string
-	HTTPTimeout    time.Duration
+	OutputDir        string
+	FFmpegBinary     string
+	Runner           StreamlinkCommandRunner
+	AggregateCount   int
+	BaseURL          string
+	LibraryID        string
+	APIKey           string
+	HTTPTimeout      time.Duration
+	UsernameResolver func(ctx context.Context, streamerID string) (string, error)
 }
 
 type BunnyChunkPublisher struct {
@@ -83,32 +84,50 @@ func (p *BunnyChunkPublisher) Publish(ctx context.Context, streamerID string, ch
 		return err
 	}
 
-	segments, err := p.listSegments(segmentsDir)
-	if err != nil {
-		return err
-	}
-	if len(segments) < p.cfg.AggregateCount {
+	return nil
+}
+
+func (p *BunnyChunkPublisher) Finalize(ctx context.Context, streamerID string, capturedAt time.Time) error {
+	if p == nil {
 		return nil
 	}
-
-	selected := segments[:p.cfg.AggregateCount]
-	windowPath, err := p.concatSegments(ctx, streamerID, segmentsDir, selected)
+	if strings.TrimSpace(p.cfg.LibraryID) == "" || strings.TrimSpace(p.cfg.APIKey) == "" {
+		return nil
+	}
+	segmentsDir := filepath.Join(p.cfg.OutputDir, sanitizeToken(streamerID), "segments")
+	segments, err := p.listSegments(segmentsDir)
+	if err != nil {
+		if errorsIsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if len(segments) == 0 {
+		return nil
+	}
+	windowPath, err := p.concatSegments(ctx, streamerID, segmentsDir, segments)
 	if err != nil {
 		return err
 	}
 	defer os.Remove(windowPath) //nolint:errcheck
 
-	videoID, err := p.createVideo(ctx, streamerID, chunk.CapturedAt)
+	videoID, err := p.createVideo(ctx, streamerID, capturedAt)
 	if err != nil {
 		return err
 	}
 	if err := p.uploadVideo(ctx, videoID, windowPath); err != nil {
 		return err
 	}
-	for _, segment := range selected {
+	for _, segment := range segments {
 		_ = os.Remove(segment)
 	}
+	_ = os.RemoveAll(segmentsDir)
+	_ = os.Remove(filepath.Join(p.cfg.OutputDir, sanitizeToken(streamerID)))
 	return nil
+}
+
+func errorsIsNotExist(err error) bool {
+	return err != nil && os.IsNotExist(err)
 }
 
 func (p *BunnyChunkPublisher) listSegments(segmentsDir string) ([]string, error) {
@@ -238,7 +257,7 @@ type bunnyCreateVideoResponse struct {
 }
 
 func (p *BunnyChunkPublisher) createVideo(ctx context.Context, streamerID string, capturedAt time.Time) (string, error) {
-	title := fmt.Sprintf("%s-%s", sanitizeToken(streamerID), sanitizeToken(capturedAt.UTC().Format(time.RFC3339Nano)))
+	title := p.buildRemoteVideoPath(ctx, streamerID, capturedAt)
 	payload, err := json.Marshal(bunnyCreateVideoRequest{Title: title})
 	if err != nil {
 		return "", err
@@ -294,4 +313,18 @@ func (p *BunnyChunkPublisher) uploadVideo(ctx context.Context, videoID, videoPat
 		return fmt.Errorf("upload bunny video failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(msg)))
 	}
 	return nil
+}
+
+func (p *BunnyChunkPublisher) buildRemoteVideoPath(ctx context.Context, streamerID string, capturedAt time.Time) string {
+	day := capturedAt.UTC().Format("2006-01-02")
+	if day == "0001-01-01" {
+		day = time.Now().UTC().Format("2006-01-02")
+	}
+	streamerFolder := sanitizeToken(streamerID)
+	if p.cfg.UsernameResolver != nil {
+		if username, err := p.cfg.UsernameResolver(ctx, streamerID); err == nil && strings.TrimSpace(username) != "" {
+			streamerFolder = sanitizeToken(streamerID + "_" + username)
+		}
+	}
+	return fmt.Sprintf("%s/%s/%s", streamerFolder, day, sanitizeToken(time.Now().UTC().Format(time.RFC3339Nano)))
 }

--- a/internal/media/publisher_test.go
+++ b/internal/media/publisher_test.go
@@ -2,6 +2,7 @@ package media
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -54,7 +55,7 @@ func (f *fakePublishRunner) Run(_ context.Context, _ io.Writer, _ io.Writer, nam
 	return nil
 }
 
-func TestBunnyChunkPublisherAggregatesAndUploadsWhenBatchReady(t *testing.T) {
+func TestBunnyChunkPublisherUploadsOnlyOnFinalize(t *testing.T) {
 	uploadCalls := 0
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -101,8 +102,18 @@ func TestBunnyChunkPublisherAggregatesAndUploadsWhenBatchReady(t *testing.T) {
 	if err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkB, CapturedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("publish second chunk: %v", err)
 	}
+	if uploadCalls != 0 {
+		t.Fatalf("uploadCalls = %d, want 0 before finalize", uploadCalls)
+	}
+	if err := publisher.Finalize(context.Background(), "str-1", time.Now().UTC()); err != nil {
+		t.Fatalf("finalize stream: %v", err)
+	}
 	if uploadCalls != 1 {
-		t.Fatalf("uploadCalls = %d, want 1 after batch ready", uploadCalls)
+		t.Fatalf("uploadCalls = %d, want 1 after finalize", uploadCalls)
+	}
+	segmentsDir := filepath.Join(dir, "str-1", "segments")
+	if _, err := os.Stat(segmentsDir); !os.IsNotExist(err) {
+		t.Fatalf("segments dir should be removed after finalize, stat err=%v", err)
 	}
 }
 
@@ -163,6 +174,9 @@ func TestBunnyChunkPublisherConcatListUsesAbsolutePaths(t *testing.T) {
 	}
 	if err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkB, CapturedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("publish second chunk: %v", err)
+	}
+	if err := publisher.Finalize(context.Background(), "str-1", time.Now().UTC()); err != nil {
+		t.Fatalf("finalize stream: %v", err)
 	}
 	if uploadCalls != 1 {
 		t.Fatalf("uploadCalls = %d, want 1", uploadCalls)
@@ -265,5 +279,57 @@ func TestParseSegmentIndex(t *testing.T) {
 	}
 	if got := parseSegmentIndex("legacy.mp4"); got != 0 {
 		t.Fatalf("parseSegmentIndex() = %d, want 0", got)
+	}
+}
+
+func TestBunnyChunkPublisherCreateVideoTitleIncludesStreamerAndDayFolders(t *testing.T) {
+	var title string
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/videos"):
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+			if raw, ok := payload["title"].(string); ok {
+				title = raw
+			}
+			_, _ = w.Write([]byte(`{"guid":"video-1"}`))
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/videos/video-1"):
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer api.Close()
+
+	runner := &fakePublishRunner{}
+	dir := t.TempDir()
+	publisher := NewBunnyChunkPublisher(BunnyChunkPublisherConfig{
+		OutputDir:    dir,
+		FFmpegBinary: "ffmpeg",
+		Runner:       runner,
+		BaseURL:      api.URL,
+		LibraryID:    "lib-1",
+		APIKey:       "key",
+		UsernameResolver: func(_ context.Context, _ string) (string, error) {
+			return "best_streamer", nil
+		},
+		HTTPTimeout: time.Second,
+	})
+
+	chunkA := filepath.Join(dir, "a.mp4")
+	if err := os.WriteFile(chunkA, []byte("A"), 0o644); err != nil {
+		t.Fatalf("write chunkA: %v", err)
+	}
+	if err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkA, CapturedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("publish chunk: %v", err)
+	}
+	at := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	if err := publisher.Finalize(context.Background(), "str-1", at); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if !strings.HasPrefix(title, "str-1_best_streamer/2026-04-10/") {
+		t.Fatalf("title = %q, want folder prefix", title)
 	}
 }

--- a/internal/media/scheduler.go
+++ b/internal/media/scheduler.go
@@ -178,6 +178,11 @@ func (s *Scheduler) runCycle(ctx context.Context, streamerID string) {
 	}
 	logger.Info("scheduler cycle triggered", zap.String("streamerID", streamerID), zap.Time("windowStart", windowStart), zap.String("windowKey", windowKey))
 	if err := s.processor.ProcessStreamer(ctx, streamerID); err != nil {
+		if errors.Is(err, ErrTrackingStop) {
+			logger.Info("scheduler stopping tracking after processor requested shutdown", zap.String("streamerID", streamerID))
+			s.Stop(streamerID)
+			return
+		}
 		logger.Error("scheduler cycle failed", zap.String("streamerID", streamerID), zap.Error(err))
 		return
 	}

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -19,6 +19,7 @@ import (
 var (
 	ErrStreamerIDRequired = errors.New("streamerID is required")
 	ErrStreamerBusy       = errors.New("streamer is already being processed")
+	ErrTrackingStop       = errors.New("stream tracking should stop")
 )
 
 type ChunkRef struct {
@@ -92,6 +93,10 @@ type Locker interface {
 
 type ChunkPublisher interface {
 	Publish(ctx context.Context, streamerID string, chunk ChunkRef) error
+}
+
+type ChunkFinalizer interface {
+	Finalize(ctx context.Context, streamerID string, capturedAt time.Time) error
 }
 
 type Worker struct {
@@ -193,9 +198,17 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 			return streamers.LLMDecision{}, nil
 		}
 		if errors.Is(err, ErrStreamlinkStreamEnded) {
+			if finalizer, ok := w.chunkPublisher.(ChunkFinalizer); ok {
+				if finalizeErr := finalizer.Finalize(ctx, id, time.Now().UTC()); finalizeErr != nil {
+					logger.Error("finalize stream video failed after stream end", zap.String("streamerID", id), zap.Error(finalizeErr))
+					w.metrics.recordFailure(ctx, id, "finalize_stream")
+					w.metrics.recordCycle(ctx, id, "failed")
+					return streamers.LLMDecision{}, finalizeErr
+				}
+			}
 			logger.Info("stream chunk capture skipped because stream has ended or is unavailable", zap.String("streamerID", id), zap.Error(err))
 			w.metrics.recordCycle(ctx, id, "stream_unavailable")
-			return streamers.LLMDecision{}, nil
+			return streamers.LLMDecision{}, ErrTrackingStop
 		}
 		logger.Error("stream chunk capture failed", zap.String("streamerID", id), zap.Error(err))
 		w.metrics.recordFailure(ctx, id, "capture")

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -471,8 +471,8 @@ func TestWorkerProcessStreamerSkipsEndedStreamWithoutFailingCycle(t *testing.T) 
 	worker := NewWorker(fakeCapture{err: ErrStreamlinkStreamEnded}, fakeClassifier{}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, runStore, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
 
 	got, err := worker.ProcessStreamer(context.Background(), "str-ended")
-	if err != nil {
-		t.Fatalf("ProcessStreamer() error = %v", err)
+	if !errors.Is(err, ErrTrackingStop) {
+		t.Fatalf("ProcessStreamer() error = %v, want %v", err, ErrTrackingStop)
 	}
 	if got != (streamers.LLMDecision{}) {
 		t.Fatalf("expected zero decision on ended stream, got %#v", got)


### PR DESCRIPTION
### Motivation

- Ensure captured stream segments are concatenated and uploaded when tracking stops (either on stream end or manual stop) and remove local artifacts afterwards.
- Include streamer username and capture day in the remote video path uploaded to Bunny to create organized folder structure.
- Propagate processor-requested tracking shutdown so the scheduler can stop cleanly when a worker signals the stream has ended.

### Description

- Added `Finalize` behavior to the Bunny chunk publisher and a `UsernameResolver` callback in `BunnyChunkPublisherConfig` to build a remote video path that includes streamer username and day via `buildRemoteVideoPath`.
- Updated `Publish` to only move segments into a per-stream `segments` directory and implemented `Finalize` to concat, create/upload the remote video, and clean up local segment files and directories.
- Exposed a `streamChunkFinalizer`/`ChunkFinalizer` interface and wired finalization into manual tracking stop in `cmd/server/main.go` and into `Worker.ProcessStreamer` when the stream ended; worker now returns `ErrTrackingStop` to signal scheduler shutdown.
- Updated `buildChunkPublisher` signature to accept `streamers.Service` and plumb the username resolver into the publisher configuration.
- Made the `Scheduler` stop tracking when the processor returns `ErrTrackingStop`.
- Added/updated unit tests in `internal/media` to assert finalize behavior, concat path usage, segment cleanup, and remote video title formatting with username.

### Testing

- Ran unit tests for the media package with `go test ./internal/media` and the updated tests `TestBunnyChunkPublisherUploadsOnlyOnFinalize`, `TestBunnyChunkPublisherConcatListUsesAbsolutePaths`, and `TestBunnyChunkPublisherCreateVideoTitleIncludesStreamerAndDayFolders`, all of which passed.
- Ran the worker unit test `TestWorkerProcessStreamerSkipsEndedStreamWithoutFailingCycle` to verify the worker returns `ErrTrackingStop`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e33c92f4832c92212ab484720c7d)