### PR TITLE
Finalize stable continuous segments by copying and require mod-time stability near deadline

### DIFF
--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -328,19 +328,30 @@ func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, stream
 		nextSegmentPath := filepath.Join(session.segmentsDir, fmt.Sprintf("%09d.mp4", targetIndex+1))
 		nextInfo, nextErr := os.Stat(nextSegmentPath)
 		segmentFinalized := nextErr == nil && nextInfo.Size() > 0
+		finalizedByStability := false
 		if statErr == nil && info.Size() > 0 {
 			if info.Size() != lastObservedSize {
 				lastObservedSize = info.Size()
 				lastSizeChangedAt = time.Now()
 			}
-			if !segmentFinalized && !lastSizeChangedAt.IsZero() && time.Since(lastSizeChangedAt) >= continuousSegmentStabilityWindow {
+			stableByObservedSize := !lastSizeChangedAt.IsZero() && time.Since(lastSizeChangedAt) >= continuousSegmentStabilityWindow
+			stableByModTime := time.Since(info.ModTime()) >= continuousSegmentStabilityWindow
+			nearDeadline := time.Until(deadline) <= continuousSegmentStabilityWindow
+			if !segmentFinalized && stableByObservedSize && stableByModTime && nearDeadline {
 				segmentFinalized = true
+				finalizedByStability = true
 			}
 		}
 		if statErr == nil && info.Size() > 0 && segmentFinalized {
 			chunkPath := filepath.Join(filepath.Dir(session.segmentsDir), fmt.Sprintf("%s.mp4", sanitizeToken(fmt.Sprintf("%09d", targetIndex))))
-			if err := os.Rename(segmentPath, chunkPath); err != nil {
-				return ChunkRef{}, err
+			if finalizedByStability {
+				if err := copyFile(segmentPath, chunkPath); err != nil {
+					return ChunkRef{}, err
+				}
+			} else {
+				if err := os.Rename(segmentPath, chunkPath); err != nil {
+					return ChunkRef{}, err
+				}
 			}
 			session.nextIndex++
 			return ChunkRef{Reference: chunkPath, CapturedAt: a.nowFn().UTC()}, nil
@@ -484,6 +495,25 @@ func sanitizeToken(value string) string {
 		return "unknown"
 	}
 	return replaced
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close() //nolint:errcheck
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close() //nolint:errcheck
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
 }
 
 func normalizeStreamlinkQuality(value string) string {

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -367,7 +367,44 @@ func TestStreamlinkCaptureAdapterContinuousAcceptsStableSegmentWithoutNextChunk(
 	if filepath.Base(chunk.Reference) != "000000001.mp4" {
 		t.Fatalf("chunk path = %q, want renamed stable segment", chunk.Reference)
 	}
-	if _, err := os.Stat(segmentPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected source segment to be moved, err=%v", err)
+	if _, err := os.Stat(segmentPath); err != nil {
+		t.Fatalf("expected source segment to remain for in-progress writer, err=%v", err)
+	}
+}
+
+func TestStreamlinkCaptureAdapterContinuousStableSegmentWaitsNearDeadline(t *testing.T) {
+	outDir := t.TempDir()
+	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
+		OutputDir: outDir,
+	}, nil, nil)
+	adapter.cfg.CaptureTimeout = 10 * time.Second
+
+	segmentsDir := filepath.Join(outDir, "str_live", "live_segments")
+	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	segmentPath := filepath.Join(segmentsDir, "000000001.mp4")
+	if err := os.WriteFile(segmentPath, []byte("segment-bytes"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	past := time.Now().Add(-3 * time.Second)
+	if err := os.Chtimes(segmentPath, past, past); err != nil {
+		t.Fatalf("Chtimes() error = %v", err)
+	}
+
+	adapter.sessions["str_live"] = &continuousCaptureSession{
+		streamerID:  "str_live",
+		channel:     "live_channel",
+		segmentsDir: segmentsDir,
+		nextIndex:   1,
+		started:     true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := adapter.captureContinuous(ctx, "str_live")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("captureContinuous() error = %v, want context deadline exceeded while far from capture deadline", err)
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent moving a segment file that may still be written to by the producer by detecting stability more robustly and copying instead of renaming when appropriate.
- Ensure a segment is only finalized by observed stability when both size and modification-time indicate stability and the capture is near its deadline.

### Description
- Added a `copyFile` helper to copy and sync files to preserve the source when finalizing in-progress segments.
- Enhanced `captureContinuous` to track `stableByObservedSize`, `stableByModTime`, and `nearDeadline`, and set `finalizedByStability` when all conditions are met.
- When `finalizedByStability` is true the code now copies the segment to the chunk path instead of renaming, otherwise it continues to use `os.Rename`.
- Updated tests to reflect the new behavior and added a test to ensure the capture waits when the deadline is not near.

### Testing
- Ran `go test ./internal/media -run TestStreamlinkCaptureAdapterContinuous*` which executed the modified and new tests and they passed.
- Updated `TestStreamlinkCaptureAdapterContinuousAcceptsStableSegmentWithoutNextChunk` to expect the source segment to remain for an in-progress writer and it passed.
- Added `TestStreamlinkCaptureAdapterContinuousStableSegmentWaitsNearDeadline` to verify waiting behavior and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90155946c832ca2778f0b811b79c0)