### PR TITLE
GameScenario orchestration: package-to-package transitions, terminal conditions, admin API and runtime support

### DIFF
--- a/docs/agent_game_scenario_packages_plan_ru.md
+++ b/docs/agent_game_scenario_packages_plan_ru.md
@@ -1,0 +1,210 @@
+# Руководство для агентов: сценарии игры на базе пакетов сценариев (Scenario Graph v2)
+
+## Зачем нужен этот документ
+
+Этот документ фиксирует **каноничную логику** для новой связи между пакетами сценариев (далее — *сценарии игры*) и задаёт единый план внедрения для backend/admin/runtime.
+
+Цель: перейти от локальной логики шагов внутри одного пакета к оркестрации **цепочек пакетов**, связанных через `Transitions`, с контролем условий старта следующего пакета и условий завершения отслеживания игры.
+
+---
+
+## Термины
+
+- **Пакет сценария (Scenario Package)** — существующая сущность, внутри которой уже есть шаги (`ScenarioStep`) и переходы между шагами.
+- **Сценарий игры (Game Scenario)** — новый граф верхнего уровня: ноды = готовые пакеты сценариев, рёбра = `Transitions` между пакетами.
+- **Переход пакета (Package Transition)** — правило перехода от текущего пакета к целевому пакету, вычисляемое по накопленному состоянию.
+- **Условие завершения цепочки (Terminal Condition)** — правило, при котором игра считается завершённой и отслеживание останавливается.
+- **Guard первого шага** — обязательная проверка: даже если `Package Transition` сработал, вход в целевой пакет разрешён только если выполняется условие входа его первого шага (`initial step condition`).
+
+---
+
+## Каноничная бизнес-логика (обязательно к реализации)
+
+1. Админ в панели собирает **сценарий игры** из уже готовых пакетов:
+   - создаёт ноды (каждая нода ссылается на существующий `ScenarioPackage`),
+   - связывает ноды через `Transitions`.
+2. У каждой цепочки есть собственные **условия завершения**.
+   - Пример: в state зафиксировано `side=ct` и `winner=ct`.
+   - При совпадении условий backend прекращает дальнейшее LLM-отслеживание этой game-session.
+3. Результат завершения/прогресса отображается в отслеживании стримера.
+4. Переход между пакетами двухфазный:
+   - фаза A: совпало условие `Package Transition`,
+   - фаза B: валидирован `entry` первого шага целевого пакета.
+   - Если фаза B не пройдена — переход **запрещён**, рантайм остаётся в текущем пакете/шаге.
+
+---
+
+## Требования к моделям и хранению
+
+> Ниже логическая модель. Конкретные имена таблиц/полей могут отличаться, но семантика должна быть сохранена.
+
+### 1) GameScenario
+- `id`
+- `slug` (уникальный ключ сценария игры)
+- `title`
+- `isActive`
+- `initialNodeId`
+- `version` / `publishedAt`
+- `createdBy`, `updatedBy`, `timestamps`
+
+### 2) GameScenarioNode
+- `id`
+- `gameScenarioId`
+- `scenarioPackageId` (ссылка на существующий пакет)
+- `alias` (уникальный в рамках графа)
+- `order` (опционально, для UX)
+- `metaJson` (опционально)
+
+### 3) GameScenarioTransition
+- `id`
+- `gameScenarioId`
+- `fromNodeId`
+- `toNodeId`
+- `priority` (чем меньше число — тем раньше проверка)
+- `conditionExprJson` (каноничный формат условия)
+- `description`
+
+### 4) GameScenarioTerminalCondition
+- `id`
+- `gameScenarioId`
+- `scope` (`global` | `node` | `edge`)
+- `nodeId` / `transitionId` (опционально в зависимости от `scope`)
+- `conditionExprJson`
+- `resultType` (`win` | `loss` | `draw` | `unknown` | кастом из домена)
+- `resultPayloadJson`
+
+### 5) Runtime state (на match-session)
+- `currentGameScenarioId`
+- `currentNodeId`
+- `currentPackageId`
+- `currentStepId`
+- `stateJson`
+- `lastTransitionTrace`
+- `finishedAt`, `finishReason`, `finalResultJson`
+
+---
+
+## Алгоритм рантайма (worker)
+
+На каждом цикле обработки:
+
+1. Обновить `stateJson` по ответу активного шага текущего пакета.
+2. Проверить `TerminalCondition` (по приоритету/детерминированному порядку).
+   - Если совпало: зафиксировать `finalResult`, проставить `finishedAt`, остановить цикл.
+3. Проверить `GameScenarioTransition` из текущей ноды (по `priority`).
+4. Если найден candidate-переход:
+   - Получить первый шаг целевого пакета.
+   - Проверить `entry condition` первого шага на **текущем** `stateJson`.
+   - Если true: переключить `currentNodeId/currentPackageId/currentStepId`.
+   - Если false: записать причину в trace и остаться в текущем пакете.
+5. Если переходов нет или ни один невалиден — продолжить текущий пакет по его внутренней step-логике.
+
+Ключевые правила:
+- Никаких хардкодов под конкретную игру.
+- Все условия читаются из данных (admin-managed).
+- Поведение детерминировано и идемпотентно для повторной обработки чанка.
+
+---
+
+## Контракт для админки
+
+Админке нужны backend-возможности:
+
+1. CRUD для `GameScenario` (черновик/публикация/активация).
+2. Добавление/удаление нод на основе существующих `ScenarioPackage`.
+3. Управление `Transitions` между нодами с `priority` и валидатором условий.
+4. Управление `TerminalConditions`.
+5. Проверка графа перед публикацией:
+   - есть `initialNode`,
+   - все `toNodeId` существуют,
+   - нет недостижимых обязательных нод (по выбранной политике),
+   - нет конфликтов приоритета без deterministic tie-break,
+   - у каждого целевого пакета существует первый шаг с валидным `entry`-контрактом.
+6. API просмотра runtime-трассировки для стримера (что сработало/почему не перешли/почему завершили).
+
+---
+
+## План имплементации (с удалением лишнего)
+
+> План ориентирован на M2.1 и текущий `scenario-graph v2`.
+
+### Этап 1 — Аудит и зачистка
+1. Найти и удалить/изолировать код, который:
+   - обходит `Scenario Package v2` и использует legacy chain/detector,
+   - принимает решение о переходах в коде вместо data-driven условий,
+   - допускает переход в пакет без проверки guard первого шага.
+2. Удалить устаревшие admin endpoints/DTO/handlers, не соответствующие текущему контракту graph-v2.
+3. Удалить/обновить устаревшие участки документации, где описана линейная цепочка без graph-модели.
+
+### Этап 2 — Модель данных верхнего уровня
+1. Ввести доменные сущности `GameScenario`, `Node`, `Transition`, `TerminalCondition`.
+2. Добавить миграции PostgreSQL и репозитории.
+3. Реализовать версионирование и флаг активного сценария игры.
+
+### Этап 3 — Runtime orchestration
+1. Расширить match-session state указателями на текущую ноду/пакет.
+2. Реализовать детерминированный резолвер переходов между пакетами.
+3. Добавить обязательный `first-step guard` check перед входом в целевой пакет.
+4. Добавить движок terminal-условий (ранняя остановка и фиксация результата).
+5. Добавить трассировку решений (`transition accepted/rejected`, причина).
+
+### Этап 4 — Admin API/валидация графа
+1. Добавить REST endpoints для CRUD сценариев игры, нод, переходов и terminal-условий.
+2. Добавить endpoint «validate/publish» с полным набором проверок графа.
+3. Ограничить админские поверхности только актуальными сущностями graph-v2.
+
+### Этап 5 — Наблюдаемость и выдача результата
+1. Публиковать runtime-статус и финальный результат в трекинг стримера (REST/WSS).
+2. Метрики: доля успешных переходов, отказов guard-проверки, частота terminal-match, latency цикла.
+3. Алерты на аномалии (резкий рост reject по guard, зацикливание в ноде, пустые terminal).
+
+### Этап 6 — Тесты и стабилизация
+1. Table-driven тесты для:
+   - переходов между пакетами,
+   - guard первого шага,
+   - terminal-условий,
+   - приоритетов и tie-break.
+2. Интеграционные тесты worker + storage + admin publish.
+3. Нагрузочный план обновить в `docs/load_testing.md` для длинных цепочек и высокочастотных апдейтов state.
+
+---
+
+## Явно удалить как «лишнее» в рамках этой задачи
+
+- Legacy prompt-chain/detector runtime path (если ещё остался в исполняемом коде).
+- Админские CRUD, которые не участвуют в graph-v2 и не нужны для управления пакетами/переходами/terminal-условиями.
+- Документацию, где финализация игры описана без `TerminalCondition`.
+- Runtime-переходы, которые не проверяют guard первого шага целевого пакета.
+
+---
+
+## Критерии готовности
+
+1. Админ может собрать сценарий игры из готовых пакетов и опубликовать его.
+2. Worker выполняет переходы между пакетами только через `Transitions` + `first-step guard`.
+3. При совпадении `TerminalCondition` отслеживание корректно завершается.
+4. В трекинге стримера видны прогресс, причины переходов/отказов и финальный результат.
+5. В коде и документации отсутствуют активные legacy-пути, противоречащие graph-v2.
+
+---
+
+## Чеклист статуса (для каждого инкремента)
+
+### M2.1 (`docs/implementation_plan.md`)
+- [ ] Re-introduce scenario-package persistence in storage (PostgreSQL) after cleanup.
+- [ ] Implement stream capture worker pipeline (`streamlink -> chunking -> state update`).
+- [ ] Implement match-session lifecycle with persisted JSON state.
+- [ ] Ship initial Counter-Strike tracker with finalization from accumulated evidence.
+- [x] Start migration to scenario-graph orchestration.
+- [ ] Add resilient orchestration (retry/idempotency/dead-letter).
+- [ ] Publish live updates via WebSocket.
+- [ ] Provide REST history endpoints for state/final decisions.
+- [ ] Add observability metrics + drift alerts.
+
+### `docs/llm_stream_orchestration_plan.md` (Goal + canonical behavior)
+- [x] 3-уровневое поведение (root -> game folder -> concrete scenario) сохранено как база.
+- [x] Transition-логика data-driven (без hardcoded keys/paths).
+- [x] Stay-on-step fallback сохранён.
+- [ ] Верхнеуровневый graph сценариев игры (пакет->пакет) внедрён в runtime полностью.
+- [ ] TerminalCondition engine внедрён в production runtime.
+- [ ] First-step guard при переходе в новый пакет внедрён в production runtime.

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -66,6 +66,7 @@ business logic and immediate backend scope.
   finalization into `win | loss | draw | unknown` only from accumulated
   evidence.
 - [x] Start migration to scenario-graph orchestration (root game-detection step + game-folder steps + concrete game sub-steps) with condition-based transitions and stay-on-step fallback.
+- [ ] Implement Game Scenario graph orchestration over scenario-packages (node = package, edge = transition), including terminal finish conditions and first-step guard validation on package transitions.
 - [ ] Add resilient orchestration with retries, idempotency keys, and dead-letter
   handling for failed LLM jobs.
 - [ ] Publish live match-state/finalization updates to clients via WebSocket.

--- a/docs/llm_stream_orchestration_plan.md
+++ b/docs/llm_stream_orchestration_plan.md
@@ -1,5 +1,8 @@
 # LLM Stream Orchestration Plan (Scenario Graph v2)
 
+> Extension for agent-facing implementation of package-to-package game scenarios:
+> `docs/agent_game_scenario_packages_plan_ru.md`.
+
 ## Goal
 Build a single orchestration model where admin-defined **scenario steps** drive the
 LLM analysis loop.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -572,6 +572,121 @@ paths:
                 $ref: '#/components/schemas/ScenarioPackageGraph'
         default:
           $ref: '#/components/responses/Error'
+  /api/admin/llm/game-scenarios:
+    get:
+      summary: List game scenarios built from scenario packages (admin)
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Game scenarios
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GameScenario'
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create game scenario graph (admin)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GameScenarioCreateRequest'
+      responses:
+        '201':
+          description: Created game scenario graph
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameScenario'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/llm/game-scenarios/{gameScenarioId}:
+    get:
+      summary: Get game scenario graph (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: gameScenarioId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Game scenario graph
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameScenario'
+        default:
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update game scenario graph (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: gameScenarioId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GameScenarioCreateRequest'
+      responses:
+        '200':
+          description: Updated game scenario graph
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameScenario'
+        default:
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Delete game scenario graph (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: gameScenarioId
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Game scenario graph deleted
+        default:
+          $ref: '#/components/responses/Error'
+  /api/admin/llm/game-scenarios/{gameScenarioId}/activate:
+    post:
+      summary: Activate game scenario graph (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: gameScenarioId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activated game scenario graph
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameScenario'
+        default:
+          $ref: '#/components/responses/Error'
   /api/events/live:
     get:
       summary: Get live events for a streamer
@@ -1390,12 +1505,15 @@ components:
           minimum: 1
     ScenarioPackageTransition:
       type: object
-      required: [priority]
+      required: [priority, condition]
       additionalProperties: false
       properties:
         toPackageId:
           type: string
-          description: Required for package-to-package linear chain transition; optional when action is `stop_tracking`.
+          description: Required for package-to-package transition; optional when action is `stop_tracking`.
+        condition:
+          type: string
+          description: Data-driven transition expression evaluated against aggregated state. Transition is considered only when condition matches.
         priority:
           type: integer
           minimum: 1
@@ -1447,8 +1565,7 @@ components:
             $ref: '#/components/schemas/ScenarioTransition'
         packageTransitions:
           type: array
-          maxItems: 1
-          description: Optional package-level connector for strict linear chain (A -> B -> N) or terminal action. Runtime evaluates it from shared state on each cycle.
+          description: Optional package-level graph edges (node = package, edge = transition) or terminal action. Runtime evaluates transitions by priority from shared state on each cycle.
           items:
             $ref: '#/components/schemas/ScenarioPackageTransition'
         finalStateOptions:
@@ -1494,8 +1611,7 @@ components:
                 $ref: '#/components/schemas/ScenarioTransition'
             packageTransitions:
               type: array
-              maxItems: 1
-              description: Effective package-level connector used by runtime to switch to the next package in the chain or stop tracking.
+              description: Effective package-level transitions used by runtime to switch across packages or stop tracking.
               items:
                 $ref: '#/components/schemas/ScenarioPackageTransition'
             finalStateOptions:
@@ -1511,6 +1627,97 @@ components:
               description: Derived state keys and value variants aggregated from all step response schemas in the package.
               items:
                 $ref: '#/components/schemas/ScenarioStateField'
+            createdBy:
+              type: string
+            activatedBy:
+              type: string
+              nullable: true
+            createdAt:
+              type: string
+              format: date-time
+            activatedAt:
+              type: string
+              format: date-time
+              nullable: true
+    GameScenarioNode:
+      type: object
+      required: [id, scenarioPackageId]
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        alias:
+          type: string
+        scenarioPackageId:
+          type: string
+    GameScenarioTransition:
+      type: object
+      required: [fromNodeId, toNodeId, condition, priority]
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        fromNodeId:
+          type: string
+        toNodeId:
+          type: string
+        condition:
+          type: string
+        priority:
+          type: integer
+          minimum: 1
+    GameScenarioTerminalCondition:
+      type: object
+      required: [condition]
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        condition:
+          type: string
+        resultLabel:
+          type: string
+        resultStateJson:
+          type: string
+          description: Optional JSON patch applied to final state on terminal match.
+        priority:
+          type: integer
+          minimum: 1
+    GameScenarioCreateRequest:
+      type: object
+      required: [name, gameSlug, initialNodeId, nodes]
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        gameSlug:
+          type: string
+        initialNodeId:
+          type: string
+        nodes:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/GameScenarioNode'
+        transitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/GameScenarioTransition'
+        terminalConditions:
+          type: array
+          items:
+            $ref: '#/components/schemas/GameScenarioTerminalCondition'
+    GameScenario:
+      allOf:
+        - $ref: '#/components/schemas/GameScenarioCreateRequest'
+        - type: object
+          properties:
+            id:
+              type: string
+            version:
+              type: integer
+            isActive:
+              type: boolean
             createdBy:
               type: string
             activatedBy:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -88,6 +88,7 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 	for _, transition := range req.PackageTransitions {
 		packageTransitions = append(packageTransitions, prompts.ScenarioPackageTransition{
 			ToPackageID:        transition.ToPackageID,
+			Condition:          transition.Condition,
 			Priority:           transition.Priority,
 			Action:             transition.Action,
 			FinalStateOptionID: transition.FinalStateOptionID,
@@ -112,6 +113,46 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 		PackageTransitions: packageTransitions,
 		FinalStateOptions:  finalStateOptions,
 		FinalCondition:     req.FinalCondition,
+		ActorID:            actorID,
+	}
+}
+
+func gameScenarioRequestToCreateRequest(req gameScenarioCreateRequest, actorID string) prompts.GameScenarioCreateRequest {
+	nodes := make([]prompts.GameScenarioNode, 0, len(req.Nodes))
+	for _, node := range req.Nodes {
+		nodes = append(nodes, prompts.GameScenarioNode{
+			ID:                node.ID,
+			Alias:             node.Alias,
+			ScenarioPackageID: node.ScenarioPackageID,
+		})
+	}
+	transitions := make([]prompts.GameScenarioTransition, 0, len(req.Transitions))
+	for _, tr := range req.Transitions {
+		transitions = append(transitions, prompts.GameScenarioTransition{
+			ID:         tr.ID,
+			FromNodeID: tr.FromNodeID,
+			ToNodeID:   tr.ToNodeID,
+			Condition:  tr.Condition,
+			Priority:   tr.Priority,
+		})
+	}
+	terminalConditions := make([]prompts.GameScenarioTerminalCondition, 0, len(req.TerminalConditions))
+	for _, item := range req.TerminalConditions {
+		terminalConditions = append(terminalConditions, prompts.GameScenarioTerminalCondition{
+			ID:              item.ID,
+			Condition:       item.Condition,
+			ResultLabel:     item.ResultLabel,
+			ResultStateJSON: item.ResultStateJSON,
+			Priority:        item.Priority,
+		})
+	}
+	return prompts.GameScenarioCreateRequest{
+		Name:               req.Name,
+		GameSlug:           req.GameSlug,
+		InitialNodeID:      req.InitialNodeID,
+		Nodes:              nodes,
+		Transitions:        transitions,
+		TerminalConditions: terminalConditions,
 		ActorID:            actorID,
 	}
 }
@@ -156,6 +197,7 @@ type scenarioTransitionRequest struct {
 
 type scenarioPackageTransitionRequest struct {
 	ToPackageID        string `json:"toPackageId"`
+	Condition          string `json:"condition"`
 	Priority           int    `json:"priority"`
 	Action             string `json:"action"`
 	FinalStateOptionID string `json:"finalStateOptionId"`
@@ -178,6 +220,37 @@ type scenarioPackageCreateRequest struct {
 	PackageTransitions []scenarioPackageTransitionRequest `json:"packageTransitions"`
 	FinalStateOptions  []scenarioFinalStateOptionRequest  `json:"finalStateOptions"`
 	FinalCondition     string                             `json:"finalCondition"`
+}
+
+type gameScenarioNodeRequest struct {
+	ID                string `json:"id"`
+	Alias             string `json:"alias"`
+	ScenarioPackageID string `json:"scenarioPackageId"`
+}
+
+type gameScenarioTransitionRequest struct {
+	ID         string `json:"id"`
+	FromNodeID string `json:"fromNodeId"`
+	ToNodeID   string `json:"toNodeId"`
+	Condition  string `json:"condition"`
+	Priority   int    `json:"priority"`
+}
+
+type gameScenarioTerminalConditionRequest struct {
+	ID              string `json:"id"`
+	Condition       string `json:"condition"`
+	ResultLabel     string `json:"resultLabel"`
+	ResultStateJSON string `json:"resultStateJson"`
+	Priority        int    `json:"priority"`
+}
+
+type gameScenarioCreateRequest struct {
+	Name               string                                 `json:"name"`
+	GameSlug           string                                 `json:"gameSlug"`
+	InitialNodeID      string                                 `json:"initialNodeId"`
+	Nodes              []gameScenarioNodeRequest              `json:"nodes"`
+	Transitions        []gameScenarioTransitionRequest        `json:"transitions"`
+	TerminalConditions []gameScenarioTerminalConditionRequest `json:"terminalConditions"`
 }
 
 type llmModelConfigUpsertRequest struct {
@@ -993,6 +1066,124 @@ func NewHandler(
 					if err := promptsService.DeleteScenarioPackage(r.Context(), path); err != nil {
 						status := http.StatusBadRequest
 						if errors.Is(err, prompts.ErrScenarioPackageNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/llm/game-scenarios", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, promptsService.ListGameScenarios(r.Context()))
+				case http.MethodPost:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req gameScenarioCreateRequest
+					if err := decodeJSONStrict(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					created, err := promptsService.CreateGameScenario(r.Context(), gameScenarioRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusCreated, created)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+
+			mux.Handle("/api/admin/llm/game-scenarios/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/admin/llm/game-scenarios/"), "/")
+				if path == "" {
+					writeError(w, http.StatusBadRequest, "game scenario id is required")
+					return
+				}
+				if strings.HasSuffix(path, "/activate") {
+					id := strings.Trim(strings.TrimSuffix(path, "/activate"), "/")
+					if r.Method != http.MethodPost {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+						return
+					}
+					item, err := promptsService.ActivateGameScenario(r.Context(), id, claims.Subject)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrGameScenarioNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					item, err := promptsService.GetGameScenario(r.Context(), path)
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrGameScenarioNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req gameScenarioCreateRequest
+					if err := decodeJSONStrict(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					item, err := promptsService.UpdateGameScenario(r.Context(), path, gameScenarioRequestToCreateRequest(req, claims.Subject))
+					if err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrGameScenarioNotFound) {
+							status = http.StatusNotFound
+						}
+						writeError(w, status, err.Error())
+						return
+					}
+					writeJSON(w, http.StatusOK, item)
+				case http.MethodDelete:
+					if err := promptsService.DeleteGameScenario(r.Context(), path); err != nil {
+						status := http.StatusBadRequest
+						if errors.Is(err, prompts.ErrGameScenarioNotFound) {
 							status = http.StatusNotFound
 						}
 						writeError(w, status, err.Error())

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -216,5 +217,91 @@ func TestAdminLLMModelConfigRoutes(t *testing.T) {
 	handler.ServeHTTP(deleteRes, deleteReq)
 	if deleteRes.Code != http.StatusNoContent {
 		t.Fatalf("delete model config status=%d body=%s", deleteRes.Code, deleteRes.Body.String())
+	}
+}
+
+func TestAdminLLMGameScenarioRoutes(t *testing.T) {
+	promptsService := prompts.NewService()
+	cfg, err := promptsService.CreateLLMModelConfig(context.Background(), prompts.LLMModelConfigUpsertRequest{
+		Name:    "Primary",
+		Model:   "gemini-2.5-flash",
+		ActorID: "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("create llm config: %v", err)
+	}
+	rootPkg, err := promptsService.CreateScenarioPackage(context.Background(), prompts.ScenarioPackageCreateRequest{
+		Name:             "root pkg",
+		GameSlug:         "global",
+		LLMModelConfigID: cfg.ID,
+		ActorID:          "admin-1",
+		Steps: []prompts.ScenarioStep{
+			{ID: "root_step", Name: "Root", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create root package: %v", err)
+	}
+	targetPkg, err := promptsService.CreateScenarioPackage(context.Background(), prompts.ScenarioPackageCreateRequest{
+		Name:             "target pkg",
+		GameSlug:         "cs2",
+		LLMModelConfigID: cfg.ID,
+		ActorID:          "admin-1",
+		Steps: []prompts.ScenarioStep{
+			{ID: "target_step", Name: "Target", PromptTemplate: "mode", ResponseSchemaJSON: `{}`, Initial: true, Order: 1, EntryCondition: `game == "cs2"`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create target package: %v", err)
+	}
+
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), nil, streamers.NewService(), nil, promptsService, nil, nil, ClientConfigResponse{})
+	adminToken := buildToken(t, "admin-1")
+
+	createBody, _ := json.Marshal(map[string]any{
+		"name":          "cs2 game scenario",
+		"gameSlug":      "cs2",
+		"initialNodeId": "node-root",
+		"nodes": []map[string]any{
+			{"id": "node-root", "alias": "Root Node", "scenarioPackageId": rootPkg.ID},
+			{"id": "node-target", "alias": "Target Node", "scenarioPackageId": targetPkg.ID},
+		},
+		"transitions": []map[string]any{
+			{"id": "tr-1", "fromNodeId": "node-root", "toNodeId": "node-target", "condition": `game == "cs2"`, "priority": 10},
+		},
+		"terminalConditions": []map[string]any{
+			{"id": "tm-1", "condition": `winner == "ct" && side == "ct"`, "resultLabel": "ct_win", "resultStateJson": `{"result":"win"}`, "priority": 100},
+		},
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/game-scenarios", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer "+adminToken)
+	createRes := httptest.NewRecorder()
+	handler.ServeHTTP(createRes, createReq)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("game scenario create status=%d body=%s", createRes.Code, createRes.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(createRes.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created game scenario: %v", err)
+	}
+	id, _ := created["id"].(string)
+	if id == "" {
+		t.Fatalf("expected created id, got %#v", created)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/game-scenarios/"+id, nil)
+	getReq.Header.Set("Authorization", "Bearer "+adminToken)
+	getRes := httptest.NewRecorder()
+	handler.ServeHTTP(getRes, getReq)
+	if getRes.Code != http.StatusOK {
+		t.Fatalf("game scenario get status=%d body=%s", getRes.Code, getRes.Body.String())
+	}
+
+	activateReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/game-scenarios/"+id+"/activate", nil)
+	activateReq.Header.Set("Authorization", "Bearer "+adminToken)
+	activateRes := httptest.NewRecorder()
+	handler.ServeHTTP(activateRes, activateReq)
+	if activateRes.Code != http.StatusOK {
+		t.Fatalf("game scenario activate status=%d body=%s", activateRes.Code, activateRes.Body.String())
 	}
 }

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -225,7 +225,8 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 		lastDecision.StreamerID = id
 		lastDecision.TransitionTerminal = true
 		lastDecision.Label = firstNonEmpty(strings.TrimSpace(execution.TerminalLabel), strings.TrimSpace(lastDecision.Label), "tracking_stopped")
-		lastDecision.UpdatedStateJSON = firstNonEmpty(strings.TrimSpace(execution.TerminalStateJSON), strings.TrimSpace(lastDecision.UpdatedStateJSON), w.resolvePreviousState(ctx, id))
+		terminalState := firstNonEmpty(strings.TrimSpace(execution.TerminalStateJSON), strings.TrimSpace(lastDecision.UpdatedStateJSON), w.resolvePreviousState(ctx, id))
+		lastDecision.UpdatedStateJSON = enrichScenarioState(`{}`, terminalState, execution.CurrentPackageID, lastDecision.Stage, execution.TransitionTrace)
 		return lastDecision, ErrTrackingStop
 	}
 
@@ -699,6 +700,7 @@ type scenarioExecutionPlan struct {
 	StopTracking          bool
 	TerminalStateJSON     string
 	TerminalLabel         string
+	TransitionTrace       map[string]any
 	PreviousState         string
 	StartPackageID        string
 	CurrentPackageID      string
@@ -715,6 +717,10 @@ func (w *Worker) planScenarioExecution(ctx context.Context, streamerID string, p
 	}
 	activePackage := pkg
 	packageChanged := false
+	transitionTrace := map[string]any{
+		"status":      "no_transition",
+		"fromPackage": strings.TrimSpace(activePackage.ID),
+	}
 	if currentPackageID != "" && currentPackageID != startPackageID {
 		resolved, err := w.prompts.GetScenarioPackage(ctx, currentPackageID)
 		if err == nil {
@@ -724,10 +730,16 @@ func (w *Worker) planScenarioExecution(ctx context.Context, streamerID string, p
 	resolution, resolveErr := activePackage.ResolveNextPackage(previousState)
 	if resolveErr == nil {
 		if resolution.StopTracking {
+			transitionTrace = map[string]any{
+				"status":      "terminal_stop",
+				"fromPackage": strings.TrimSpace(activePackage.ID),
+				"reason":      "terminal_condition_matched",
+			}
 			return scenarioExecutionPlan{
 				StopTracking:      true,
 				TerminalStateJSON: mergeJSONState(previousState, resolution.FinalStateJSON),
 				TerminalLabel:     firstNonEmpty(strings.TrimSpace(resolution.FinalLabel), "tracking_stopped"),
+				TransitionTrace:   transitionTrace,
 				PreviousState:     previousState,
 				StartPackageID:    startPackageID,
 				CurrentPackageID:  strings.TrimSpace(activePackage.ID),
@@ -736,9 +748,32 @@ func (w *Worker) planScenarioExecution(ctx context.Context, streamerID string, p
 		if resolution.Changed {
 			nextPackage, pkgErr := w.prompts.GetScenarioPackage(ctx, resolution.PackageID)
 			if pkgErr == nil {
-				activePackage = nextPackage
-				currentPackageID = strings.TrimSpace(nextPackage.ID)
-				packageChanged = true
+				canEnter, enterErr := nextPackage.CanEnter(previousState)
+				if enterErr == nil && canEnter {
+					transitionTrace = map[string]any{
+						"status":      "accepted",
+						"fromPackage": strings.TrimSpace(activePackage.ID),
+						"toPackage":   strings.TrimSpace(nextPackage.ID),
+						"reason":      "transition_condition_and_entry_guard_matched",
+					}
+					activePackage = nextPackage
+					currentPackageID = strings.TrimSpace(nextPackage.ID)
+					packageChanged = true
+				} else {
+					transitionTrace = map[string]any{
+						"status":      "rejected",
+						"fromPackage": strings.TrimSpace(activePackage.ID),
+						"toPackage":   strings.TrimSpace(nextPackage.ID),
+						"reason":      "target_initial_entry_condition_failed",
+					}
+				}
+			} else {
+				transitionTrace = map[string]any{
+					"status":      "rejected",
+					"fromPackage": strings.TrimSpace(activePackage.ID),
+					"toPackage":   strings.TrimSpace(resolution.PackageID),
+					"reason":      "target_package_not_found",
+				}
 			}
 		}
 	}
@@ -776,6 +811,7 @@ func (w *Worker) planScenarioExecution(ctx context.Context, streamerID string, p
 		Step:                  step,
 		Entering:              entering,
 		StopTracking:          false,
+		TransitionTrace:       transitionTrace,
 		PreviousState:         previousState,
 		StartPackageID:        startPackageID,
 		CurrentPackageID:      strings.TrimSpace(activePackage.ID),
@@ -837,7 +873,7 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 	if err != nil {
 		return streamers.LLMDecision{}, err
 	}
-	result.UpdatedStateJSON = enrichScenarioState(result.UpdatedStateJSON, execution.PreviousState, pkg.ID, step.ID)
+	result.UpdatedStateJSON = enrichScenarioState(result.UpdatedStateJSON, execution.PreviousState, pkg.ID, step.ID, execution.TransitionTrace)
 	decision, err := w.processStageResult(ctx, activePrompt, result, chunk, runID, streamerID, previousState)
 	if err != nil {
 		return streamers.LLMDecision{}, err
@@ -901,7 +937,7 @@ func mergeJSONState(baseJSON, patchJSON string) string {
 	return string(body)
 }
 
-func enrichScenarioState(currentState, previousState, packageID, stepID string) string {
+func enrichScenarioState(currentState, previousState, packageID, stepID string, transitionTrace map[string]any) string {
 	base := parseJSONMap(previousState)
 	if existing, ok := base["_scenario"].(map[string]any); ok {
 		baseScenario := map[string]any{}
@@ -919,6 +955,9 @@ func enrichScenarioState(currentState, previousState, packageID, stepID string) 
 	scenarioMeta, _ := base["_scenario"].(map[string]any)
 	scenarioMeta["packageId"] = strings.TrimSpace(packageID)
 	scenarioMeta["stepId"] = strings.TrimSpace(stepID)
+	if len(transitionTrace) > 0 {
+		scenarioMeta["transition"] = transitionTrace
+	}
 	base["_scenario"] = scenarioMeta
 	body, err := json.Marshal(base)
 	if err != nil {

--- a/internal/media/worker_package_state_test.go
+++ b/internal/media/worker_package_state_test.go
@@ -5,7 +5,9 @@ import "testing"
 func TestEnrichScenarioState(t *testing.T) {
 	t.Parallel()
 
-	got := enrichScenarioState(`{"game":"cs2"}`, `{"state":{"round":3}}`, "pkg-2", "step-a")
+	got := enrichScenarioState(`{"game":"cs2"}`, `{"state":{"round":3}}`, "pkg-2", "step-a", map[string]any{
+		"status": "accepted",
+	})
 	if got == "" {
 		t.Fatalf("enrichScenarioState() returned empty state")
 	}

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -53,6 +53,7 @@ func (f fakeClassifier) Classify(_ context.Context, input StageRequest) (StageCl
 type fakePromptResolver struct {
 	prompts        []prompts.PromptVersion
 	scenario       prompts.ScenarioPackage
+	scenariosByID  map[string]prompts.ScenarioPackage
 	scenarioErr    error
 	llmModelConfig prompts.LLMModelConfig
 	llmConfigErr   error
@@ -104,6 +105,9 @@ func (f fakePromptResolver) GetActiveScenarioPackage(_ context.Context, _ string
 }
 
 func (f fakePromptResolver) GetScenarioPackage(_ context.Context, id string) (prompts.ScenarioPackage, error) {
+	if item, ok := f.scenariosByID[id]; ok {
+		return item, nil
+	}
 	if f.scenario.ID == id {
 		return f.scenario, nil
 	}
@@ -572,7 +576,9 @@ func TestWorkerProcessStreamerIgnoresRawResponseStatePayloads(t *testing.T) {
 	if len(decisions.items) != 1 {
 		t.Fatalf("recorded %d decisions, want 1", len(decisions.items))
 	}
-	if got := decisions.items[0].UpdatedStateJSON; got != `{"_scenario":{"packageId":"scenario-test","stepId":"start"}}` {
+	state := parseJSONMap(decisions.items[0].UpdatedStateJSON)
+	meta, _ := state["_scenario"].(map[string]any)
+	if meta["packageId"] != "scenario-test" || meta["stepId"] != "start" {
 		t.Fatalf("updated state = %q", decisions.items[0].UpdatedStateJSON)
 	}
 }
@@ -603,8 +609,14 @@ func TestWorkerProcessStreamerUsesLLMStateEvenWhenUnknownPlaceholdersAreReturned
 	if second.Label != "state_updated" {
 		t.Fatalf("second label = %q, want state_updated", second.Label)
 	}
-	if got := second.UpdatedStateJSON; got != `{"_scenario":{"packageId":"scenario-test","stepId":"match_update"},"final_outcome":"unknown","state":{"ct_score":0,"mode":"unknown","t_score":0}}` {
-		t.Fatalf("updated state = %q", got)
+	state := parseJSONMap(second.UpdatedStateJSON)
+	meta, _ := state["_scenario"].(map[string]any)
+	if meta["packageId"] != "scenario-test" || meta["stepId"] != "match_update" {
+		t.Fatalf("updated state = %q", second.UpdatedStateJSON)
+	}
+	payload, _ := state["state"].(map[string]any)
+	if payload["ct_score"] != float64(0) || payload["t_score"] != float64(0) || payload["mode"] != "unknown" {
+		t.Fatalf("updated state payload = %#v", payload)
 	}
 	if len(decisions.items) != 2 {
 		t.Fatalf("recorded %d decisions, want 2", len(decisions.items))
@@ -758,7 +770,7 @@ func TestWorkerProcessStreamerStopsFromPackageTransitionAndReturnsState(t *testi
 					{ID: "initial", Name: "Initial", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
 				},
 				PackageTransitions: []prompts.ScenarioPackageTransition{
-					{Priority: 1, Action: prompts.ScenarioPackageTransitionActionStopTracking, FinalStateOptionID: "ct_win"},
+					{Condition: `outcome == "ct_win"`, Priority: 1, Action: prompts.ScenarioPackageTransitionActionStopTracking, FinalStateOptionID: "ct_win"},
 				},
 				FinalStateOptions: []prompts.ScenarioFinalStateOption{
 					{ID: "ct_win", Name: "CT Win", Condition: `outcome == "ct_win" && streamer_side == "ct"`, FinalStateJSON: `{"result":"win"}`, FinalLabel: "final_ct_win"},
@@ -780,7 +792,69 @@ func TestWorkerProcessStreamerStopsFromPackageTransitionAndReturnsState(t *testi
 	if state["outcome"] != "ct_win" || state["streamer_side"] != "ct" || state["result"] != "win" {
 		t.Fatalf("expected merged terminal state, got %#v", state)
 	}
+	meta, _ := state["_scenario"].(map[string]any)
+	transition, _ := meta["transition"].(map[string]any)
+	if transition["status"] != "terminal_stop" {
+		t.Fatalf("expected terminal transition trace, got %#v", transition)
+	}
 	if decision.Label != "final_ct_win" {
 		t.Fatalf("expected final label in decision, got %s", decision.Label)
+	}
+}
+
+func TestWorkerProcessStreamerDoesNotSwitchPackageWhenInitialGuardFails(t *testing.T) {
+	decisions := &fakeDecisionStore{
+		items: []streamers.RecordDecisionRequest{
+			{StreamerID: "streamer-1", Stage: "initial", Label: "running", UpdatedStateJSON: `{"game":"cs2","mode":"no_match"}`},
+		},
+	}
+	rootPackage := prompts.ScenarioPackage{
+		ID:               "scenario-root",
+		GameSlug:         "global",
+		LLMModelConfigID: "cfg-default",
+		Steps: []prompts.ScenarioStep{
+			{ID: "initial", Name: "Initial", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+		},
+		PackageTransitions: []prompts.ScenarioPackageTransition{
+			{ToPackageID: "scenario-cs2", Condition: `game == "cs2"`, Priority: 1},
+		},
+	}
+	cs2Package := prompts.ScenarioPackage{
+		ID:               "scenario-cs2",
+		GameSlug:         "cs2",
+		LLMModelConfigID: "cfg-default",
+		Steps: []prompts.ScenarioStep{
+			{ID: "cs2_initial", Name: "CS2 Initial", PromptTemplate: "cs2", ResponseSchemaJSON: `{}`, Initial: true, Order: 1, EntryCondition: `mode == "match"`},
+		},
+	}
+	worker := NewWorker(
+		&fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Now().UTC()}},
+		fakeClassifier{results: map[string]StageClassification{"initial": {Label: "ok", Confidence: 0.9}}},
+		fakePromptResolver{
+			scenario: rootPackage,
+			scenariosByID: map[string]prompts.ScenarioPackage{
+				"scenario-root": rootPackage,
+				"scenario-cs2":  cs2Package,
+			},
+			llmModelConfig: prompts.LLMModelConfig{ID: "cfg-default", Model: "gemini-2.5-flash"},
+		},
+		&InMemoryRunStore{},
+		decisions,
+		NewInMemoryLocker(),
+		WorkerConfig{MinConfidence: 0.5},
+	)
+
+	decision, err := worker.ProcessStreamer(context.Background(), "streamer-1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	state := parseJSONMap(decision.UpdatedStateJSON)
+	meta, _ := state["_scenario"].(map[string]any)
+	if meta["packageId"] != "scenario-root" {
+		t.Fatalf("expected to stay in root package, got %#v", state)
+	}
+	transition, _ := meta["transition"].(map[string]any)
+	if transition["status"] != "rejected" {
+		t.Fatalf("expected rejected transition trace, got %#v", transition)
 	}
 }

--- a/internal/prompts/game_scenario.go
+++ b/internal/prompts/game_scenario.go
@@ -1,0 +1,291 @@
+package prompts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+var (
+	ErrGameScenarioNotFound = errors.New("game scenario not found")
+	ErrInvalidGameScenario  = errors.New("game scenario is invalid")
+)
+
+type GameScenarioNode struct {
+	ID                string `json:"id"`
+	Alias             string `json:"alias"`
+	ScenarioPackageID string `json:"scenarioPackageId"`
+}
+
+type GameScenarioTransition struct {
+	ID         string `json:"id"`
+	FromNodeID string `json:"fromNodeId"`
+	ToNodeID   string `json:"toNodeId"`
+	Condition  string `json:"condition"`
+	Priority   int    `json:"priority"`
+}
+
+type GameScenarioTerminalCondition struct {
+	ID              string `json:"id"`
+	Condition       string `json:"condition"`
+	ResultLabel     string `json:"resultLabel,omitempty"`
+	ResultStateJSON string `json:"resultStateJson,omitempty"`
+	Priority        int    `json:"priority"`
+}
+
+type GameScenario struct {
+	ID                 string                          `json:"id"`
+	Name               string                          `json:"name"`
+	GameSlug           string                          `json:"gameSlug"`
+	Version            int                             `json:"version"`
+	IsActive           bool                            `json:"isActive"`
+	InitialNodeID      string                          `json:"initialNodeId"`
+	Nodes              []GameScenarioNode              `json:"nodes"`
+	Transitions        []GameScenarioTransition        `json:"transitions"`
+	TerminalConditions []GameScenarioTerminalCondition `json:"terminalConditions"`
+	CreatedBy          string                          `json:"createdBy"`
+	ActivatedBy        string                          `json:"activatedBy,omitempty"`
+	CreatedAt          time.Time                       `json:"createdAt"`
+	ActivatedAt        time.Time                       `json:"activatedAt,omitempty"`
+}
+
+type GameScenarioCreateRequest struct {
+	Name               string
+	GameSlug           string
+	InitialNodeID      string
+	Nodes              []GameScenarioNode
+	Transitions        []GameScenarioTransition
+	TerminalConditions []GameScenarioTerminalCondition
+	ActorID            string
+}
+
+func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScenarioCreateRequest) error {
+	if strings.TrimSpace(req.Name) == "" || strings.TrimSpace(req.GameSlug) == "" {
+		return ErrInvalidGameScenario
+	}
+	if len(req.Nodes) == 0 {
+		return fmt.Errorf("%w: nodes are required", ErrInvalidGameScenario)
+	}
+	nodeIDs := make(map[string]GameScenarioNode, len(req.Nodes))
+	for _, node := range req.Nodes {
+		nodeID := strings.TrimSpace(node.ID)
+		if nodeID == "" || strings.TrimSpace(node.ScenarioPackageID) == "" {
+			return fmt.Errorf("%w: node id and scenarioPackageId are required", ErrInvalidGameScenario)
+		}
+		if _, exists := nodeIDs[nodeID]; exists {
+			return fmt.Errorf("%w: duplicated node id %s", ErrInvalidGameScenario, nodeID)
+		}
+		pkg, err := s.GetScenarioPackage(ctx, node.ScenarioPackageID)
+		if err != nil {
+			return fmt.Errorf("%w: node %s references unknown scenario package %s", ErrInvalidGameScenario, nodeID, node.ScenarioPackageID)
+		}
+		if _, err := pkg.InitialStep(); err != nil {
+			return fmt.Errorf("%w: package %s has no valid initial step", ErrInvalidGameScenario, node.ScenarioPackageID)
+		}
+		nodeIDs[nodeID] = node
+	}
+	if _, ok := nodeIDs[strings.TrimSpace(req.InitialNodeID)]; !ok {
+		return fmt.Errorf("%w: initialNodeId must reference existing node", ErrInvalidGameScenario)
+	}
+	for _, tr := range req.Transitions {
+		if _, ok := nodeIDs[strings.TrimSpace(tr.FromNodeID)]; !ok {
+			return fmt.Errorf("%w: transition fromNodeId %s not found", ErrInvalidGameScenario, tr.FromNodeID)
+		}
+		toNode, ok := nodeIDs[strings.TrimSpace(tr.ToNodeID)]
+		if !ok {
+			return fmt.Errorf("%w: transition toNodeId %s not found", ErrInvalidGameScenario, tr.ToNodeID)
+		}
+		if strings.TrimSpace(tr.Condition) == "" {
+			return fmt.Errorf("%w: transition condition is required", ErrInvalidGameScenario)
+		}
+		if err := validateScenarioCondition(tr.Condition); err != nil {
+			return fmt.Errorf("%w: transition condition: %v", ErrInvalidGameScenario, err)
+		}
+		pkg, err := s.GetScenarioPackage(ctx, toNode.ScenarioPackageID)
+		if err != nil {
+			return fmt.Errorf("%w: transition target package %s not found", ErrInvalidGameScenario, toNode.ScenarioPackageID)
+		}
+		if _, err := pkg.InitialStep(); err != nil {
+			return fmt.Errorf("%w: transition target package %s has no initial step", ErrInvalidGameScenario, toNode.ScenarioPackageID)
+		}
+	}
+	for _, tc := range req.TerminalConditions {
+		if strings.TrimSpace(tc.Condition) == "" {
+			return fmt.Errorf("%w: terminal condition is required", ErrInvalidGameScenario)
+		}
+		if err := validateScenarioCondition(tc.Condition); err != nil {
+			return fmt.Errorf("%w: terminal condition: %v", ErrInvalidGameScenario, err)
+		}
+		if strings.TrimSpace(tc.ResultStateJSON) != "" && !isValidJSON(tc.ResultStateJSON) {
+			return fmt.Errorf("%w: terminal resultStateJson must be valid json", ErrInvalidGameScenario)
+		}
+	}
+	return nil
+}
+
+func (s *Service) ListGameScenarios(ctx context.Context) []GameScenario {
+	_ = ctx
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]GameScenario, 0)
+	for _, versions := range s.gameScenarios {
+		items = append(items, versions...)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].GameSlug == items[j].GameSlug {
+			return items[i].Version > items[j].Version
+		}
+		return items[i].GameSlug < items[j].GameSlug
+	})
+	return items
+}
+
+func (s *Service) CreateGameScenario(ctx context.Context, req GameScenarioCreateRequest) (GameScenario, error) {
+	if err := s.validateGameScenarioRequest(ctx, req); err != nil {
+		return GameScenario{}, err
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.counter++
+	versions := s.gameScenarios[req.GameSlug]
+	item := GameScenario{
+		ID:                 fmt.Sprintf("game-scenario-%d", s.counter),
+		Name:               strings.TrimSpace(req.Name),
+		GameSlug:           strings.TrimSpace(req.GameSlug),
+		Version:            len(versions) + 1,
+		InitialNodeID:      strings.TrimSpace(req.InitialNodeID),
+		Nodes:              append([]GameScenarioNode(nil), req.Nodes...),
+		Transitions:        append([]GameScenarioTransition(nil), req.Transitions...),
+		TerminalConditions: append([]GameScenarioTerminalCondition(nil), req.TerminalConditions...),
+		CreatedBy:          strings.TrimSpace(req.ActorID),
+		CreatedAt:          now,
+	}
+	if len(versions) == 0 {
+		item.IsActive = true
+		item.ActivatedBy = strings.TrimSpace(req.ActorID)
+		item.ActivatedAt = now
+	}
+	s.gameScenarios[req.GameSlug] = append(versions, item)
+	return item, nil
+}
+
+func (s *Service) GetGameScenario(ctx context.Context, id string) (GameScenario, error) {
+	_ = ctx
+	lookup := strings.TrimSpace(id)
+	if lookup == "" {
+		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, versions := range s.gameScenarios {
+		for _, item := range versions {
+			if item.ID == lookup {
+				return item, nil
+			}
+		}
+	}
+	return GameScenario{}, ErrGameScenarioNotFound
+}
+
+func (s *Service) UpdateGameScenario(ctx context.Context, id string, req GameScenarioCreateRequest) (GameScenario, error) {
+	if err := s.validateGameScenarioRequest(ctx, req); err != nil {
+		return GameScenario{}, err
+	}
+	lookup := strings.TrimSpace(id)
+	if lookup == "" {
+		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for slug, versions := range s.gameScenarios {
+		for i, item := range versions {
+			if item.ID != lookup {
+				continue
+			}
+			updated := item
+			updated.Name = strings.TrimSpace(req.Name)
+			updated.GameSlug = strings.TrimSpace(req.GameSlug)
+			updated.InitialNodeID = strings.TrimSpace(req.InitialNodeID)
+			updated.Nodes = append([]GameScenarioNode(nil), req.Nodes...)
+			updated.Transitions = append([]GameScenarioTransition(nil), req.Transitions...)
+			updated.TerminalConditions = append([]GameScenarioTerminalCondition(nil), req.TerminalConditions...)
+			if updated.GameSlug != slug {
+				updated.IsActive = false
+				updated.ActivatedBy = ""
+				updated.ActivatedAt = time.Time{}
+				s.gameScenarios[slug] = append(versions[:i], versions[i+1:]...)
+				s.gameScenarios[updated.GameSlug] = append(s.gameScenarios[updated.GameSlug], updated)
+			} else {
+				versions[i] = updated
+				s.gameScenarios[slug] = versions
+			}
+			return updated, nil
+		}
+	}
+	return GameScenario{}, ErrGameScenarioNotFound
+}
+
+func (s *Service) DeleteGameScenario(ctx context.Context, id string) error {
+	_ = ctx
+	lookup := strings.TrimSpace(id)
+	if lookup == "" {
+		return ErrGameScenarioNotFound
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for slug, versions := range s.gameScenarios {
+		for i, item := range versions {
+			if item.ID != lookup {
+				continue
+			}
+			s.gameScenarios[slug] = append(versions[:i], versions[i+1:]...)
+			return nil
+		}
+	}
+	return ErrGameScenarioNotFound
+}
+
+func (s *Service) ActivateGameScenario(ctx context.Context, id, actorID string) (GameScenario, error) {
+	_ = ctx
+	lookup := strings.TrimSpace(id)
+	if lookup == "" {
+		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for slug, versions := range s.gameScenarios {
+		active := -1
+		for i := range versions {
+			if versions[i].ID == lookup {
+				active = i
+				break
+			}
+		}
+		if active == -1 {
+			continue
+		}
+		now := time.Now().UTC()
+		for i := range versions {
+			versions[i].IsActive = i == active
+			if versions[i].IsActive {
+				versions[i].ActivatedBy = strings.TrimSpace(actorID)
+				versions[i].ActivatedAt = now
+			} else {
+				versions[i].ActivatedBy = ""
+				versions[i].ActivatedAt = time.Time{}
+			}
+		}
+		s.gameScenarios[slug] = versions
+		return versions[active], nil
+	}
+	return GameScenario{}, ErrGameScenarioNotFound
+}
+
+func isValidJSON(raw string) bool {
+	return json.Valid([]byte(strings.TrimSpace(raw)))
+}

--- a/internal/prompts/game_scenario_test.go
+++ b/internal/prompts/game_scenario_test.go
@@ -1,0 +1,104 @@
+package prompts
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestGameScenarioCRUD(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	cfg := mustCreateModelConfig(t, svc)
+	rootPkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "root",
+		GameSlug:         "global",
+		LLMModelConfigID: cfg.ID,
+		ActorID:          "admin-1",
+		Steps: []ScenarioStep{
+			{ID: "root", Name: "root", PromptTemplate: "x", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create root package: %v", err)
+	}
+	nextPkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "next",
+		GameSlug:         "cs2",
+		LLMModelConfigID: cfg.ID,
+		ActorID:          "admin-1",
+		Steps: []ScenarioStep{
+			{ID: "next", Name: "next", PromptTemplate: "x", ResponseSchemaJSON: `{}`, Initial: true, Order: 1, EntryCondition: `game == "cs2"`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create next package: %v", err)
+	}
+
+	created, err := svc.CreateGameScenario(context.Background(), GameScenarioCreateRequest{
+		Name:          "cs2 tournament",
+		GameSlug:      "cs2",
+		InitialNodeID: "n1",
+		Nodes: []GameScenarioNode{
+			{ID: "n1", ScenarioPackageID: rootPkg.ID},
+			{ID: "n2", ScenarioPackageID: nextPkg.ID},
+		},
+		Transitions:        []GameScenarioTransition{{FromNodeID: "n1", ToNodeID: "n2", Condition: `game == "cs2"`, Priority: 10}},
+		TerminalConditions: []GameScenarioTerminalCondition{{Condition: `winner == "ct"`, ResultLabel: "ct_win", ResultStateJSON: `{"result":"win"}`, Priority: 100}},
+		ActorID:            "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateGameScenario() error = %v", err)
+	}
+	if created.ID == "" || created.InitialNodeID != "n1" {
+		t.Fatalf("unexpected created game scenario: %#v", created)
+	}
+	loaded, err := svc.GetGameScenario(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetGameScenario() error = %v", err)
+	}
+	if loaded.Name != "cs2 tournament" {
+		t.Fatalf("unexpected loaded name %q", loaded.Name)
+	}
+
+	activated, err := svc.ActivateGameScenario(context.Background(), created.ID, "admin-1")
+	if err != nil {
+		t.Fatalf("ActivateGameScenario() error = %v", err)
+	}
+	if !activated.IsActive {
+		t.Fatalf("expected active game scenario")
+	}
+}
+
+func TestGameScenarioCreateRejectsMissingTransitionCondition(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	cfg := mustCreateModelConfig(t, svc)
+	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "root",
+		GameSlug:         "global",
+		LLMModelConfigID: cfg.ID,
+		ActorID:          "admin-1",
+		Steps:            []ScenarioStep{{ID: "root", Name: "root", PromptTemplate: "x", ResponseSchemaJSON: `{}`, Initial: true, Order: 1}},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+
+	_, err = svc.CreateGameScenario(context.Background(), GameScenarioCreateRequest{
+		Name:          "invalid",
+		GameSlug:      "cs2",
+		InitialNodeID: "n1",
+		Nodes:         []GameScenarioNode{{ID: "n1", ScenarioPackageID: pkg.ID}},
+		Transitions:   []GameScenarioTransition{{FromNodeID: "n1", ToNodeID: "n1", Priority: 1}},
+		ActorID:       "admin-1",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !errors.Is(err, ErrInvalidGameScenario) {
+		t.Fatalf("expected ErrInvalidGameScenario, got %v", err)
+	}
+}

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -21,7 +21,6 @@ var (
 	ErrInvalidScenarioCondition = errors.New("scenario step entry condition is invalid")
 	ErrInvalidScenarioModelRef  = errors.New("scenario package llmModelConfigId must not be empty")
 	ErrInvalidScenarioName      = errors.New("scenario package name must not be empty")
-	ErrInvalidPackageChain      = errors.New("scenario package must have at most one package transition")
 )
 
 type ScenarioStep struct {
@@ -48,6 +47,7 @@ type ScenarioTransition struct {
 
 type ScenarioPackageTransition struct {
 	ToPackageID        string `json:"toPackageId"`
+	Condition          string `json:"condition,omitempty"`
 	Priority           int    `json:"priority"`
 	Action             string `json:"action,omitempty"`
 	FinalStateOptionID string `json:"finalStateOptionId,omitempty"`
@@ -178,9 +178,6 @@ func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) erro
 			return fmt.Errorf("%w: transition %s -> %s: %v", ErrInvalidScenarioCondition, from, to, err)
 		}
 	}
-	if len(req.PackageTransitions) > 1 {
-		return ErrInvalidPackageChain
-	}
 	optionByID := make(map[string]ScenarioFinalStateOption, len(req.FinalStateOptions))
 	for _, option := range req.FinalStateOptions {
 		id := strings.TrimSpace(option.ID)
@@ -207,6 +204,12 @@ func ValidateScenarioPackageCreateRequest(req ScenarioPackageCreateRequest) erro
 		action := normalizeScenarioPackageTransitionAction(transition.Action)
 		if strings.TrimSpace(transition.ToPackageID) == "" && action != ScenarioPackageTransitionActionStopTracking {
 			return fmt.Errorf("%w: package transition toPackageId is required", ErrInvalidScenarioStepID)
+		}
+		if strings.TrimSpace(transition.Condition) == "" {
+			return fmt.Errorf("%w: package transition condition is required", ErrInvalidScenarioCondition)
+		}
+		if err := validateScenarioCondition(transition.Condition); err != nil {
+			return fmt.Errorf("%w: package transition condition: %v", ErrInvalidScenarioCondition, err)
 		}
 		optionID := strings.TrimSpace(transition.FinalStateOptionID)
 		if optionID != "" {
@@ -321,6 +324,7 @@ func normalizeScenarioPackageTransitions(transitions []ScenarioPackageTransition
 	for _, tr := range transitions {
 		next := ScenarioPackageTransition{
 			ToPackageID:        strings.TrimSpace(tr.ToPackageID),
+			Condition:          strings.TrimSpace(tr.Condition),
 			Priority:           tr.Priority,
 			Action:             normalizeScenarioPackageTransitionAction(tr.Action),
 			FinalStateOptionID: strings.TrimSpace(tr.FinalStateOptionID),
@@ -876,13 +880,8 @@ func (p ScenarioPackage) ResolveNextPackage(stateJSON string) (ScenarioPackageRe
 	}
 	sort.Slice(transitions, func(i, j int) bool { return transitions[i].Priority > transitions[j].Priority })
 	for _, tr := range transitions {
-		condition := strings.TrimSpace(p.FinalCondition)
+		condition := strings.TrimSpace(tr.Condition)
 		optionID := strings.TrimSpace(tr.FinalStateOptionID)
-		if condition == "" && optionID != "" {
-			if option, ok := optionsByID[optionID]; ok {
-				condition = strings.TrimSpace(option.Condition)
-			}
-		}
 		matched, err := evaluateCondition(condition, state)
 		if err != nil || !matched {
 			continue
@@ -906,6 +905,15 @@ func (p ScenarioPackage) ResolveNextPackage(stateJSON string) (ScenarioPackageRe
 		return ScenarioPackageResolution{PackageID: target, Changed: true}, nil
 	}
 	return ScenarioPackageResolution{PackageID: currentPackageID}, nil
+}
+
+func (p ScenarioPackage) CanEnter(stateJSON string) (bool, error) {
+	initial, err := p.InitialStep()
+	if err != nil {
+		return false, err
+	}
+	state := parseJSONMap(stateJSON)
+	return evaluateCondition(initial.EntryCondition, state)
 }
 
 func (p ScenarioPackage) InitialStep() (ScenarioStep, error) {

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -604,13 +604,13 @@ func TestScenarioPackageCreateAppliesStepDefaults(t *testing.T) {
 	}
 }
 
-func TestScenarioPackageCreateRejectsMultiplePackageTransitions(t *testing.T) {
+func TestScenarioPackageCreateAcceptsMultiplePackageTransitions(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService()
 	config := mustCreateModelConfig(t, svc)
-	_, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
-		Name:             "linear chain only",
+	item, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "graph transitions",
 		GameSlug:         "global",
 		ActorID:          "admin-1",
 		LLMModelConfigID: config.ID,
@@ -618,15 +618,15 @@ func TestScenarioPackageCreateRejectsMultiplePackageTransitions(t *testing.T) {
 			{ID: "initial", Name: "Initial", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
 		},
 		PackageTransitions: []ScenarioPackageTransition{
-			{ToPackageID: "pkg-2", Priority: 1},
-			{ToPackageID: "pkg-3", Priority: 1},
+			{ToPackageID: "pkg-cs2", Condition: `game == "cs2"`, Priority: 2},
+			{ToPackageID: "pkg-dota2", Condition: `game == "dota2"`, Priority: 1},
 		},
 	})
-	if err == nil {
-		t.Fatalf("expected linear chain validation error")
+	if err != nil {
+		t.Fatalf("expected package graph transitions to be accepted, got %v", err)
 	}
-	if !errors.Is(err, ErrInvalidPackageChain) {
-		t.Fatalf("expected ErrInvalidPackageChain, got %v", err)
+	if len(item.PackageTransitions) != 2 {
+		t.Fatalf("expected 2 package transitions, got %#v", item.PackageTransitions)
 	}
 }
 
@@ -647,7 +647,7 @@ func TestScenarioPackageCreateAcceptsFinalStateOptionInPackageTransition(t *test
 			{ID: "ct_win", Name: "CT Win", Condition: `outcome == "ct_win" && streamer_side == "ct"`, FinalStateJSON: `{"result":"win"}`, FinalLabel: "ct_win"},
 		},
 		PackageTransitions: []ScenarioPackageTransition{
-			{Priority: 1, Action: ScenarioPackageTransitionActionStopTracking, FinalStateOptionID: "ct_win"},
+			{Condition: `outcome == "ct_win"`, Priority: 1, Action: ScenarioPackageTransitionActionStopTracking, FinalStateOptionID: "ct_win"},
 		},
 	})
 	if err != nil {
@@ -655,6 +655,31 @@ func TestScenarioPackageCreateAcceptsFinalStateOptionInPackageTransition(t *test
 	}
 	if len(item.FinalStateOptions) != 1 || item.FinalStateOptions[0].ID != "ct_win" {
 		t.Fatalf("expected final state option to be persisted, got %#v", item.FinalStateOptions)
+	}
+}
+
+func TestScenarioPackageCreateRejectsInvalidPackageTransitionCondition(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	config := mustCreateModelConfig(t, svc)
+	_, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "invalid package transition condition",
+		GameSlug:         "global",
+		ActorID:          "admin-1",
+		LLMModelConfigID: config.ID,
+		Steps: []ScenarioStep{
+			{ID: "initial", Name: "Initial", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+		},
+		PackageTransitions: []ScenarioPackageTransition{
+			{ToPackageID: "pkg-cs2", Condition: `game ~~ "cs2"`, Priority: 1},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected invalid condition error")
+	}
+	if !errors.Is(err, ErrInvalidScenarioCondition) {
+		t.Fatalf("expected ErrInvalidScenarioCondition, got %v", err)
 	}
 }
 

--- a/internal/prompts/scenario_package_transitions_test.go
+++ b/internal/prompts/scenario_package_transitions_test.go
@@ -8,7 +8,7 @@ func TestScenarioPackageResolveNextPackage(t *testing.T) {
 	pkg := ScenarioPackage{
 		ID: "pkg-root",
 		PackageTransitions: []ScenarioPackageTransition{
-			{ToPackageID: "pkg-cs2", Priority: 10},
+			{ToPackageID: "pkg-cs2", Condition: `game == "cs2"`, Priority: 10},
 		},
 	}
 
@@ -30,8 +30,8 @@ func TestScenarioPackageResolveNextPackage(t *testing.T) {
 	if resolution.StopTracking {
 		t.Fatalf("ResolveNextPackage() fallback stop=%v, want false", resolution.StopTracking)
 	}
-	if !resolution.Changed || resolution.PackageID != "pkg-cs2" {
-		t.Fatalf("ResolveNextPackage() fallback = (%q,%v), want (pkg-cs2,true)", resolution.PackageID, resolution.Changed)
+	if resolution.Changed || resolution.PackageID != "pkg-root" {
+		t.Fatalf("ResolveNextPackage() fallback = (%q,%v), want (pkg-root,false)", resolution.PackageID, resolution.Changed)
 	}
 }
 
@@ -44,7 +44,7 @@ func TestScenarioPackageResolveNextPackageStopTracking(t *testing.T) {
 			{ID: "ct_win", Name: "CT win", Condition: `outcome == "ct_win"`, FinalStateJSON: `{"result":"win"}`, FinalLabel: "ct_win"},
 		},
 		PackageTransitions: []ScenarioPackageTransition{
-			{Priority: 1, Action: ScenarioPackageTransitionActionStopTracking, FinalStateOptionID: "ct_win"},
+			{Condition: `outcome == "ct_win"`, Priority: 1, Action: ScenarioPackageTransitionActionStopTracking, FinalStateOptionID: "ct_win"},
 		},
 		FinalCondition: `outcome == "ct_win"`,
 	}
@@ -75,5 +75,31 @@ func TestScenarioPackageResolveNextPackageStopTracking(t *testing.T) {
 	}
 	if resolution.StopTracking {
 		t.Fatalf("ResolveNextPackage() final condition mismatch stop=%v, want false", resolution.StopTracking)
+	}
+}
+
+func TestScenarioPackageCanEnterByInitialStepCondition(t *testing.T) {
+	t.Parallel()
+
+	pkg := ScenarioPackage{
+		ID: "pkg-cs2",
+		Steps: []ScenarioStep{
+			{ID: "initial", Initial: true, EntryCondition: `game == "cs2"`},
+		},
+	}
+	ok, err := pkg.CanEnter(`{"game":"cs2"}`)
+	if err != nil {
+		t.Fatalf("CanEnter() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("CanEnter() = false, want true")
+	}
+
+	ok, err = pkg.CanEnter(`{"game":"dota2"}`)
+	if err != nil {
+		t.Fatalf("CanEnter() mismatch error = %v", err)
+	}
+	if ok {
+		t.Fatalf("CanEnter() = true, want false")
 	}
 }

--- a/internal/prompts/service.go
+++ b/internal/prompts/service.go
@@ -11,6 +11,7 @@ type Service struct {
 	counter          int
 	configCounter    int
 	scenarioPackages map[string][]ScenarioPackage
+	gameScenarios    map[string][]GameScenario
 	modelConfigs     map[string]LLMModelConfig
 	modelConfigStore modelConfigStore
 	scenarioStore    scenarioPackageStore
@@ -19,6 +20,7 @@ type Service struct {
 func NewService() *Service {
 	return &Service{
 		scenarioPackages: map[string][]ScenarioPackage{},
+		gameScenarios:    map[string][]GameScenario{},
 		modelConfigs:     map[string]LLMModelConfig{},
 	}
 }


### PR DESCRIPTION
### Motivation
- Introduce a top-level game scenario graph to orchestrate chains of existing `ScenarioPackage` objects with data-driven transitions and explicit terminal conditions. 
- Ensure runtime determinism by requiring a `first-step` guard on package entry and by tracing why transitions were accepted/rejected. 
- Provide admin CRUD and validation for game scenarios so admins can compose packages into graphs and publish active scenarios. 
- Replace legacy linear package chaining with a data-driven graph model for future extensions and observability. 

### Description
- Added agent-facing documentation `docs/agent_game_scenario_packages_plan_ru.md` and updated `docs/implementation_plan.md` and `docs/llm_stream_orchestration_plan.md` to include the GameScenario plan. 
- Extended OpenAPI (`docs/openapi.yaml`) with new admin endpoints under `/api/admin/llm/game-scenarios` and new schemas `GameScenario`, `GameScenarioNode`, `GameScenarioTransition` and `GameScenarioTerminalCondition`. 
- Implemented admin HTTP handlers and request mappings in `internal/app/router.go` including `gameScenarioRequestToCreateRequest` and new request types to accept/validate game scenario payloads. 
- Added in-memory game scenario domain and service logic in `internal/prompts/game_scenario.go` with CRUD, validation (`validateGameScenarioRequest`), listing and activation semantics. 
- Evolved scenario package flow in `internal/prompts/scenario_flow.go` to require `Condition` on package transitions, evaluate transition conditions in `ResolveNextPackage`, and added `CanEnter` to verify a target package's initial step `EntryCondition`. 
- Enhanced runtime worker in `internal/media/worker.go` to compute a `TransitionTrace`, check `CanEnter` before switching packages, propagate transition trace into scenario state via `enrichScenarioState`, and handle terminal-stop traces. 
- Updated and added unit tests across packages (`internal/prompts/*`, `internal/media/*`, `internal/app/*`) to cover CRUD, package transitions, `CanEnter` guard behavior, trace enrichment and admin routing. 

### Testing
- Ran the full unit test suite with `go test ./...` and all tests passed. 
- Added unit tests `TestGameScenarioCRUD`, `TestGameScenarioCreateRejectsMissingTransitionCondition`, `TestScenarioPackageCanEnterByInitialStepCondition`, `TestAdminLLMGameScenarioRoutes`, `TestWorkerProcessStreamerDoesNotSwitchPackageWhenInitialGuardFails` and others which exercised validation, router handlers, worker transitions and state enrichment and they succeeded. 
- Existing scenario package and worker tests were updated to reflect new package transition `condition` semantics and all updated tests passed. 
- No integration or load tests were included in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e8d80a4c832cacf0ea59d7618014)