### PR TITLE
Normalize scenario steps to ensure a single initial step and add related tests

### DIFF
--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -695,3 +695,40 @@ func TestWorkerProcessStreamerStopsWhenInitialMaxRequestsExceeded(t *testing.T) 
 		t.Fatalf("expected ErrTrackingStop, got %v", err)
 	}
 }
+
+func TestWorkerProcessStreamerStopsWhenInitialHasNoMatchingBranchAndLimitReached(t *testing.T) {
+	decisions := &fakeDecisionStore{
+		items: []streamers.RecordDecisionRequest{
+			{StreamerID: "streamer-1", Stage: "initial", UpdatedStateJSON: `{"game":"unknown"}`},
+			{StreamerID: "streamer-1", Stage: "initial", UpdatedStateJSON: `{"game":"unknown"}`},
+		},
+	}
+	worker := NewWorker(
+		&fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Now().UTC()}},
+		fakeClassifier{results: map[string]StageClassification{"initial": {Label: "ok", Confidence: 0.9}}},
+		fakePromptResolver{
+			scenario: prompts.ScenarioPackage{
+				ID:               "scenario-1",
+				GameSlug:         "global",
+				LLMModelConfigID: "cfg-default",
+				Steps: []prompts.ScenarioStep{
+					{ID: "initial", Name: "Initial", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1, MaxRequests: 2},
+					{ID: "cs2_mode", Name: "CS2", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
+				},
+				Transitions: []prompts.ScenarioTransition{
+					{FromStepID: "initial", ToStepID: "cs2_mode", Condition: "game == cs2", Priority: 1},
+				},
+			},
+			llmModelConfig: prompts.LLMModelConfig{ID: "cfg-default", Model: "gemini-2.5-flash"},
+		},
+		&InMemoryRunStore{},
+		decisions,
+		NewInMemoryLocker(),
+		WorkerConfig{MinConfidence: 0.5},
+	)
+
+	_, err := worker.ProcessStreamer(context.Background(), "streamer-1")
+	if !errors.Is(err, ErrTrackingStop) {
+		t.Fatalf("expected ErrTrackingStop when initial branch did not match and max requests reached, got %v", err)
+	}
+}

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -168,6 +168,29 @@ func normalizeScenarioSteps(steps []ScenarioStep, fallbackGameSlug string, now t
 			normalized[i].MaxRequests = 0
 		}
 	}
+	if len(normalized) == 0 {
+		return normalized
+	}
+	initialIndex := -1
+	for i := range normalized {
+		if !normalized[i].Initial {
+			continue
+		}
+		if initialIndex == -1 || normalized[i].Order < normalized[initialIndex].Order || (normalized[i].Order == normalized[initialIndex].Order && strings.TrimSpace(normalized[i].ID) < strings.TrimSpace(normalized[initialIndex].ID)) {
+			initialIndex = i
+		}
+	}
+	if initialIndex == -1 {
+		initialIndex = 0
+		for i := 1; i < len(normalized); i++ {
+			if normalized[i].Order < normalized[initialIndex].Order || (normalized[i].Order == normalized[initialIndex].Order && strings.TrimSpace(normalized[i].ID) < strings.TrimSpace(normalized[initialIndex].ID)) {
+				initialIndex = i
+			}
+		}
+	}
+	for i := range normalized {
+		normalized[i].Initial = i == initialIndex
+	}
 	return normalized
 }
 

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -98,6 +98,70 @@ func TestScenarioPackageResolveStepFallsBackToFirstInitialWhenNoConditionMatches
 	}
 }
 
+func TestCreateScenarioPackageNormalizesToSingleInitialStep(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	config := mustCreateModelConfig(t, svc)
+	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "single initial",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
+		Steps: []ScenarioStep{
+			{ID: "fallback", Name: "Fallback", PromptTemplate: "fallback", ResponseSchemaJSON: `{}`, Initial: true, Order: 2},
+			{ID: "root", Name: "Root", PromptTemplate: "root", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+			{ID: "branch", Name: "Branch", PromptTemplate: "branch", ResponseSchemaJSON: `{}`, Initial: false, Order: 3},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+
+	initialCount := 0
+	initialID := ""
+	for _, step := range pkg.Steps {
+		if step.Initial {
+			initialCount++
+			initialID = step.ID
+		}
+	}
+	if initialCount != 1 {
+		t.Fatalf("expected exactly one initial step, got %d (%#v)", initialCount, pkg.Steps)
+	}
+	if initialID != "root" {
+		t.Fatalf("expected lowest-order initial step root to be preserved, got %q", initialID)
+	}
+}
+
+func TestCreateScenarioPackageAssignsInitialWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	config := mustCreateModelConfig(t, svc)
+	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "auto root",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
+		Steps: []ScenarioStep{
+			{ID: "mode", Name: "Mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Order: 2},
+			{ID: "detect", Name: "Detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Order: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+
+	initial, err := pkg.InitialStep()
+	if err != nil {
+		t.Fatalf("initial step: %v", err)
+	}
+	if initial.ID != "detect" {
+		t.Fatalf("expected lowest-order step detect to become initial, got %q", initial.ID)
+	}
+}
+
 func TestScenarioPackageResolveStepUsesHighestPriorityTransition(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Motivation

- Guarantee scenario packages have exactly one initial step so flow resolution is deterministic and transitions behave consistently.
- Cover the case where an initial step never matches any branch and its request limit is reached to ensure worker processing stops as expected.

### Description

- Update `normalizeScenarioSteps` to pick a single initial step by choosing the lowest `Order` (and tie-breaking by `ID`) and set `Initial` flags accordingly, with a fallback to the first step when no initial is marked.  
- Preserve existing defaulting for `CreatedAt`, `Order`, `GameSlug`, `SegmentSeconds`, and non-negative `MaxRequests` while early-returning on empty step lists.  
- Add `TestCreateScenarioPackageNormalizesToSingleInitialStep` and `TestCreateScenarioPackageAssignsInitialWhenMissing` to `internal/prompts/scenario_flow_test.go` to validate the normalization and auto-assignment behavior.  
- Add `TestWorkerProcessStreamerStopsWhenInitialHasNoMatchingBranchAndLimitReached` to `internal/media/worker_test.go` to assert `ProcessStreamer` returns `ErrTrackingStop` when an initial step never matches transitions and its `MaxRequests` limit is reached.

### Testing

- Ran the new unit tests in `internal/prompts` and `internal/media`, and they passed.  
- Ran the package test suite with `go test ./...` to validate changes across packages, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de378fa050832c839c32366951734a)