### PR TITLE
Fix vet/build failure: update buildChunkPublisher test calls and add agent hint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This repository contains the backend modular monolith for the FunPot Telegram Mi
 ## Testing & Quality
 - Prefer table-driven tests for Go packages.
 - Maintain linting via `golangci-lint`.
+- If you change a function signature, update all call sites in tests (especially in `cmd/server/main_test.go`) and run `go test ./...` to catch vet/build failures early.
 - Include load/performance test plans in `docs/load_testing.md` when behavior changes.
 
 ## PR Expectations

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -122,7 +122,7 @@ func TestStreamWorkerLockTTLIncludesBuffer(t *testing.T) {
 }
 
 func TestBuildChunkPublisherReturnsNilWhenBunnyNotConfigured(t *testing.T) {
-	if got := buildChunkPublisher(config.Config{}); got != nil {
+	if got := buildChunkPublisher(config.Config{}, nil); got != nil {
 		t.Fatal("expected nil publisher")
 	}
 }
@@ -138,7 +138,7 @@ func TestBuildChunkPublisherReturnsPublisherWhenConfigured(t *testing.T) {
 			BunnyAPIKey:    "api-key",
 		},
 	}
-	if got := buildChunkPublisher(cfg); got == nil {
+	if got := buildChunkPublisher(cfg, nil); got == nil {
 		t.Fatal("expected publisher")
 	}
 }


### PR DESCRIPTION
### Motivation
- Fix a `go vet`/build failure caused by the `buildChunkPublisher` signature change, and add a short preventive hint for agents so similar test-call-site mismatches are caught earlier.

### Description
- Update `cmd/server/main_test.go` to call `buildChunkPublisher(cfg, nil)` in the two affected tests so the call matches the new signature.
- Add a short note in `AGENTS.md` (Testing & Quality) advising to update test call sites after changing function signatures and to run `go test ./...` to catch vet/build issues early.

### Testing
- Ran `go test ./cmd/server -run TestBuildChunkPublisher` and `go test ./...`, and both succeeded (package tests passed).
- Checklist: [x] Fix vet/build failure in `cmd/server` by updating tests; [x] Add agent guidance to `AGENTS.md`; [ ] Align with `docs/implementation_plan.md` milestone M2.1; [ ] Verify alignment with `docs/llm_stream_orchestration_plan.md` (remaining documentation/tasks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e7eb460c832cbe71a6180988c36f)