### PR TITLE
Switch streamer tracking runtime to Game Scenario entrypoint

### DIFF
--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -77,6 +77,7 @@ type StageClassifier interface {
 }
 
 type PromptResolver interface {
+	GetActiveGameScenario(ctx context.Context, gameSlug string) (prompts.GameScenario, error)
 	GetActiveScenarioPackage(ctx context.Context, gameSlug string) (prompts.ScenarioPackage, error)
 	GetScenarioPackage(ctx context.Context, id string) (prompts.ScenarioPackage, error)
 	GetLLMModelConfig(ctx context.Context, id string) (prompts.LLMModelConfig, error)
@@ -195,14 +196,28 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 		logger.Info("streamer processing lock released", zap.String("streamerID", id), zap.String("lockKey", lockKey))
 	}()
 
-	pkg, err := w.prompts.GetActiveScenarioPackage(ctx, "global")
+	gameScenario, err := w.prompts.GetActiveGameScenario(ctx, "global")
 	if err != nil {
-		logger.Error("active scenario package lookup failed", zap.String("streamerID", id), zap.String("gameSlug", "global"), zap.Error(err))
+		logger.Error("active game scenario lookup failed", zap.String("streamerID", id), zap.String("gameSlug", "global"), zap.Error(err))
+		w.metrics.recordFailure(ctx, id, "lookup_game_scenario")
+		w.metrics.recordCycle(ctx, id, "failed")
+		return streamers.LLMDecision{}, err
+	}
+	rootNode, err := gameScenario.InitialNode()
+	if err != nil {
+		logger.Error("game scenario initial node resolve failed", zap.String("streamerID", id), zap.String("gameScenarioID", gameScenario.ID), zap.Error(err))
+		w.metrics.recordFailure(ctx, id, "resolve_game_scenario_initial")
+		w.metrics.recordCycle(ctx, id, "failed")
+		return streamers.LLMDecision{}, err
+	}
+	pkg, err := w.prompts.GetScenarioPackage(ctx, rootNode.ScenarioPackageID)
+	if err != nil {
+		logger.Error("initial scenario package lookup failed", zap.String("streamerID", id), zap.String("gameScenarioID", gameScenario.ID), zap.String("packageID", rootNode.ScenarioPackageID), zap.Error(err))
 		w.metrics.recordFailure(ctx, id, "lookup_scenario_package")
 		w.metrics.recordCycle(ctx, id, "failed")
 		return streamers.LLMDecision{}, err
 	}
-	execution, err := w.planScenarioExecution(ctx, id, pkg)
+	execution, err := w.planScenarioExecution(ctx, id, gameScenario, pkg)
 	if err != nil {
 		if errors.Is(err, ErrTrackingStop) {
 			w.metrics.recordCycle(ctx, id, "tracking_stop")
@@ -272,7 +287,7 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 		if execution.CurrentPackageID != "" && execution.StartPackageID != "" && execution.CurrentPackageID != execution.StartPackageID {
 			rootPkg, rootErr := w.prompts.GetScenarioPackage(ctx, execution.StartPackageID)
 			if rootErr == nil {
-				rootExecution, planErr := w.planScenarioExecution(ctx, id, rootPkg)
+				rootExecution, planErr := w.planScenarioExecution(ctx, id, gameScenario, rootPkg)
 				if planErr == nil {
 					lastDecision, err = w.processExecutionPlan(ctx, runID, id, chunk, rootPkg, rootExecution)
 				}
@@ -412,7 +427,9 @@ func (w *Worker) processStageResult(ctx context.Context, activePrompt prompts.Pr
 }
 
 func hasConcreteTrackerChange(previousState, updatedState, evidenceDelta, conflicts, finalOutcome string) bool {
-	if normalizeStateJSON(previousState) != normalizeStateJSON(updatedState) {
+	prevNormalized := normalizeStateJSONWithoutScenario(previousState)
+	updatedNormalized := normalizeStateJSONWithoutScenario(updatedState)
+	if prevNormalized != updatedNormalized {
 		return true
 	}
 	if normalized := normalizeStateJSON(evidenceDelta); normalized != "" && normalized != "[]" {
@@ -423,6 +440,16 @@ func hasConcreteTrackerChange(previousState, updatedState, evidenceDelta, confli
 	}
 	outcome := strings.TrimSpace(strings.ToLower(finalOutcome))
 	return outcome != "" && outcome != "unknown"
+}
+
+func normalizeStateJSONWithoutScenario(raw string) string {
+	state := parseJSONMap(raw)
+	delete(state, "_scenario")
+	body, err := json.Marshal(state)
+	if err != nil {
+		return ""
+	}
+	return string(body)
 }
 
 func (w *Worker) resolvePreviousState(ctx context.Context, streamerID string) string {
@@ -707,25 +734,57 @@ type scenarioExecutionPlan struct {
 	CurrentPackageChanged bool
 }
 
-func (w *Worker) planScenarioExecution(ctx context.Context, streamerID string, pkg prompts.ScenarioPackage) (scenarioExecutionPlan, error) {
+func (w *Worker) planScenarioExecution(ctx context.Context, streamerID string, gameScenario prompts.GameScenario, pkg prompts.ScenarioPackage) (scenarioExecutionPlan, error) {
 	latest := w.latestDecisionByStreamer(ctx, streamerID)
 	previousState := w.resolvePreviousState(ctx, streamerID)
 	startPackageID := strings.TrimSpace(pkg.ID)
-	currentPackageID := scenarioStatePackageID(previousState)
-	if currentPackageID == "" {
-		currentPackageID = startPackageID
+	currentNodeID := scenarioStateNodeID(previousState)
+	resolvedNode, nodeChanged, err := gameScenario.ResolveNode(currentNodeID, previousState)
+	if err != nil {
+		return scenarioExecutionPlan{}, err
+	}
+	currentPackageID := startPackageID
+	if strings.TrimSpace(resolvedNode.ScenarioPackageID) != "" {
+		currentPackageID = strings.TrimSpace(resolvedNode.ScenarioPackageID)
 	}
 	activePackage := pkg
-	packageChanged := false
+	if currentPackageID != "" && currentPackageID != startPackageID {
+		resolved, pkgErr := w.prompts.GetScenarioPackage(ctx, currentPackageID)
+		if pkgErr != nil {
+			return scenarioExecutionPlan{}, pkgErr
+		}
+		activePackage = resolved
+	}
+	packageChanged := nodeChanged || currentPackageID != startPackageID
 	transitionTrace := map[string]any{
 		"status":      "no_transition",
-		"fromPackage": strings.TrimSpace(activePackage.ID),
+		"fromNode":    firstNonEmpty(strings.TrimSpace(currentNodeID), strings.TrimSpace(gameScenario.InitialNodeID)),
+		"toNode":      strings.TrimSpace(resolvedNode.ID),
+		"fromPackage": strings.TrimSpace(startPackageID),
+		"toPackage":   strings.TrimSpace(currentPackageID),
 	}
-	if currentPackageID != "" && currentPackageID != startPackageID {
-		resolved, err := w.prompts.GetScenarioPackage(ctx, currentPackageID)
-		if err == nil {
-			activePackage = resolved
+	if nodeChanged {
+		transitionTrace["status"] = "accepted"
+		transitionTrace["reason"] = "game_scenario_transition_matched"
+	}
+	if terminal, ok, terminalErr := gameScenario.ResolveTerminalCondition(previousState); terminalErr != nil {
+		return scenarioExecutionPlan{}, terminalErr
+	} else if ok {
+		transitionTrace = map[string]any{
+			"status":      "terminal_stop",
+			"fromNode":    strings.TrimSpace(resolvedNode.ID),
+			"fromPackage": strings.TrimSpace(activePackage.ID),
+			"reason":      "game_scenario_terminal_condition_matched",
 		}
+		return scenarioExecutionPlan{
+			StopTracking:      true,
+			TerminalStateJSON: mergeJSONState(previousState, terminal.ResultStateJSON),
+			TerminalLabel:     firstNonEmpty(strings.TrimSpace(terminal.ResultLabel), "tracking_stopped"),
+			TransitionTrace:   transitionTrace,
+			PreviousState:     previousState,
+			StartPackageID:    startPackageID,
+			CurrentPackageID:  strings.TrimSpace(activePackage.ID),
+		}, nil
 	}
 	resolution, resolveErr := activePackage.ResolveNextPackage(previousState)
 	if resolveErr == nil {
@@ -955,6 +1014,12 @@ func enrichScenarioState(currentState, previousState, packageID, stepID string, 
 	scenarioMeta, _ := base["_scenario"].(map[string]any)
 	scenarioMeta["packageId"] = strings.TrimSpace(packageID)
 	scenarioMeta["stepId"] = strings.TrimSpace(stepID)
+	if toNode, ok := transitionTrace["toNode"]; ok {
+		nodeID := strings.TrimSpace(fmt.Sprint(toNode))
+		if nodeID != "" {
+			scenarioMeta["gameScenarioNodeId"] = nodeID
+		}
+	}
 	if len(transitionTrace) > 0 {
 		scenarioMeta["transition"] = transitionTrace
 	}
@@ -977,4 +1042,17 @@ func scenarioStatePackageID(stateJSON string) string {
 		return ""
 	}
 	return strings.TrimSpace(fmt.Sprint(meta["packageId"]))
+}
+
+func scenarioStateNodeID(stateJSON string) string {
+	state := parseJSONMap(stateJSON)
+	raw, ok := state["_scenario"]
+	if !ok {
+		return ""
+	}
+	meta, ok := raw.(map[string]any)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(meta["gameScenarioNodeId"]))
 }

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -52,11 +52,35 @@ func (f fakeClassifier) Classify(_ context.Context, input StageRequest) (StageCl
 
 type fakePromptResolver struct {
 	prompts        []prompts.PromptVersion
+	gameScenario   prompts.GameScenario
 	scenario       prompts.ScenarioPackage
 	scenariosByID  map[string]prompts.ScenarioPackage
 	scenarioErr    error
 	llmModelConfig prompts.LLMModelConfig
 	llmConfigErr   error
+}
+
+func (f fakePromptResolver) GetActiveGameScenario(_ context.Context, _ string) (prompts.GameScenario, error) {
+	if strings.TrimSpace(f.gameScenario.ID) != "" {
+		return f.gameScenario, nil
+	}
+	packageID := strings.TrimSpace(f.scenario.ID)
+	if packageID == "" && len(f.prompts) > 0 {
+		packageID = "scenario-test"
+	}
+	if packageID != "" {
+		return prompts.GameScenario{
+			ID:            "game-scenario-test",
+			Name:          "generated",
+			GameSlug:      "global",
+			InitialNodeID: "node-root",
+			Nodes: []prompts.GameScenarioNode{
+				{ID: "node-root", ScenarioPackageID: packageID},
+			},
+			IsActive: true,
+		}, nil
+	}
+	return prompts.GameScenario{}, prompts.ErrGameScenarioNotFound
 }
 
 func (f fakePromptResolver) GetActiveScenarioPackage(_ context.Context, _ string) (prompts.ScenarioPackage, error) {
@@ -110,6 +134,9 @@ func (f fakePromptResolver) GetScenarioPackage(_ context.Context, id string) (pr
 	}
 	if f.scenario.ID == id {
 		return f.scenario, nil
+	}
+	if len(f.prompts) > 0 && strings.TrimSpace(id) == "scenario-test" {
+		return f.GetActiveScenarioPackage(context.Background(), "global")
 	}
 	return prompts.ScenarioPackage{}, prompts.ErrScenarioPackageNotFound
 }

--- a/internal/prompts/game_scenario.go
+++ b/internal/prompts/game_scenario.go
@@ -286,6 +286,103 @@ func (s *Service) ActivateGameScenario(ctx context.Context, id, actorID string) 
 	return GameScenario{}, ErrGameScenarioNotFound
 }
 
+func (s *Service) GetActiveGameScenario(ctx context.Context, gameSlug string) (GameScenario, error) {
+	_ = ctx
+	lookup := strings.TrimSpace(gameSlug)
+	if lookup == "" {
+		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	versions := s.gameScenarios[lookup]
+	for _, item := range versions {
+		if item.IsActive {
+			return item, nil
+		}
+	}
+	return GameScenario{}, ErrGameScenarioNotFound
+}
+
+func (g GameScenario) InitialNode() (GameScenarioNode, error) {
+	initial := strings.TrimSpace(g.InitialNodeID)
+	if initial == "" {
+		return GameScenarioNode{}, ErrInvalidGameScenario
+	}
+	for _, node := range g.Nodes {
+		if strings.TrimSpace(node.ID) == initial {
+			return node, nil
+		}
+	}
+	return GameScenarioNode{}, ErrInvalidGameScenario
+}
+
+func (g GameScenario) ResolveTerminalCondition(stateJSON string) (GameScenarioTerminalCondition, bool, error) {
+	state := parseJSONMap(stateJSON)
+	ordered := append([]GameScenarioTerminalCondition(nil), g.TerminalConditions...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].Priority == ordered[j].Priority {
+			return strings.TrimSpace(ordered[i].ID) < strings.TrimSpace(ordered[j].ID)
+		}
+		return ordered[i].Priority > ordered[j].Priority
+	})
+	for _, terminal := range ordered {
+		ok, err := evaluateCondition(terminal.Condition, state)
+		if err != nil {
+			return GameScenarioTerminalCondition{}, false, err
+		}
+		if ok {
+			return terminal, true, nil
+		}
+	}
+	return GameScenarioTerminalCondition{}, false, nil
+}
+
+func (g GameScenario) ResolveNode(currentNodeID, stateJSON string) (GameScenarioNode, bool, error) {
+	activeNodeID := strings.TrimSpace(currentNodeID)
+	if activeNodeID == "" {
+		initial, err := g.InitialNode()
+		return initial, true, err
+	}
+	nodeByID := make(map[string]GameScenarioNode, len(g.Nodes))
+	for _, node := range g.Nodes {
+		nodeByID[strings.TrimSpace(node.ID)] = node
+	}
+	currentNode, ok := nodeByID[activeNodeID]
+	if !ok {
+		initial, err := g.InitialNode()
+		return initial, true, err
+	}
+	state := parseJSONMap(stateJSON)
+	ordered := append([]GameScenarioTransition(nil), g.Transitions...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].Priority == ordered[j].Priority {
+			left := strings.TrimSpace(ordered[i].ID) + strings.TrimSpace(ordered[i].ToNodeID)
+			right := strings.TrimSpace(ordered[j].ID) + strings.TrimSpace(ordered[j].ToNodeID)
+			return left < right
+		}
+		return ordered[i].Priority > ordered[j].Priority
+	})
+	for _, tr := range ordered {
+		if strings.TrimSpace(tr.FromNodeID) != activeNodeID {
+			continue
+		}
+		matched, err := evaluateCondition(tr.Condition, state)
+		if err != nil {
+			return GameScenarioNode{}, false, err
+		}
+		if !matched {
+			continue
+		}
+		targetID := strings.TrimSpace(tr.ToNodeID)
+		next, exists := nodeByID[targetID]
+		if !exists {
+			return GameScenarioNode{}, false, ErrInvalidGameScenario
+		}
+		return next, targetID != strings.TrimSpace(currentNode.ID), nil
+	}
+	return currentNode, false, nil
+}
+
 func isValidJSON(raw string) bool {
 	return json.Valid([]byte(strings.TrimSpace(raw)))
 }


### PR DESCRIPTION
### Motivation
- Align streamer tracking bootstrap with the scenario-graph v2 model so runtime starts from an admin-defined Game Scenario (node graph) and then resolves the scenario package, instead of starting directly from a scenario package.
- Ensure node-level routing and terminal conditions are evaluated per-cycle from persisted state to support multi-level orchestration (game detection → game scenario node → package → step).

### Description
- Replace worker bootstrap to query `GetActiveGameScenario` and resolve the initial node package before execution, and update `planScenarioExecution` to accept a `GameScenario` along with a `ScenarioPackage` (changes in `internal/media/worker.go`).
- Add Game Scenario runtime helpers in `internal/prompts/game_scenario.go`: `GetActiveGameScenario`, `InitialNode`, `ResolveNode` (priority-based node transitions), and `ResolveTerminalCondition` (priority-based terminal checks).
- Persist and read node metadata via `_scenario.gameScenarioNodeId` (added `scenarioStateNodeID` and write in `enrichScenarioState`) and keep package-level transitions as a secondary layer after node routing.
- Update `PromptResolver` contract and tests: add `GetActiveGameScenario` to the interface and extend `fakePromptResolver` in `internal/media/worker_test.go` to provide default Game Scenario data; also adjust unchanged-state detection to ignore `_scenario` metadata-only diffs when deciding whether `match_update` produced a concrete change.

### Testing
- Ran unit tests: `go test ./internal/media ./internal/prompts` and `go test ./...`, both succeeded.
- Checklist (aligned to `docs/implementation_plan.md` M2.1 and `docs/llm_stream_orchestration_plan.md`): [x] Runtime bootstrap uses Game Scenario → package → step; [x] Condition-based transitions and terminal-stop behavior preserved; [x] State + transitions evaluated per cycle including node routing; [ ] Update docs to explicitly describe the new runtime bootstrap path and add broader integration tests for mixed game-scenario + package transition chains.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e123c20980832c9ec0d4f2d2f3d5c8)