### PR TITLE
Use InitialStep() helper in ResolveStep to centralize initial-step logic

### DIFF
--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -518,16 +518,11 @@ func (p ScenarioPackage) ResolveStep(currentStepID, stateJSON string) (ScenarioS
 	state := parseJSONMap(stateJSON)
 	current := strings.TrimSpace(currentStepID)
 	if current == "" {
-		initial := make([]ScenarioStep, 0, len(p.Steps))
-		for _, step := range p.Steps {
-			if step.Initial {
-				initial = append(initial, step)
-			}
+		entry, err := p.InitialStep()
+		if err != nil {
+			return ScenarioStep{}, false, err
 		}
-		if len(initial) != 1 {
-			return ScenarioStep{}, false, ErrInvalidScenarioInitial
-		}
-		return initial[0], true, nil
+		return entry, true, nil
 	}
 
 	active, ok := byID[current]


### PR DESCRIPTION
### Motivation
- Consolidate initial-step selection logic by delegating to the `InitialStep()` helper to reduce duplication and ensure consistent validation when `ResolveStep` is invoked with an empty `currentStepID`.

### Description
- Replace inline code that collected steps with `Initial == true` inside `ResolveStep` with a call to `InitialStep()` and propagate its error, returning the entry on success.

### Testing
- Ran unit tests with `go test ./...` and focused scenario tests with `go test ./internal/prompts -run TestScenario*`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5a3f13ec832cbf3364df52a5dcc4)