### PR TITLE
fix: format internal/prompts/scenario_flow.go

### DIFF
--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -517,17 +517,17 @@ func (p ScenarioPackage) ResolveStep(currentStepID, stateJSON string) (ScenarioS
 
 	state := parseJSONMap(stateJSON)
 	current := strings.TrimSpace(currentStepID)
-		if current == "" {
-			initial := make([]ScenarioStep, 0, len(p.Steps))
-			for _, step := range p.Steps {
-				if step.Initial {
-					initial = append(initial, step)
-				}
+	if current == "" {
+		initial := make([]ScenarioStep, 0, len(p.Steps))
+		for _, step := range p.Steps {
+			if step.Initial {
+				initial = append(initial, step)
 			}
-			if len(initial) == 0 {
-				return ScenarioStep{}, false, ErrInvalidScenarioInitial
-			}
-			sort.Slice(initial, func(i, j int) bool { return initial[i].Order < initial[j].Order })
+		}
+		if len(initial) == 0 {
+			return ScenarioStep{}, false, ErrInvalidScenarioInitial
+		}
+		sort.Slice(initial, func(i, j int) bool { return initial[i].Order < initial[j].Order })
 		for _, candidate := range initial {
 			ok, err := evaluateCondition(candidate.EntryCondition, state)
 			if err == nil && ok {


### PR DESCRIPTION
### Motivation
- CI `Verify formatting` failed because `internal/prompts/scenario_flow.go` was not `gofmt`-compliant, which blocked the build; this change restores proper formatting without altering runtime behavior.

### Description
- Run `gofmt` on `internal/prompts/scenario_flow.go` to normalize indentation/whitespace in the `ResolveStep` block; no logic changes were made. 
- Checklist aligned to planning docs:  
  - M2.1 implementation_plan.md: [x] formatting gate fixed, [ ] additional M2.1 feature work remains.  
  - llm_stream_orchestration_plan.md: [x] preserved existing scenario-graph runtime behavior, [ ] further alignment tasks remain.

### Testing
- Ran `gofmt -l internal/prompts/scenario_flow.go` and it produced no output, indicating file is formatted. 
- Ran `go test ./...` and all automated tests passed for tested packages (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5205a10c832c916996eed19fecbf)