### PR TITLE
Fix continuous stream capture no-data timeout

### DIFF
--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -43,6 +43,7 @@ var streamlinkEndedMarkers = []string{
 const defaultPreferredStreamQuality = "1080p60,1080p,720p60,720p,936p60,936p,648p60,648p,480p,best"
 const minimumStreamlinkCaptureTimeout = 30 * time.Second
 const streamlinkCaptureShutdownGracePeriod = 5 * time.Second
+const continuousSegmentStabilityWindow = 1500 * time.Millisecond
 
 type StreamlinkChannelResolver interface {
 	ResolveStreamlinkChannel(ctx context.Context, streamerID string) (string, error)
@@ -314,6 +315,8 @@ func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, stream
 
 	targetIndex := session.nextIndex
 	deadline := time.Now().Add(a.cfg.CaptureTimeout + streamlinkCaptureShutdownGracePeriod)
+	lastObservedSize := int64(-1)
+	var lastSizeChangedAt time.Time
 	for {
 		select {
 		case <-ctx.Done():
@@ -325,6 +328,15 @@ func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, stream
 		nextSegmentPath := filepath.Join(session.segmentsDir, fmt.Sprintf("%09d.mp4", targetIndex+1))
 		nextInfo, nextErr := os.Stat(nextSegmentPath)
 		segmentFinalized := nextErr == nil && nextInfo.Size() > 0
+		if statErr == nil && info.Size() > 0 {
+			if info.Size() != lastObservedSize {
+				lastObservedSize = info.Size()
+				lastSizeChangedAt = time.Now()
+			}
+			if !segmentFinalized && !lastSizeChangedAt.IsZero() && time.Since(lastSizeChangedAt) >= continuousSegmentStabilityWindow {
+				segmentFinalized = true
+			}
+		}
 		if statErr == nil && info.Size() > 0 && segmentFinalized {
 			chunkPath := filepath.Join(filepath.Dir(session.segmentsDir), fmt.Sprintf("%s.mp4", sanitizeToken(fmt.Sprintf("%09d", targetIndex))))
 			if err := os.Rename(segmentPath, chunkPath); err != nil {
@@ -332,6 +344,10 @@ func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, stream
 			}
 			session.nextIndex++
 			return ChunkRef{Reference: chunkPath, CapturedAt: a.nowFn().UTC()}, nil
+		}
+		if statErr != nil {
+			lastObservedSize = -1
+			lastSizeChangedAt = time.Time{}
 		}
 		if time.Now().After(deadline) {
 			return ChunkRef{}, fmt.Errorf("%w: no continuous segment available before deadline", ErrStreamlinkNoData)

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -328,3 +328,46 @@ func TestNormalizeStreamlinkQualityPrefers1080p(t *testing.T) {
 		t.Fatalf("normalizeStreamlinkQuality(custom) = %q, want 480p", got)
 	}
 }
+
+func TestStreamlinkCaptureAdapterContinuousAcceptsStableSegmentWithoutNextChunk(t *testing.T) {
+	outDir := t.TempDir()
+	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
+		OutputDir: outDir,
+	}, nil, nil)
+	adapter.cfg.CaptureTimeout = 2 * time.Second
+
+	segmentsDir := filepath.Join(outDir, "str_live", "live_segments")
+	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	segmentPath := filepath.Join(segmentsDir, "000000001.mp4")
+	if err := os.WriteFile(segmentPath, []byte("segment-bytes"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	past := time.Now().Add(-3 * time.Second)
+	if err := os.Chtimes(segmentPath, past, past); err != nil {
+		t.Fatalf("Chtimes() error = %v", err)
+	}
+
+	adapter.sessions["str_live"] = &continuousCaptureSession{
+		streamerID:  "str_live",
+		channel:     "live_channel",
+		segmentsDir: segmentsDir,
+		nextIndex:   1,
+		started:     true,
+	}
+
+	chunk, err := adapter.captureContinuous(context.Background(), "str_live")
+	if err != nil {
+		t.Fatalf("captureContinuous() error = %v", err)
+	}
+	if chunk.Reference == "" {
+		t.Fatal("expected chunk reference")
+	}
+	if filepath.Base(chunk.Reference) != "000000001.mp4" {
+		t.Fatalf("chunk path = %q, want renamed stable segment", chunk.Reference)
+	}
+	if _, err := os.Stat(segmentPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected source segment to be moved, err=%v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Production cycles showed `streamlink capture produced no data: no continuous segment available before deadline` when a live stream had a current segment but the next segment had not yet been created.  
- The continuous capture loop treated a missing next segment as lack of data and timed out, causing scheduler failures and dropped capture attempts.

### Description
- Add `continuousSegmentStabilityWindow` (1500ms) and logic in `captureContinuous` to treat a segment as final if its size has been stable for the window, even when the next segment file is not yet present.  
- Track `lastObservedSize` and `lastSizeChangedAt` per capture attempt and use these to decide a stability-based finalize fallback; reset tracking when the segment disappears.  
- Keep the existing fast path (next segment exists) unchanged and add a regression test `TestStreamlinkCaptureAdapterContinuousAcceptsStableSegmentWithoutNextChunk` covering the stable-segment-without-next-file case.  
- Checklist (aligned with implementation plan milestones):  
  - [x] Fix runtime failure in media capture path affecting scheduler reliability (M2.1).  
  - [x] Add regression test for the edge case where a stable segment exists without a next segment.  
  - [ ] Add operational metrics to differentiate finalize reasons (`next_segment` vs `size_stable`).  
  - [ ] Validate scheduler interval vs capture timeout under staging load and update `docs/load_testing.md` if required.

### Testing
- Ran `go test ./internal/media/...` and it passed.  
- Ran `go test ./...` and the full test suite passed for affected packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fd1f91e0832c81de600e9aa98bdb)