### PR TITLE
Run DB migrations during container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ WORKDIR /app
 # - tini для корректной работы с subprocess/signal handling
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     python3 \
     python3-venv \
     python3-pip \
@@ -58,6 +59,18 @@ RUN python3 -m venv /opt/venv \
     && /opt/venv/bin/streamlink --version \
     && ffmpeg -version
 
+# Install golang-migrate CLI for startup schema migrations
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in \
+        amd64) MIGRATE_ARCH="amd64" ;; \
+        arm64) MIGRATE_ARCH="arm64" ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/golang-migrate/migrate/releases/download/v4.18.3/migrate.linux-${MIGRATE_ARCH}.tar.gz" \
+      | tar -xz -C /usr/local/bin migrate \
+    && chmod +x /usr/local/bin/migrate \
+    && migrate -version
+
 # Непривилегированный пользователь
 RUN groupadd -g 10001 appuser \
     && useradd -r -u 10001 -g appuser -d /app -s /usr/sbin/nologin appuser
@@ -66,14 +79,17 @@ RUN groupadd -g 10001 appuser \
 COPY --from=build /out/funpot /usr/local/bin/funpot
 
 # Если у вас есть дополнительные файлы, раскомментируйте:
-# COPY --from=build /app/migrations /app/migrations
+COPY --from=build /app/migrations /app/migrations
 # COPY --from=build /app/configs /app/configs
 # COPY --from=build /app/static /app/static
 
-RUN chown -R appuser:appuser /app /usr/local/bin/funpot
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && chown -R appuser:appuser /app /usr/local/bin/funpot /usr/local/bin/entrypoint.sh
 
 USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/funpot"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "${FUNPOT_RUN_MIGRATIONS_ON_STARTUP:-true}" = "true" ]; then
+  if [ -z "${FUNPOT_DATABASE_URL:-}" ]; then
+    if [ -n "${FUNPOT_DATABASE_USER:-}" ] && [ -n "${FUNPOT_DATABASE_PASSWORD:-}" ] && [ -n "${FUNPOT_DATABASE_HOST:-}" ] && [ -n "${FUNPOT_DATABASE_NAME:-}" ]; then
+      FUNPOT_DATABASE_URL="postgres://${FUNPOT_DATABASE_USER}:${FUNPOT_DATABASE_PASSWORD}@${FUNPOT_DATABASE_HOST}:${FUNPOT_DATABASE_PORT:-5432}/${FUNPOT_DATABASE_NAME}?sslmode=${FUNPOT_DATABASE_SSLMODE:-disable}"
+      export FUNPOT_DATABASE_URL
+    fi
+  fi
+
+  if [ -n "${FUNPOT_DATABASE_URL:-}" ]; then
+    migrate -path /app/migrations -database "${FUNPOT_DATABASE_URL}" up
+  else
+    echo "[entrypoint] FUNPOT_DATABASE_URL not provided; skipping migrations" >&2
+  fi
+fi
+
+exec /usr/local/bin/funpot

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -62,6 +62,8 @@ FUNPOT_DATABASE_NAME=funpot
 FUNPOT_DATABASE_USER=funpot
 FUNPOT_DATABASE_PASSWORD=funpot
 FUNPOT_DATABASE_SSLMODE=disable
+FUNPOT_DATABASE_URL=
+FUNPOT_RUN_MIGRATIONS_ON_STARTUP=true
 FUNPOT_DATABASE_MAX_OPEN_CONNS=10
 FUNPOT_DATABASE_MIN_OPEN_CONNS=1
 FUNPOT_DATABASE_CONNECT_TIMEOUT=5s
@@ -180,6 +182,8 @@ repository `Dockerfile`:
 docker build -t funpot-core:dev .
 docker run --rm -p 8080:8080 --env-file .env funpot-core:dev
 ```
+
+Container startup now applies migrations automatically (via `migrate up`) when database configuration is present. Set `FUNPOT_RUN_MIGRATIONS_ON_STARTUP=false` to disable this behavior for one-off debug runs.
 
 On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /healthz` – liveness probe returning the current timestamp.


### PR DESCRIPTION
### Motivation
- Ensure database schema is kept in sync with deployed code when containers are restarted by the CD process, because previously the runtime image neither contained the `migrations/` files nor invoked `migrate` at startup, which can cause runtime failures due to schema drift.
- Checklist:
[x] Copy `migrations/` into the final runtime image and ship a container entrypoint that can apply migrations automatically when DB config is present.
[x] Document new environment toggles and the startup migration behavior in `docs/local_setup.md` to make the rollout explicit and reproducible.
[ ] Validate in staging/production that the container has a correct `FUNPOT_DATABASE_URL` (or `FUNPOT_DATABASE_*`) and that the DB user has DDL permissions before enabling automatic migrations.

### Description
- Added `docker/entrypoint.sh` which derives `FUNPOT_DATABASE_URL` when necessary and runs `migrate -path /app/migrations -database "${FUNPOT_DATABASE_URL}" up` before starting the `funpot` binary.
- Updated `Dockerfile` to install `curl`, install the `golang-migrate` CLI (arch-aware), copy `migrations/` from the build stage, and replace the binary entrypoint with the new entrypoint script.
- Updated `docs/local_setup.md` to introduce `FUNPOT_DATABASE_URL` and `FUNPOT_RUN_MIGRATIONS_ON_STARTUP` and to document that the container will apply migrations by default on startup, with a toggle to disable.

### Testing
- Ran unit tests with `go test ./...` and all package tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da44bf329c832c987bbc6d78a78ffd)