### PR TITLE
docs: align scenario OpenAPI schemas with runtime behavior

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1327,9 +1327,10 @@ components:
               type: string
               format: date-time
               nullable: true
-    ScenarioStep:
+    ScenarioStepRequest:
       type: object
       required: [id, name, promptTemplate, responseSchemaJson, initial, order]
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -1346,22 +1347,28 @@ components:
         responseSchemaJson:
           type: string
           description: JSON schema/template contract that the LLM response must follow exactly (legacy coercion is not applied).
-        segmentSeconds:
-          type: integer
-          minimum: 1
-          description: Video segment duration in seconds for this step. Defaults to 15 for the initial step and 30 for all other steps.
-        maxRequests:
-          type: integer
-          minimum: 0
-          description: Maximum number of LLM requests allowed for this step (0 = unlimited). If a non-initial step reaches this limit runtime returns to the initial step; if the initial step reaches this limit runtime stops tracking the streamer.
         initial:
           type: boolean
         order:
           type: integer
           minimum: 1
+    ScenarioStep:
+      allOf:
+        - $ref: '#/components/schemas/ScenarioStepRequest'
+        - type: object
+          properties:
+            segmentSeconds:
+              type: integer
+              minimum: 1
+              description: Video segment duration in seconds for this step. Defaults to 15 for the initial step and 30 for all other steps.
+            maxRequests:
+              type: integer
+              minimum: 0
+              description: Maximum number of LLM requests allowed for this step (0 = unlimited). If a non-initial step reaches this limit runtime returns to the initial step; if the initial step reaches this limit runtime stops tracking the streamer.
     ScenarioTransition:
       type: object
       required: [fromStepId, toStepId, condition, priority]
+      additionalProperties: false
       properties:
         fromStepId:
           type: string
@@ -1375,6 +1382,7 @@ components:
     ScenarioPackageCreateRequest:
       type: object
       required: [gameSlug, name, llmModelConfigId, steps]
+      additionalProperties: false
       properties:
         gameSlug:
           type: string
@@ -1386,7 +1394,7 @@ components:
           type: array
           minItems: 1
           items:
-            $ref: '#/components/schemas/ScenarioStep'
+            $ref: '#/components/schemas/ScenarioStepRequest'
         transitions:
           type: array
           description: Optional explicit graph edges for branching scenario flow. When omitted, backend auto-generates linear transitions by `order`.
@@ -1403,6 +1411,10 @@ components:
               type: integer
             isActive:
               type: boolean
+            steps:
+              type: array
+              items:
+                $ref: '#/components/schemas/ScenarioStep'
             transitions:
               type: array
               description: Effective transitions used by runtime (explicit admin-defined edges or backend auto-generated linear edges when omitted in create/update payload).


### PR DESCRIPTION
### Motivation
- Align the public OpenAPI contract for scenario packages with the runtime scenario-graph v2 behavior so admin create/update payloads do not accept runtime-only fields.
- Ensure admin payloads are strictly validated by adding `additionalProperties: false` to request schemas to reflect backend strict JSON decoding behavior.
- Checklist (aligned with M2.1 and `docs/llm_stream_orchestration_plan.md`): [x] Update OpenAPI scenario contract (`docs/openapi.yaml`); [x] Enforce strict admin payload shape; [ ] Re-introduce scenario-package persistence/versioning in PostgreSQL (separate task); [ ] Add load testing scenarios and CI gate for load tests (separate task).

### Description
- Split the step schema into a request and response variant by adding `ScenarioStepRequest` and making `ScenarioStep` an `allOf` that extends the request with runtime fields (`segmentSeconds`, `maxRequests`) in `docs/openapi.yaml`.
- Mark request schemas as strict by adding `additionalProperties: false` for `ScenarioStepRequest`, `ScenarioTransition`, and `ScenarioPackageCreateRequest`.
- Update `ScenarioPackageCreateRequest` to reference `ScenarioStepRequest` for `steps`, and update `ScenarioPackageVersion` to return `steps` using the runtime-enriched `ScenarioStep`.
- Change is limited to documentation: modified `docs/openapi.yaml` only.

### Testing
- Ran `go test ./...` and the test suite completed successfully.
- No other automated checks were required for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3f722388832cbd3ba43b1e61a9a8)