### PR TITLE
Use mediadelivery player URLs for Bunny uploaded videos

### DIFF
--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	defaultBunnyBaseURL          = "https://video.bunnycdn.com"
+	defaultBunnyPlaybackBaseURL  = "https://player.mediadelivery.net"
 	defaultChunkPublishBatchSize = 5
 )
 
@@ -136,7 +137,7 @@ func (p *BunnyChunkPublisher) Finalize(ctx context.Context, streamerID string, c
 	p.appendUploadedVideo(ctx, streamerID, UploadedVideo{
 		ID:        videoID,
 		Title:     title,
-		URL:       strings.TrimRight(p.cfg.BaseURL, "/") + "/library/" + p.cfg.LibraryID + "/videos/" + videoID,
+		URL:       bunnyPlaybackURL(p.cfg.LibraryID, videoID),
 		CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
 	})
 	for _, segment := range segments {
@@ -432,4 +433,13 @@ func (p *BunnyChunkPublisher) buildRemoteVideoPath(ctx context.Context, streamer
 		}
 	}
 	return fmt.Sprintf("%s/%s/%s", streamerFolder, day, sanitizeToken(time.Now().UTC().Format(time.RFC3339Nano)))
+}
+
+func bunnyPlaybackURL(libraryID, videoID string) string {
+	library := strings.TrimSpace(libraryID)
+	video := strings.TrimSpace(videoID)
+	if library == "" || video == "" {
+		return ""
+	}
+	return strings.TrimRight(defaultBunnyPlaybackBaseURL, "/") + "/play/" + library + "/" + video
 }

--- a/internal/media/publisher_test.go
+++ b/internal/media/publisher_test.go
@@ -333,3 +333,15 @@ func TestBunnyChunkPublisherCreateVideoTitleIncludesStreamerAndDayFolders(t *tes
 		t.Fatalf("title = %q, want folder prefix", title)
 	}
 }
+
+func TestBunnyPlaybackURL(t *testing.T) {
+	if got := bunnyPlaybackURL("625785", "ddd765cf-8d71-4c55-b6a7-103fce69726a"); got != "https://player.mediadelivery.net/play/625785/ddd765cf-8d71-4c55-b6a7-103fce69726a" {
+		t.Fatalf("bunnyPlaybackURL() = %q", got)
+	}
+	if got := bunnyPlaybackURL("", "video-1"); got != "" {
+		t.Fatalf("bunnyPlaybackURL() = %q, want empty for missing library", got)
+	}
+	if got := bunnyPlaybackURL("lib-1", ""); got != "" {
+		t.Fatalf("bunnyPlaybackURL() = %q, want empty for missing video", got)
+	}
+}


### PR DESCRIPTION
### Motivation
- Admin history stored Bunny API-style URLs (`https://video.bunnycdn.com/library/{lib}/videos/{guid}`) which are not directly playable; clients expect player links like `https://player.mediadelivery.net/play/{library}/{guid}`.

### Description
- Added `defaultBunnyPlaybackBaseURL` constant and a helper `bunnyPlaybackURL(libraryID, videoID string)` that builds the player-style link and returns empty string when inputs are missing in `internal/media/publisher.go`.
- Switched stored uploaded-video `URL` in `Finalize` to use `bunnyPlaybackURL(p.cfg.LibraryID, videoID)` instead of the API-style path.
- Added unit test `TestBunnyPlaybackURL` in `internal/media/publisher_test.go` to cover the exact sample format and empty-input guards.

### Testing
- Ran `go test ./internal/media ./internal/app` and all tests passed (`ok` for both packages).
- Checklist aligned with repo planning documents:
  - [ ] `docs/implementation_plan.md` milestone **M2.1** — not applicable to this small URL-format fix.
  - [ ] `docs/llm_stream_orchestration_plan.md` — not affected by this change.
  - [x] Runtime fix implemented and covered by unit test (`internal/media/publisher.go`, `internal/media/publisher_test.go`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90d5586d0832cadc79f05e6ff3a21)