### PR TITLE
Enforce single initial ScenarioStep and remove bootstrap fallback

### DIFF
--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -524,23 +524,10 @@ func (p ScenarioPackage) ResolveStep(currentStepID, stateJSON string) (ScenarioS
 				initial = append(initial, step)
 			}
 		}
-		if len(initial) == 0 {
+		if len(initial) != 1 {
 			return ScenarioStep{}, false, ErrInvalidScenarioInitial
 		}
-		sort.Slice(initial, func(i, j int) bool { return initial[i].Order < initial[j].Order })
-		for _, candidate := range initial {
-			ok, err := evaluateCondition(candidate.EntryCondition, state)
-			if err == nil && ok {
-				return candidate, true, nil
-			}
-		}
-		// Bootstrap fail-safe: if no initial candidate condition matches,
-		// still start from the first ordered initial/root step.
-		// This keeps scheduler cycles running when state payload is sparse.
-		if len(initial) > 0 {
-			return initial[0], true, nil
-		}
-		return ScenarioStep{}, false, ErrScenarioStepNotFound
+		return initial[0], true, nil
 	}
 
 	active, ok := byID[current]
@@ -576,15 +563,9 @@ func (p ScenarioPackage) InitialStep() (ScenarioStep, error) {
 			initial = append(initial, step)
 		}
 	}
-	if len(initial) == 0 {
+	if len(initial) != 1 {
 		return ScenarioStep{}, ErrInvalidScenarioInitial
 	}
-	sort.Slice(initial, func(i, j int) bool {
-		if initial[i].Order == initial[j].Order {
-			return initial[i].ID < initial[j].ID
-		}
-		return initial[i].Order < initial[j].Order
-	})
 	return initial[0], nil
 }
 

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -73,12 +73,12 @@ func TestScenarioPackageResolveStep(t *testing.T) {
 	}
 }
 
-func TestScenarioPackageResolveStepFallsBackToFirstInitialWhenNoConditionMatches(t *testing.T) {
+func TestScenarioPackageResolveStepRejectsMultipleInitialStepsOnBootstrap(t *testing.T) {
 	t.Parallel()
 
 	pkg := ScenarioPackage{
 		ID:       "pkg-1",
-		Name:     "fallback flow",
+		Name:     "invalid bootstrap flow",
 		GameSlug: "global",
 		Steps: []ScenarioStep{
 			{ID: "root_detect", Name: "Root detect", Initial: true, Order: 1, EntryCondition: "game == cs2"},
@@ -86,15 +86,9 @@ func TestScenarioPackageResolveStepFallsBackToFirstInitialWhenNoConditionMatches
 		},
 	}
 
-	step, entered, err := pkg.ResolveStep("", `{"game":"dota2"}`)
-	if err != nil {
-		t.Fatalf("resolve initial fallback: %v", err)
-	}
-	if !entered {
-		t.Fatalf("expected entered=true for bootstrap fallback")
-	}
-	if step.ID != "root_detect" {
-		t.Fatalf("expected fallback to first ordered initial step root_detect, got %s", step.ID)
+	_, _, err := pkg.ResolveStep("", `{"game":"dota2"}`)
+	if !errors.Is(err, ErrInvalidScenarioInitial) {
+		t.Fatalf("expected ErrInvalidScenarioInitial, got %v", err)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Prevent ambiguous bootstrap behavior when a scenario package defines multiple initial steps by enforcing a single initial step.
- Simplify startup resolution logic to avoid implicit fallbacks that mask invalid package definitions.

### Description

- Changed `ScenarioPackage.ResolveStep` to require exactly one initial step at bootstrap and return `ErrInvalidScenarioInitial` when that invariant is violated, removing the previous conditional evaluation and fallback-to-first behavior. 
- Updated `ScenarioPackage.InitialStep` to also enforce exactly one initial step and return `ErrInvalidScenarioInitial` when there are zero or multiple initial steps.
- Adjusted unit tests in `scenario_flow_test.go` to expect rejection of multiple initial steps during bootstrap and renamed the test to `TestScenarioPackageResolveStepRejectsMultipleInitialStepsOnBootstrap`.

### Testing

- Ran the updated unit test `TestScenarioPackageResolveStepRejectsMultipleInitialStepsOnBootstrap` which asserts the error behavior for multiple initials, and it passed.
- Verified `TestCreateScenarioPackageRejectsMultipleInitialSteps` still fails with `ErrInvalidScenarioInitial` as expected. 
- Executed package unit tests with `go test ./...` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de54dae9dc832c9508723ee4e2de54)