### PR TITLE
Add admin endpoints and schemas for streamer LLM history and cleanup

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -290,6 +290,57 @@ paths:
           description: Game deleted
         default:
           $ref: '#/components/responses/Error'
+  /api/admin/streamers/{streamerId}/llm-history:
+    get:
+      summary: Get streamer LLM history (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: streamerId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            minimum: 1
+            default: 20
+      responses:
+        '200':
+          description: Paginated streamer LLM history with uploaded videos
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminStreamerLLMHistoryResponse'
+        default:
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Clear streamer LLM history (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: streamerId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Streamer history and uploaded videos cleanup result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminStreamerHistoryDeleteResponse'
+        default:
+          $ref: '#/components/responses/Error'
   /api/admin/llm/model-configs:
     get:
       summary: List LLM model configs (admin)
@@ -1130,6 +1181,65 @@ components:
         createdAt:
           type: string
           format: date-time
+    UploadedVideo:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        url:
+          type: string
+          format: uri
+        createdAt:
+          type: string
+          format: date-time
+    AdminHistoryEvent:
+      allOf:
+        - $ref: '#/components/schemas/LLMDecision'
+        - type: object
+          properties:
+            eventTime:
+              type: string
+              format: date-time
+            stepName:
+              type: string
+            llmResponse:
+              type: string
+            globalStateDelta:
+              type: string
+            confidence:
+              type: number
+    AdminStreamerLLMHistoryResponse:
+      type: object
+      required: [streamerId, page, pageSize, total, items, videos]
+      properties:
+        streamerId:
+          type: string
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        total:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminHistoryEvent'
+        videos:
+          type: array
+          items:
+            $ref: '#/components/schemas/UploadedVideo'
+    AdminStreamerHistoryDeleteResponse:
+      type: object
+      required: [streamerId, deletedDecisions, deletedBunnyVideos]
+      properties:
+        streamerId:
+          type: string
+        deletedDecisions:
+          type: integer
+        deletedBunnyVideos:
+          type: integer
     GameUpsertRequest:
       type: object
       required: [slug, title, status]


### PR DESCRIPTION
### Motivation
- Provide admin APIs to inspect and clear a streamer's LLM decision history and related uploaded videos for operational/debugging and privacy maintenance.

### Description
- Added new admin endpoints `GET` and `DELETE` at `/api/admin/streamers/{streamerId}/llm-history` with `bearerAuth` and pagination query parameters `page` and `pageSize`.
- Introduced new schemas `UploadedVideo`, `AdminHistoryEvent`, `AdminStreamerLLMHistoryResponse`, and `AdminStreamerHistoryDeleteResponse`, and wired them into the endpoint responses.
- Updated OpenAPI responses so `GET` returns a paginated `AdminStreamerLLMHistoryResponse` and `DELETE` returns `AdminStreamerHistoryDeleteResponse`, with error references preserved.

### Testing
- Validated the updated OpenAPI spec using `spectral` and the linter passed without errors.
- Executed the repository test suite with `npm test` and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f4fd75e4832c8c2e45155aef5f71)