### PR TITLE
Add admin LLM history timeline with pagination and cleanup

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -196,7 +196,8 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - When Streamlink reports that a Twitch URL has no playable streams (for example, the stream ended or is offline), the scheduler treats that cycle as a graceful skip instead of a hard worker failure and retries on the next 10-second window.
 - `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM match-session / state-tracker status for a streamer, including full chronological LLM call history (`history`) with request/response payloads per decision.
 - `DELETE /api/streamers/{streamerId}/tracking` – stops the active Streamlink/LLM tracking loop for a streamer and returns the updated `stopped` status so the client can disable the tracking button immediately.
-- Decision history REST endpoints were removed as part of scenario-graph v2 cleanup; `/api/streamers/{streamerId}/status` remains the supported read model.
+- `GET /api/admin/streamers/{streamerId}/llm-history?page=1&pageSize=20` – admin timeline endpoint with paginated LLM decision history (step name, LLM response, global state delta, event timestamps) plus uploaded Bunny video metadata for the streamer.
+- `DELETE /api/admin/streamers/{streamerId}/llm-history` – admin cleanup endpoint that deletes persisted LLM decision history and removes tracked Bunny videos for the streamer.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
 - `GET /api/admin/games` – admin-only endpoint listing all configured games.
 - `POST /api/admin/games` – admin-only endpoint creating a game definition.

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -18,6 +19,7 @@ import (
 	"github.com/funpot/funpot-go-core/internal/config"
 	"github.com/funpot/funpot-go-core/internal/events"
 	"github.com/funpot/funpot-go-core/internal/games"
+	"github.com/funpot/funpot-go-core/internal/media"
 	"github.com/funpot/funpot-go-core/internal/prompts"
 	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
@@ -152,6 +154,35 @@ type meResponse struct {
 	IsAdmin bool `json:"isAdmin"`
 }
 
+type adminHistoryEvent struct {
+	EventTime        string  `json:"eventTime"`
+	StepName         string  `json:"stepName"`
+	LLMResponse      string  `json:"llmResponse"`
+	GlobalStateDelta string  `json:"globalStateDelta,omitempty"`
+	Confidence       float64 `json:"confidence"`
+	streamers.LLMDecision
+}
+
+type adminStreamerLLMHistoryResponse struct {
+	StreamerID string                `json:"streamerId"`
+	Page       int                   `json:"page"`
+	PageSize   int                   `json:"pageSize"`
+	Total      int                   `json:"total"`
+	Items      []adminHistoryEvent   `json:"items"`
+	Videos     []media.UploadedVideo `json:"videos"`
+}
+
+type adminStreamerHistoryDeleteResponse struct {
+	StreamerID        string `json:"streamerId"`
+	DeletedDecisions  int    `json:"deletedDecisions"`
+	DeletedBunnyVideo int    `json:"deletedBunnyVideos"`
+}
+
+type adminStreamerVideoManager interface {
+	ListUploadedVideos(streamerID string) []media.UploadedVideo
+	DeleteStreamerVideos(ctx context.Context, streamerID string) (int, error)
+}
+
 // NewHandler wires the base HTTP routes for the service.
 func NewHandler(
 	logger *zap.Logger,
@@ -163,7 +194,7 @@ func NewHandler(
 	streamersService *streamers.Service,
 	gamesService *games.Service,
 	promptsService *prompts.Service,
-	_ any,
+	streamerVideoManager any,
 	eventsService *events.Service,
 	clientConfig ClientConfigResponse,
 ) http.Handler {
@@ -471,6 +502,74 @@ func NewHandler(
 					writeJSON(w, http.StatusOK, streamersService.GetLLMStatus(r.Context(), streamerID))
 				default:
 					writeError(w, http.StatusNotFound, "streamer route not found")
+				}
+			})))
+
+			videoManager, _ := streamerVideoManager.(adminStreamerVideoManager)
+			mux.Handle("/api/admin/streamers/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/admin/streamers/"), "/")
+				parts := strings.Split(path, "/")
+				if len(parts) != 2 || strings.TrimSpace(parts[1]) != "llm-history" {
+					writeError(w, http.StatusNotFound, "admin streamer route not found")
+					return
+				}
+				streamerID := strings.TrimSpace(parts[0])
+				if streamerID == "" {
+					writeError(w, http.StatusBadRequest, "streamer id is required")
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					page := parsePositiveIntDefault(r.URL.Query().Get("page"), 1)
+					pageSize := parsePositiveIntDefault(r.URL.Query().Get("pageSize"), 20)
+					items, total := streamersService.ListLLMDecisionsPage(r.Context(), streamerID, page, pageSize)
+					events := make([]adminHistoryEvent, 0, len(items))
+					for _, item := range items {
+						eventTime := firstNonEmpty(item.CreatedAt, item.ChunkCapturedAt)
+						events = append(events, adminHistoryEvent{
+							EventTime:        eventTime,
+							StepName:         item.Stage,
+							LLMResponse:      item.Label,
+							GlobalStateDelta: item.UpdatedStateJSON,
+							Confidence:       item.Confidence,
+							LLMDecision:      item,
+						})
+					}
+					videos := []media.UploadedVideo{}
+					if videoManager != nil {
+						videos = videoManager.ListUploadedVideos(streamerID)
+					}
+					writeJSON(w, http.StatusOK, adminStreamerLLMHistoryResponse{
+						StreamerID: streamerID,
+						Page:       page,
+						PageSize:   pageSize,
+						Total:      total,
+						Items:      events,
+						Videos:     videos,
+					})
+				case http.MethodDelete:
+					deletedDecisions := streamersService.ClearLLMHistory(r.Context(), streamerID)
+					deletedVideos := 0
+					if videoManager != nil {
+						count, err := videoManager.DeleteStreamerVideos(r.Context(), streamerID)
+						if err != nil {
+							logger.Error("failed to delete bunny videos for streamer history cleanup", zap.String("streamerID", streamerID), zap.Error(err))
+							writeError(w, http.StatusBadGateway, "failed to delete bunny videos")
+							return
+						}
+						deletedVideos = count
+					}
+					writeJSON(w, http.StatusOK, adminStreamerHistoryDeleteResponse{
+						StreamerID:        streamerID,
+						DeletedDecisions:  deletedDecisions,
+						DeletedBunnyVideo: deletedVideos,
+					})
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
 				}
 			})))
 		}
@@ -916,4 +1015,21 @@ func decodeJSONStrict(body []byte, out any) error {
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(out)
+}
+
+func parsePositiveIntDefault(raw string, fallback int) int {
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }

--- a/internal/app/router_admin_streamers_history_test.go
+++ b/internal/app/router_admin_streamers_history_test.go
@@ -1,0 +1,132 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/funpot/funpot-go-core/internal/admin"
+	"github.com/funpot/funpot-go-core/internal/media"
+	"github.com/funpot/funpot-go-core/internal/streamers"
+)
+
+type fakeAdminVideoManager struct {
+	videosByStreamer  map[string][]media.UploadedVideo
+	deletedByStreamer map[string]int
+}
+
+func (f *fakeAdminVideoManager) ListUploadedVideos(streamerID string) []media.UploadedVideo {
+	items := f.videosByStreamer[streamerID]
+	out := make([]media.UploadedVideo, len(items))
+	copy(out, items)
+	return out
+}
+
+func (f *fakeAdminVideoManager) DeleteStreamerVideos(_ context.Context, streamerID string) (int, error) {
+	count := len(f.videosByStreamer[streamerID])
+	f.deletedByStreamer[streamerID] = count
+	delete(f.videosByStreamer, streamerID)
+	return count, nil
+}
+
+func TestAdminStreamerHistoryGetWithPagination(t *testing.T) {
+	streamersService := streamers.NewService()
+	videoManager := &fakeAdminVideoManager{videosByStreamer: map[string][]media.UploadedVideo{
+		"str-1": {{ID: "video-1", URL: "https://video.bunnycdn.com/library/lib-1/videos/video-1", CreatedAt: "2026-01-01T00:00:00Z"}},
+	}, deletedByStreamer: map[string]int{}}
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamersService,
+		nil,
+		nil,
+		videoManager,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	for _, req := range []streamers.RecordDecisionRequest{
+		{RunID: "run-1", StreamerID: "str-1", Stage: "root_detect", Label: "cs_detected", Confidence: 0.9, UpdatedStateJSON: `{"state":{"game":"cs2"}}`},
+		{RunID: "run-1", StreamerID: "str-1", Stage: "mode_detect", Label: "competitive", Confidence: 0.8, UpdatedStateJSON: `{"state":{"mode":"competitive"}}`},
+		{RunID: "run-1", StreamerID: "str-1", Stage: "state_tracker", Label: "score_update", Confidence: 0.7, UpdatedStateJSON: `{"state":{"ct":10,"t":8}}`},
+	} {
+		if _, err := streamersService.RecordLLMDecision(context.Background(), req); err != nil {
+			t.Fatalf("RecordLLMDecision() error = %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/streamers/str-1/llm-history?page=2&pageSize=2", nil)
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if payload["total"] != float64(3) {
+		t.Fatalf("expected total=3 got %#v", payload["total"])
+	}
+	items, ok := payload["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("expected 1 item on second page, got %#v", payload["items"])
+	}
+	item, _ := items[0].(map[string]any)
+	if item["stepName"] != "state_tracker" {
+		t.Fatalf("expected state_tracker step, got %#v", item["stepName"])
+	}
+	videos, ok := payload["videos"].([]any)
+	if !ok || len(videos) != 1 {
+		t.Fatalf("expected one uploaded video, got %#v", payload["videos"])
+	}
+}
+
+func TestAdminStreamerHistoryDeleteRemovesDecisionsAndVideos(t *testing.T) {
+	streamersService := streamers.NewService()
+	videoManager := &fakeAdminVideoManager{videosByStreamer: map[string][]media.UploadedVideo{
+		"str-1": {{ID: "video-1"}, {ID: "video-2"}},
+	}, deletedByStreamer: map[string]int{}}
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		nil,
+		streamersService,
+		nil,
+		nil,
+		videoManager,
+		nil,
+		ClientConfigResponse{},
+	)
+	if _, err := streamersService.RecordLLMDecision(context.Background(), streamers.RecordDecisionRequest{RunID: "run", StreamerID: "str-1", Stage: "root", Label: "ok", Confidence: 0.9}); err != nil {
+		t.Fatalf("RecordLLMDecision() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/admin/streamers/str-1/llm-history", nil)
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+
+	if got := len(streamersService.ListAllLLMDecisions(context.Background(), "str-1")); got != 0 {
+		t.Fatalf("expected cleared history, got %d decisions", got)
+	}
+	if got := videoManager.deletedByStreamer["str-1"]; got != 2 {
+		t.Fatalf("expected 2 deleted videos, got %d", got)
+	}
+}

--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -33,8 +34,17 @@ type BunnyChunkPublisherConfig struct {
 }
 
 type BunnyChunkPublisher struct {
-	cfg    BunnyChunkPublisherConfig
-	client *http.Client
+	cfg              BunnyChunkPublisherConfig
+	client           *http.Client
+	uploadedMu       sync.RWMutex
+	uploadedByStream map[string][]UploadedVideo
+}
+
+type UploadedVideo struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	URL       string `json:"url"`
+	CreatedAt string `json:"createdAt"`
 }
 
 func NewBunnyChunkPublisher(cfg BunnyChunkPublisherConfig) *BunnyChunkPublisher {
@@ -56,7 +66,11 @@ func NewBunnyChunkPublisher(cfg BunnyChunkPublisherConfig) *BunnyChunkPublisher 
 	if cfg.HTTPTimeout <= 0 {
 		cfg.HTTPTimeout = 2 * time.Minute
 	}
-	return &BunnyChunkPublisher{cfg: cfg, client: &http.Client{Timeout: cfg.HTTPTimeout}}
+	return &BunnyChunkPublisher{
+		cfg:              cfg,
+		client:           &http.Client{Timeout: cfg.HTTPTimeout},
+		uploadedByStream: make(map[string][]UploadedVideo),
+	}
 }
 
 func (p *BunnyChunkPublisher) Publish(ctx context.Context, streamerID string, chunk ChunkRef) error {
@@ -111,13 +125,19 @@ func (p *BunnyChunkPublisher) Finalize(ctx context.Context, streamerID string, c
 	}
 	defer os.Remove(windowPath) //nolint:errcheck
 
-	videoID, err := p.createVideo(ctx, streamerID, capturedAt)
+	videoID, title, err := p.createVideo(ctx, streamerID, capturedAt)
 	if err != nil {
 		return err
 	}
 	if err := p.uploadVideo(ctx, videoID, windowPath); err != nil {
 		return err
 	}
+	p.appendUploadedVideo(streamerID, UploadedVideo{
+		ID:        videoID,
+		Title:     title,
+		URL:       strings.TrimRight(p.cfg.BaseURL, "/") + "/library/" + p.cfg.LibraryID + "/videos/" + videoID,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	})
 	for _, segment := range segments {
 		_ = os.Remove(segment)
 	}
@@ -256,37 +276,104 @@ type bunnyCreateVideoResponse struct {
 	GUID string `json:"guid"`
 }
 
-func (p *BunnyChunkPublisher) createVideo(ctx context.Context, streamerID string, capturedAt time.Time) (string, error) {
+func (p *BunnyChunkPublisher) createVideo(ctx context.Context, streamerID string, capturedAt time.Time) (string, string, error) {
 	title := p.buildRemoteVideoPath(ctx, streamerID, capturedAt)
 	payload, err := json.Marshal(bunnyCreateVideoRequest{Title: title})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	endpoint := strings.TrimRight(p.cfg.BaseURL, "/") + "/library/" + p.cfg.LibraryID + "/videos"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	req.Header.Set("AccessKey", p.cfg.APIKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := p.client.Do(req)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-		return "", fmt.Errorf("create bunny video failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(msg)))
+		return "", "", fmt.Errorf("create bunny video failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(msg)))
 	}
 	var decoded bunnyCreateVideoResponse
 	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
-		return "", err
+		return "", "", err
 	}
 	if strings.TrimSpace(decoded.GUID) == "" {
-		return "", fmt.Errorf("create bunny video: empty guid")
+		return "", "", fmt.Errorf("create bunny video: empty guid")
 	}
-	return decoded.GUID, nil
+	return decoded.GUID, title, nil
+}
+
+func (p *BunnyChunkPublisher) ListUploadedVideos(streamerID string) []UploadedVideo {
+	if p == nil {
+		return []UploadedVideo{}
+	}
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return []UploadedVideo{}
+	}
+	p.uploadedMu.RLock()
+	defer p.uploadedMu.RUnlock()
+	items := p.uploadedByStream[key]
+	out := make([]UploadedVideo, len(items))
+	copy(out, items)
+	return out
+}
+
+func (p *BunnyChunkPublisher) DeleteStreamerVideos(ctx context.Context, streamerID string) (int, error) {
+	if p == nil {
+		return 0, nil
+	}
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return 0, nil
+	}
+	items := p.ListUploadedVideos(key)
+	deleted := 0
+	for _, item := range items {
+		if err := p.deleteVideo(ctx, item.ID); err != nil {
+			return deleted, err
+		}
+		deleted++
+	}
+	p.uploadedMu.Lock()
+	delete(p.uploadedByStream, key)
+	p.uploadedMu.Unlock()
+	return deleted, nil
+}
+
+func (p *BunnyChunkPublisher) appendUploadedVideo(streamerID string, item UploadedVideo) {
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return
+	}
+	p.uploadedMu.Lock()
+	p.uploadedByStream[key] = append(p.uploadedByStream[key], item)
+	p.uploadedMu.Unlock()
+}
+
+func (p *BunnyChunkPublisher) deleteVideo(ctx context.Context, videoID string) error {
+	endpoint := strings.TrimRight(p.cfg.BaseURL, "/") + "/library/" + p.cfg.LibraryID + "/videos/" + videoID
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("AccessKey", p.cfg.APIKey)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("delete bunny video failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(msg)))
+	}
+	return nil
 }
 
 func (p *BunnyChunkPublisher) uploadVideo(ctx context.Context, videoID, videoPath string) error {

--- a/internal/streamers/memory_repository.go
+++ b/internal/streamers/memory_repository.go
@@ -64,3 +64,15 @@ func (r *InMemoryDecisionRepository) ListAllLLMDecisions(_ context.Context, stre
 	copy(out, items)
 	return out, nil
 }
+
+func (r *InMemoryDecisionRepository) DeleteAllLLMDecisions(_ context.Context, streamerID string) (int, error) {
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return 0, nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := len(r.items[key])
+	delete(r.items, key)
+	return count, nil
+}

--- a/internal/streamers/repository.go
+++ b/internal/streamers/repository.go
@@ -7,4 +7,5 @@ type DecisionRepository interface {
 	RecordLLMDecision(ctx context.Context, item LLMDecision) error
 	ListLLMDecisions(ctx context.Context, streamerID string, limit int) ([]LLMDecision, error)
 	ListAllLLMDecisions(ctx context.Context, streamerID string) ([]LLMDecision, error)
+	DeleteAllLLMDecisions(ctx context.Context, streamerID string) (int, error)
 }

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -385,6 +385,39 @@ func (s *Service) ListAllLLMDecisions(ctx context.Context, streamerID string) []
 	return items
 }
 
+func (s *Service) ListLLMDecisionsPage(ctx context.Context, streamerID string, page, pageSize int) ([]LLMDecision, int) {
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return []LLMDecision{}, 0
+	}
+	if page < 1 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+
+	items := s.ListAllLLMDecisions(ctx, key)
+	total := len(items)
+	if total == 0 {
+		return []LLMDecision{}, 0
+	}
+	start := (page - 1) * pageSize
+	if start >= total {
+		return []LLMDecision{}, total
+	}
+	end := start + pageSize
+	if end > total {
+		end = total
+	}
+	out := make([]LLMDecision, end-start)
+	copy(out, items[start:end])
+	return out, total
+}
+
 func (s *Service) ListLLMDecisions(ctx context.Context, streamerID string, limit int) []LLMDecision {
 	key := strings.TrimSpace(streamerID)
 	if key == "" {
@@ -409,6 +442,27 @@ func (s *Service) ListLLMDecisions(ctx context.Context, streamerID string, limit
 		return []LLMDecision{}
 	}
 	return items
+}
+
+func (s *Service) ClearLLMHistory(ctx context.Context, streamerID string) int {
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return 0
+	}
+	s.mu.RLock()
+	repo := s.decisionRepo
+	s.mu.RUnlock()
+	if repo == nil {
+		return 0
+	}
+	deleted, err := repo.DeleteAllLLMDecisions(ctx, key)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("failed to clear llm history", zap.String("streamerID", key), zap.Error(err))
+		}
+		return 0
+	}
+	return deleted
 }
 
 func (s *Service) GetLLMStatus(ctx context.Context, streamerID string) LLMStatus {


### PR DESCRIPTION
### Motivation
- Provide admin visibility into chronological LLM decisions (step, LLM response, state deltas) with clear event timestamps and associated Bunny video metadata to aid debugging and tuning. 
- Allow admins to purge long histories and remove associated Bunny-hosted videos to reclaim storage and reset analysis for a streamer. 
- Support long histories via simple page-based pagination to avoid excessively large responses.

### Description
- Added admin endpoints `GET /api/admin/streamers/{streamerId}/llm-history?page={n}&pageSize={m}` and `DELETE /api/admin/streamers/{streamerId}/llm-history` implemented in `internal/app/router.go` with admin-only checks and timeline-oriented response models (`adminHistoryEvent`, `adminStreamerLLMHistoryResponse`, `adminStreamerHistoryDeleteResponse`).
- Extended the streamer persistence/service APIs: added `DeleteAllLLMDecisions` to `DecisionRepository`, implemented `DeleteAllLLMDecisions` in the in-memory repo, added `ListLLMDecisionsPage` and `ClearLLMHistory` on `streamers.Service` to support paged listing and purge. (`internal/streamers/repository.go`, `internal/streamers/memory_repository.go`, `internal/streamers/service.go`).
- Extended Bunny publisher tracking in `internal/media/publisher.go` to record uploaded videos per-streamer (`UploadedVideo`), expose `ListUploadedVideos` and `DeleteStreamerVideos`, append uploaded metadata on `Finalize`, and perform HTTP `DELETE` to Bunny when removing videos.
- Added router-level wiring to optionally call the video manager for listing/deletion (accepts an `adminStreamerVideoManager` in `NewHandler`), and updated local docs `docs/local_setup.md` to document the new admin endpoints.
- Added unit tests `internal/app/router_admin_streamers_history_test.go` that verify paginated GET behavior and the DELETE cleanup flow (decisions cleared and Bunny videos deleted).

### Testing
- Ran formatter and tidy: `gofmt -w` on modified Go files (applied to `.go` files only) to ensure formatting was applied successfully.
- Ran focused unit tests: `go test ./internal/app ./internal/streamers ./internal/media` — all tests passed.
- Ran full test suite: `go test ./...` — all packages passed.
- Status checklist aligned to implementation plan: [x] admin timeline endpoint added; [x] admin cleanup endpoint added; [x] service/repository and Bunny publisher changes implemented; [x] router tests added; [ ] OpenAPI (`docs/openapi.yaml`) update for the new admin endpoints (follow-up).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f0fc4d64832cafdadb476266bf28)