### PR TITLE
Persist Bunny uploaded video metadata to Postgres and wire store into chunk publisher

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -118,7 +118,7 @@ func main() {
 		configurableCapture.SetLogger(logger.Named("stream_capture"))
 	}
 
-	chunkPublisher := buildChunkPublisher(cfg, streamersService)
+	chunkPublisher := buildChunkPublisher(cfg, db, streamersService)
 	streamWorker := media.NewWorker(
 		streamCapture,
 		buildStageClassifier(logger, cfg),
@@ -199,7 +199,7 @@ func main() {
 		streamersService,
 		gamesService,
 		promptsService,
-		nil,
+		chunkPublisher,
 		eventsService,
 		app.ConfigResponseFromConfig(cfg),
 	)
@@ -262,9 +262,13 @@ func streamWorkerLockTTL(cfg config.Config) time.Duration {
 	return interval + 5*time.Second
 }
 
-func buildChunkPublisher(cfg config.Config, streamersService *streamers.Service) media.ChunkPublisher {
+func buildChunkPublisher(cfg config.Config, db *sql.DB, streamersService *streamers.Service) media.ChunkPublisher {
 	if cfg.Streamlink.BunnyLibraryID == "" || cfg.Streamlink.BunnyAPIKey == "" {
 		return nil
+	}
+	var videoStore media.UploadedVideoStore
+	if db != nil {
+		videoStore = media.NewPostgresUploadedVideoStore(db)
 	}
 	return media.NewBunnyChunkPublisher(media.BunnyChunkPublisherConfig{
 		OutputDir:      cfg.Streamlink.OutputDir,
@@ -279,6 +283,7 @@ func buildChunkPublisher(cfg config.Config, streamersService *streamers.Service)
 			}
 			return streamersService.ResolveStreamlinkChannel(ctx, streamerID)
 		},
+		VideoStore: videoStore,
 	})
 }
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -122,7 +122,7 @@ func TestStreamWorkerLockTTLIncludesBuffer(t *testing.T) {
 }
 
 func TestBuildChunkPublisherReturnsNilWhenBunnyNotConfigured(t *testing.T) {
-	if got := buildChunkPublisher(config.Config{}, nil); got != nil {
+	if got := buildChunkPublisher(config.Config{}, nil, nil); got != nil {
 		t.Fatal("expected nil publisher")
 	}
 }
@@ -138,7 +138,7 @@ func TestBuildChunkPublisherReturnsPublisherWhenConfigured(t *testing.T) {
 			BunnyAPIKey:    "api-key",
 		},
 	}
-	if got := buildChunkPublisher(cfg, nil); got == nil {
+	if got := buildChunkPublisher(cfg, nil, nil); got == nil {
 		t.Fatal("expected publisher")
 	}
 }

--- a/docs/migrations_plan.md
+++ b/docs/migrations_plan.md
@@ -14,7 +14,9 @@
 > `migrations/0008_llm_model_configs_and_scenario_binding.up.sql`, and
 > `migrations/0008_llm_model_configs_and_scenario_binding.down.sql`,
 > `migrations/0009_remove_legacy_tracker_response_fields.up.sql`, and
-> `migrations/0009_remove_legacy_tracker_response_fields.down.sql`.
+> `migrations/0009_remove_legacy_tracker_response_fields.down.sql`,
+> `migrations/0010_streamer_uploaded_videos.up.sql`, and
+> `migrations/0010_streamer_uploaded_videos.down.sql`.
 >
 > Legacy duplicate-version migration files were removed so `golang-migrate`
 > sees a single `*.up.sql` and `*.down.sql` pair per version.

--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -31,6 +31,7 @@ type BunnyChunkPublisherConfig struct {
 	APIKey           string
 	HTTPTimeout      time.Duration
 	UsernameResolver func(ctx context.Context, streamerID string) (string, error)
+	VideoStore       UploadedVideoStore
 }
 
 type BunnyChunkPublisher struct {
@@ -132,7 +133,7 @@ func (p *BunnyChunkPublisher) Finalize(ctx context.Context, streamerID string, c
 	if err := p.uploadVideo(ctx, videoID, windowPath); err != nil {
 		return err
 	}
-	p.appendUploadedVideo(streamerID, UploadedVideo{
+	p.appendUploadedVideo(ctx, streamerID, UploadedVideo{
 		ID:        videoID,
 		Title:     title,
 		URL:       strings.TrimRight(p.cfg.BaseURL, "/") + "/library/" + p.cfg.LibraryID + "/videos/" + videoID,
@@ -317,6 +318,12 @@ func (p *BunnyChunkPublisher) ListUploadedVideos(streamerID string) []UploadedVi
 	if key == "" {
 		return []UploadedVideo{}
 	}
+	if p.cfg.VideoStore != nil {
+		items, err := p.cfg.VideoStore.ListByStreamer(context.Background(), key)
+		if err == nil {
+			return items
+		}
+	}
 	p.uploadedMu.RLock()
 	defer p.uploadedMu.RUnlock()
 	items := p.uploadedByStream[key]
@@ -341,16 +348,27 @@ func (p *BunnyChunkPublisher) DeleteStreamerVideos(ctx context.Context, streamer
 		}
 		deleted++
 	}
+	if p.cfg.VideoStore != nil {
+		if err := p.cfg.VideoStore.DeleteByStreamer(ctx, key); err != nil {
+			return deleted, err
+		}
+		return deleted, nil
+	}
 	p.uploadedMu.Lock()
 	delete(p.uploadedByStream, key)
 	p.uploadedMu.Unlock()
 	return deleted, nil
 }
 
-func (p *BunnyChunkPublisher) appendUploadedVideo(streamerID string, item UploadedVideo) {
+func (p *BunnyChunkPublisher) appendUploadedVideo(ctx context.Context, streamerID string, item UploadedVideo) {
 	key := strings.TrimSpace(streamerID)
 	if key == "" {
 		return
+	}
+	if p.cfg.VideoStore != nil {
+		if err := p.cfg.VideoStore.Save(ctx, key, item); err == nil {
+			return
+		}
 	}
 	p.uploadedMu.Lock()
 	p.uploadedByStream[key] = append(p.uploadedByStream[key], item)

--- a/internal/media/video_store.go
+++ b/internal/media/video_store.go
@@ -1,0 +1,10 @@
+package media
+
+import "context"
+
+// UploadedVideoStore persists uploaded video metadata for admin history endpoints.
+type UploadedVideoStore interface {
+	Save(ctx context.Context, streamerID string, item UploadedVideo) error
+	ListByStreamer(ctx context.Context, streamerID string) ([]UploadedVideo, error)
+	DeleteByStreamer(ctx context.Context, streamerID string) error
+}

--- a/internal/media/video_store_postgres.go
+++ b/internal/media/video_store_postgres.go
@@ -1,0 +1,86 @@
+package media
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// PostgresUploadedVideoStore stores uploaded Bunny video metadata in PostgreSQL.
+type PostgresUploadedVideoStore struct {
+	db *sql.DB
+}
+
+func NewPostgresUploadedVideoStore(db *sql.DB) *PostgresUploadedVideoStore {
+	return &PostgresUploadedVideoStore{db: db}
+}
+
+func (s *PostgresUploadedVideoStore) Save(ctx context.Context, streamerID string, item UploadedVideo) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return nil
+	}
+	const query = `
+INSERT INTO streamer_uploaded_videos (streamer_id, video_id, title, url, created_at)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (streamer_id, video_id)
+DO UPDATE SET title = EXCLUDED.title,
+              url = EXCLUDED.url,
+              created_at = EXCLUDED.created_at`
+	if _, err := s.db.ExecContext(ctx, query, key, strings.TrimSpace(item.ID), strings.TrimSpace(item.Title), strings.TrimSpace(item.URL), strings.TrimSpace(item.CreatedAt)); err != nil {
+		return fmt.Errorf("save uploaded video metadata: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresUploadedVideoStore) ListByStreamer(ctx context.Context, streamerID string) ([]UploadedVideo, error) {
+	if s == nil || s.db == nil {
+		return []UploadedVideo{}, nil
+	}
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return []UploadedVideo{}, nil
+	}
+	const query = `
+SELECT video_id, title, url, created_at
+FROM streamer_uploaded_videos
+WHERE streamer_id = $1
+ORDER BY created_at DESC, video_id DESC`
+	rows, err := s.db.QueryContext(ctx, query, key)
+	if err != nil {
+		return nil, fmt.Errorf("list uploaded videos by streamer: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	items := make([]UploadedVideo, 0)
+	for rows.Next() {
+		var item UploadedVideo
+		if err := rows.Scan(&item.ID, &item.Title, &item.URL, &item.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan uploaded video metadata: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate uploaded video metadata: %w", err)
+	}
+	return items, nil
+}
+
+func (s *PostgresUploadedVideoStore) DeleteByStreamer(ctx context.Context, streamerID string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	key := strings.TrimSpace(streamerID)
+	if key == "" {
+		return nil
+	}
+	const query = `DELETE FROM streamer_uploaded_videos WHERE streamer_id = $1`
+	if _, err := s.db.ExecContext(ctx, query, key); err != nil {
+		return fmt.Errorf("delete uploaded videos by streamer: %w", err)
+	}
+	return nil
+}

--- a/internal/media/video_store_postgres_test.go
+++ b/internal/media/video_store_postgres_test.go
@@ -1,0 +1,76 @@
+package media
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPostgresUploadedVideoStoreSave(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresUploadedVideoStore(db)
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO streamer_uploaded_videos")).
+		WithArgs("str-1", "vid-1", "title", "https://video", "2026-01-01T00:00:00Z").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = store.Save(context.Background(), "str-1", UploadedVideo{ID: "vid-1", Title: "title", URL: "https://video", CreatedAt: "2026-01-01T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestPostgresUploadedVideoStoreListByStreamer(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresUploadedVideoStore(db)
+	rows := sqlmock.NewRows([]string{"video_id", "title", "url", "created_at"}).
+		AddRow("vid-2", "title-2", "https://video/2", "2026-01-02T00:00:00Z").
+		AddRow("vid-1", "title-1", "https://video/1", "2026-01-01T00:00:00Z")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT video_id, title, url, created_at")).WithArgs("str-1").WillReturnRows(rows)
+
+	items, err := store.ListByStreamer(context.Background(), "str-1")
+	if err != nil {
+		t.Fatalf("ListByStreamer error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("len(items)=%d, want 2", len(items))
+	}
+	if items[0].ID != "vid-2" || items[1].ID != "vid-1" {
+		t.Fatalf("unexpected items order: %#v", items)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestPostgresUploadedVideoStoreDeleteByStreamer(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresUploadedVideoStore(db)
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM streamer_uploaded_videos WHERE streamer_id = $1")).WithArgs("str-1").WillReturnResult(sqlmock.NewResult(0, 2))
+
+	if err := store.DeleteByStreamer(context.Background(), "str-1"); err != nil {
+		t.Fatalf("DeleteByStreamer error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/migrations/0010_streamer_uploaded_videos.down.sql
+++ b/migrations/0010_streamer_uploaded_videos.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_streamer_uploaded_videos_streamer_created_at;
+DROP TABLE IF EXISTS streamer_uploaded_videos;

--- a/migrations/0010_streamer_uploaded_videos.up.sql
+++ b/migrations/0010_streamer_uploaded_videos.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS streamer_uploaded_videos (
+    streamer_id TEXT NOT NULL,
+    video_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    url TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (streamer_id, video_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_streamer_uploaded_videos_streamer_created_at
+    ON streamer_uploaded_videos (streamer_id, created_at DESC, video_id DESC);


### PR DESCRIPTION
### Motivation

- Persist uploaded Bunny video metadata so admin/history endpoints can serve reliable records beyond in-memory state.
- Ensure uploaded video lifecycle (list, delete, save) works with a durable store when a Postgres `db` is available.

### Description

- Add `UploadedVideoStore` interface and a `PostgresUploadedVideoStore` implementation with `Save`, `ListByStreamer`, and `DeleteByStreamer` in `internal/media`.
- Extend `BunnyChunkPublisherConfig` to accept a `VideoStore` and update `BunnyChunkPublisher` to use the store for `ListUploadedVideos`, `DeleteStreamerVideos`, and when appending uploaded videos.
- Wire the Postgres store into the publisher by changing `buildChunkPublisher` to accept a `*sql.DB` and construct `NewPostgresUploadedVideoStore(db)` when `db` is present; update `main` to pass `db` to `buildChunkPublisher`.
- Add SQL migration files `migrations/0010_streamer_uploaded_videos.up.sql` and `.down.sql` and update `docs/migrations_plan.md` to include the new migration.
- Update unit tests and signatures in `cmd/server/main_test.go` and add `internal/media/video_store_postgres_test.go` tests validating `Save`, `ListByStreamer`, and `DeleteByStreamer` behavior using `sqlmock`.

### Testing

- Ran the new unit tests in `internal/media/video_store_postgres_test.go` (`TestPostgresUploadedVideoStoreSave`, `TestPostgresUploadedVideoStoreListByStreamer`, `TestPostgresUploadedVideoStoreDeleteByStreamer`) and they passed. 
- Ran updated `cmd/server` tests (including `TestBuildChunkPublisherReturnsNilWhenBunnyNotConfigured` and `TestBuildChunkPublisherReturnsPublisherWhenConfigured`) and they passed.
- Ran `go test ./...` across the codebase and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fcf73b2c832c8c19d3ef896ddadd)