### PR TITLE
Add per-step `segmentSeconds`/`maxRequests` and require exactly one initial scenario step

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1347,8 +1347,17 @@ components:
         responseSchemaJson:
           type: string
           description: JSON schema/template contract that the LLM response must follow exactly (legacy coercion is not applied).
+        segmentSeconds:
+          type: integer
+          minimum: 1
+          description: Video segment duration in seconds for this step. Defaults to 15 for the initial step and 30 for all other steps.
+        maxRequests:
+          type: integer
+          minimum: 0
+          description: Maximum number of LLM requests allowed for this step (0 = unlimited). If a non-initial step reaches this limit runtime returns to the initial step; if the initial step reaches this limit runtime stops tracking the streamer.
         initial:
           type: boolean
+          description: Exactly one step in the package must have `initial=true`. Runtime always starts from this step before transitioning to scenario branches.
         order:
           type: integer
           minimum: 1

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -69,6 +69,8 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 			EntryCondition:     step.EntryCondition,
 			PromptTemplate:     step.PromptTemplate,
 			ResponseSchemaJSON: step.ResponseSchemaJSON,
+			SegmentSeconds:     step.SegmentSeconds,
+			MaxRequests:        step.MaxRequests,
 			Initial:            step.Initial,
 			Order:              step.Order,
 		})
@@ -117,6 +119,8 @@ type scenarioStepRequest struct {
 	EntryCondition     string `json:"entryCondition"`
 	PromptTemplate     string `json:"promptTemplate"`
 	ResponseSchemaJSON string `json:"responseSchemaJson"`
+	SegmentSeconds     int    `json:"segmentSeconds"`
+	MaxRequests        int    `json:"maxRequests"`
 	Initial            bool   `json:"initial"`
 	Order              int    `json:"order"`
 }

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -64,6 +64,8 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"gameSlug":           "global",
 				"promptTemplate":     "detect",
 				"responseSchemaJson": "{}",
+				"segmentSeconds":     15,
+				"maxRequests":        4,
 				"initial":            true,
 				"order":              1,
 			},
@@ -104,6 +106,20 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	transitions, ok := created["transitions"].([]any)
 	if !ok || len(transitions) != 1 {
 		t.Fatalf("expected explicit transitions in response, got %#v", created["transitions"])
+	}
+	steps, ok := created["steps"].([]any)
+	if !ok || len(steps) == 0 {
+		t.Fatalf("expected steps in response, got %#v", created["steps"])
+	}
+	firstStep, ok := steps[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected first step object, got %#v", steps[0])
+	}
+	if got, _ := firstStep["segmentSeconds"].(float64); int(got) != 15 {
+		t.Fatalf("expected segmentSeconds=15, got %#v", firstStep["segmentSeconds"])
+	}
+	if got, _ := firstStep["maxRequests"].(float64); int(got) != 4 {
+		t.Fatalf("expected maxRequests=4, got %#v", firstStep["maxRequests"])
 	}
 
 	updateBody, _ := json.Marshal(map[string]any{

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -17,6 +17,7 @@ var (
 	ErrScenarioStepNotFound     = errors.New("scenario step not found")
 	ErrInvalidScenarioPackage   = errors.New("scenario package must contain at least one step")
 	ErrInvalidScenarioStepID    = errors.New("scenario step id must not be empty")
+	ErrInvalidScenarioInitial   = errors.New("scenario package must contain exactly one initial step")
 	ErrInvalidScenarioCondition = errors.New("scenario step entry condition is invalid")
 	ErrInvalidScenarioModelRef  = errors.New("scenario package llmModelConfigId must not be empty")
 	ErrInvalidScenarioName      = errors.New("scenario package name must not be empty")
@@ -115,15 +116,22 @@ func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) erro
 		return ErrInvalidScenarioPackage
 	}
 	seenSteps := make(map[string]struct{}, len(req.Steps))
+	initialCount := 0
 	for _, step := range req.Steps {
 		id := strings.TrimSpace(step.ID)
 		if id == "" {
 			return ErrInvalidScenarioStepID
 		}
+		if step.Initial {
+			initialCount++
+		}
 		if err := validateScenarioCondition(step.EntryCondition); err != nil {
 			return fmt.Errorf("%w: step %s: %v", ErrInvalidScenarioCondition, id, err)
 		}
 		seenSteps[id] = struct{}{}
+	}
+	if initialCount != 1 {
+		return ErrInvalidScenarioInitial
 	}
 	for _, transition := range req.Transitions {
 		from := strings.TrimSpace(transition.FromStepID)
@@ -167,29 +175,6 @@ func normalizeScenarioSteps(steps []ScenarioStep, fallbackGameSlug string, now t
 		if normalized[i].MaxRequests < 0 {
 			normalized[i].MaxRequests = 0
 		}
-	}
-	if len(normalized) == 0 {
-		return normalized
-	}
-	initialIndex := -1
-	for i := range normalized {
-		if !normalized[i].Initial {
-			continue
-		}
-		if initialIndex == -1 || normalized[i].Order < normalized[initialIndex].Order || (normalized[i].Order == normalized[initialIndex].Order && strings.TrimSpace(normalized[i].ID) < strings.TrimSpace(normalized[initialIndex].ID)) {
-			initialIndex = i
-		}
-	}
-	if initialIndex == -1 {
-		initialIndex = 0
-		for i := 1; i < len(normalized); i++ {
-			if normalized[i].Order < normalized[initialIndex].Order || (normalized[i].Order == normalized[initialIndex].Order && strings.TrimSpace(normalized[i].ID) < strings.TrimSpace(normalized[initialIndex].ID)) {
-				initialIndex = i
-			}
-		}
-	}
-	for i := range normalized {
-		normalized[i].Initial = i == initialIndex
 	}
 	return normalized
 }
@@ -532,17 +517,17 @@ func (p ScenarioPackage) ResolveStep(currentStepID, stateJSON string) (ScenarioS
 
 	state := parseJSONMap(stateJSON)
 	current := strings.TrimSpace(currentStepID)
-	if current == "" {
-		initial := make([]ScenarioStep, 0, len(p.Steps))
-		for _, step := range p.Steps {
-			if step.Initial {
-				initial = append(initial, step)
+		if current == "" {
+			initial := make([]ScenarioStep, 0, len(p.Steps))
+			for _, step := range p.Steps {
+				if step.Initial {
+					initial = append(initial, step)
+				}
 			}
-		}
-		if len(initial) == 0 {
-			initial = append(initial, p.Steps...)
-		}
-		sort.Slice(initial, func(i, j int) bool { return initial[i].Order < initial[j].Order })
+			if len(initial) == 0 {
+				return ScenarioStep{}, false, ErrInvalidScenarioInitial
+			}
+			sort.Slice(initial, func(i, j int) bool { return initial[i].Order < initial[j].Order })
 		for _, candidate := range initial {
 			ok, err := evaluateCondition(candidate.EntryCondition, state)
 			if err == nil && ok {
@@ -592,10 +577,7 @@ func (p ScenarioPackage) InitialStep() (ScenarioStep, error) {
 		}
 	}
 	if len(initial) == 0 {
-		initial = append(initial, p.Steps...)
-	}
-	if len(initial) == 0 {
-		return ScenarioStep{}, ErrScenarioStepNotFound
+		return ScenarioStep{}, ErrInvalidScenarioInitial
 	}
 	sort.Slice(initial, func(i, j int) bool {
 		if initial[i].Order == initial[j].Order {

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -98,12 +98,12 @@ func TestScenarioPackageResolveStepFallsBackToFirstInitialWhenNoConditionMatches
 	}
 }
 
-func TestCreateScenarioPackageNormalizesToSingleInitialStep(t *testing.T) {
+func TestCreateScenarioPackageRejectsMultipleInitialSteps(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService()
 	config := mustCreateModelConfig(t, svc)
-	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+	_, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
 		Name:             "single initial",
 		GameSlug:         "global",
 		ActorID:          "admin-1",
@@ -114,32 +114,17 @@ func TestCreateScenarioPackageNormalizesToSingleInitialStep(t *testing.T) {
 			{ID: "branch", Name: "Branch", PromptTemplate: "branch", ResponseSchemaJSON: `{}`, Initial: false, Order: 3},
 		},
 	})
-	if err != nil {
-		t.Fatalf("create scenario package: %v", err)
-	}
-
-	initialCount := 0
-	initialID := ""
-	for _, step := range pkg.Steps {
-		if step.Initial {
-			initialCount++
-			initialID = step.ID
-		}
-	}
-	if initialCount != 1 {
-		t.Fatalf("expected exactly one initial step, got %d (%#v)", initialCount, pkg.Steps)
-	}
-	if initialID != "root" {
-		t.Fatalf("expected lowest-order initial step root to be preserved, got %q", initialID)
+	if !errors.Is(err, ErrInvalidScenarioInitial) {
+		t.Fatalf("expected ErrInvalidScenarioInitial, got %v", err)
 	}
 }
 
-func TestCreateScenarioPackageAssignsInitialWhenMissing(t *testing.T) {
+func TestCreateScenarioPackageRejectsMissingInitialStep(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService()
 	config := mustCreateModelConfig(t, svc)
-	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+	_, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
 		Name:             "auto root",
 		GameSlug:         "global",
 		ActorID:          "admin-1",
@@ -149,16 +134,8 @@ func TestCreateScenarioPackageAssignsInitialWhenMissing(t *testing.T) {
 			{ID: "detect", Name: "Detect", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Order: 1},
 		},
 	})
-	if err != nil {
-		t.Fatalf("create scenario package: %v", err)
-	}
-
-	initial, err := pkg.InitialStep()
-	if err != nil {
-		t.Fatalf("initial step: %v", err)
-	}
-	if initial.ID != "detect" {
-		t.Fatalf("expected lowest-order step detect to become initial, got %q", initial.ID)
+	if !errors.Is(err, ErrInvalidScenarioInitial) {
+		t.Fatalf("expected ErrInvalidScenarioInitial, got %v", err)
 	}
 }
 
@@ -325,7 +302,7 @@ func TestScenarioPackageUpdateAcrossGameDeactivatesAndNormalizesSteps(t *testing
 		ActorID:          "admin-1",
 		LLMModelConfigID: config.ID,
 		Steps: []ScenarioStep{
-			{ID: "cs2_mode", Name: "Mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`},
+			{ID: "cs2_mode", Name: "Mode", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Initial: true},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
### Motivation

- Add per-step video segment duration and LLM request limits to scenario steps so runtimes can control timing and request quotas.
- Prevent ambiguous package bootstrapping by requiring exactly one initial step instead of silently normalizing multiple or missing initials.
- Surface the new fields through the API and ensure behavior is validated consistently across service, router, and docs.

### Description

- Introduce `SegmentSeconds` and `MaxRequests` on `ScenarioStep` and wire them into the API by updating `docs/openapi.yaml`, the admin router request types, and `scenarioPackageRequestToCreateRequest` mapping.
- Change validation in `ValidateScenarioPackageCreateRequest` to enforce exactly one initial step and add `ErrInvalidScenarioInitial` for this case, and remove the previous auto-assignment logic from `normalizeScenarioSteps`.
- Keep normalization defaults for steps so that `SegmentSeconds` defaults to `15` for the initial step and `30` for others, and negative `MaxRequests` are normalized to `0`.
- Update `ResolveStep` and `InitialStep` to return `ErrInvalidScenarioInitial` when no initial steps are present, and update admin route responses to include the new fields.

### Testing

- Ran unit tests with `go test ./...`, which include `TestAdminLLMScenarioPackageRoutes` and the scenario package tests in `internal/prompts/scenario_flow_test.go`, and they passed.
- Updated tests `TestCreateScenarioPackageRejectsMultipleInitialSteps`, `TestCreateScenarioPackageRejectsMissingInitialStep`, and assertions in `TestAdminLLMScenarioPackageRoutes` to cover the new validation and fields, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4ba1a714832c8d66e3e42c97caf5)