### PR TITLE
Add node-level terminal conditions and enforce single active scenario across slugs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1650,6 +1650,11 @@ components:
           type: string
         scenarioPackageId:
           type: string
+        terminalConditions:
+          type: array
+          description: Terminal conditions scoped to this node (branch).
+          items:
+            $ref: '#/components/schemas/GameScenarioTerminalCondition'
     GameScenarioTransition:
       type: object
       required: [fromNodeId, toNodeId, condition, priority]
@@ -1705,6 +1710,7 @@ components:
             $ref: '#/components/schemas/GameScenarioTransition'
         terminalConditions:
           type: array
+          description: Deprecated graph-wide terminal conditions; prefer node-level terminalConditions.
           items:
             $ref: '#/components/schemas/GameScenarioTerminalCondition'
     GameScenario:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -120,10 +120,21 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 func gameScenarioRequestToCreateRequest(req gameScenarioCreateRequest, actorID string) prompts.GameScenarioCreateRequest {
 	nodes := make([]prompts.GameScenarioNode, 0, len(req.Nodes))
 	for _, node := range req.Nodes {
+		nodeTerminalConditions := make([]prompts.GameScenarioTerminalCondition, 0, len(node.TerminalConditions))
+		for _, item := range node.TerminalConditions {
+			nodeTerminalConditions = append(nodeTerminalConditions, prompts.GameScenarioTerminalCondition{
+				ID:              item.ID,
+				Condition:       item.Condition,
+				ResultLabel:     item.ResultLabel,
+				ResultStateJSON: item.ResultStateJSON,
+				Priority:        item.Priority,
+			})
+		}
 		nodes = append(nodes, prompts.GameScenarioNode{
-			ID:                node.ID,
-			Alias:             node.Alias,
-			ScenarioPackageID: node.ScenarioPackageID,
+			ID:                 node.ID,
+			Alias:              node.Alias,
+			ScenarioPackageID:  node.ScenarioPackageID,
+			TerminalConditions: nodeTerminalConditions,
 		})
 	}
 	transitions := make([]prompts.GameScenarioTransition, 0, len(req.Transitions))
@@ -223,9 +234,10 @@ type scenarioPackageCreateRequest struct {
 }
 
 type gameScenarioNodeRequest struct {
-	ID                string `json:"id"`
-	Alias             string `json:"alias"`
-	ScenarioPackageID string `json:"scenarioPackageId"`
+	ID                 string                                 `json:"id"`
+	Alias              string                                 `json:"alias"`
+	ScenarioPackageID  string                                 `json:"scenarioPackageId"`
+	TerminalConditions []gameScenarioTerminalConditionRequest `json:"terminalConditions"`
 }
 
 type gameScenarioTransitionRequest struct {

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -767,7 +767,7 @@ func (w *Worker) planScenarioExecution(ctx context.Context, streamerID string, g
 		transitionTrace["status"] = "accepted"
 		transitionTrace["reason"] = "game_scenario_transition_matched"
 	}
-	if terminal, ok, terminalErr := gameScenario.ResolveTerminalCondition(previousState); terminalErr != nil {
+	if terminal, ok, terminalErr := gameScenario.ResolveTerminalCondition(resolvedNode.ID, previousState); terminalErr != nil {
 		return scenarioExecutionPlan{}, terminalErr
 	} else if ok {
 		transitionTrace = map[string]any{

--- a/internal/prompts/game_scenario.go
+++ b/internal/prompts/game_scenario.go
@@ -16,9 +16,10 @@ var (
 )
 
 type GameScenarioNode struct {
-	ID                string `json:"id"`
-	Alias             string `json:"alias"`
-	ScenarioPackageID string `json:"scenarioPackageId"`
+	ID                 string                          `json:"id"`
+	Alias              string                          `json:"alias"`
+	ScenarioPackageID  string                          `json:"scenarioPackageId"`
+	TerminalConditions []GameScenarioTerminalCondition `json:"terminalConditions,omitempty"`
 }
 
 type GameScenarioTransition struct {
@@ -85,6 +86,17 @@ func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScena
 		}
 		if _, err := pkg.InitialStep(); err != nil {
 			return fmt.Errorf("%w: package %s has no valid initial step", ErrInvalidGameScenario, node.ScenarioPackageID)
+		}
+		for _, tc := range node.TerminalConditions {
+			if strings.TrimSpace(tc.Condition) == "" {
+				return fmt.Errorf("%w: node %s terminal condition is required", ErrInvalidGameScenario, nodeID)
+			}
+			if err := validateScenarioCondition(tc.Condition); err != nil {
+				return fmt.Errorf("%w: node %s terminal condition: %v", ErrInvalidGameScenario, nodeID, err)
+			}
+			if strings.TrimSpace(tc.ResultStateJSON) != "" && !isValidJSON(tc.ResultStateJSON) {
+				return fmt.Errorf("%w: node %s terminal resultStateJson must be valid json", ErrInvalidGameScenario, nodeID)
+			}
 		}
 		nodeIDs[nodeID] = node
 	}
@@ -165,7 +177,7 @@ func (s *Service) CreateGameScenario(ctx context.Context, req GameScenarioCreate
 		CreatedBy:          strings.TrimSpace(req.ActorID),
 		CreatedAt:          now,
 	}
-	if len(versions) == 0 {
+	if !s.hasActiveGameScenarioLocked() {
 		item.IsActive = true
 		item.ActivatedBy = strings.TrimSpace(req.ActorID)
 		item.ActivatedAt = now
@@ -243,7 +255,11 @@ func (s *Service) DeleteGameScenario(ctx context.Context, id string) error {
 			if item.ID != lookup {
 				continue
 			}
+			removedActive := item.IsActive
 			s.gameScenarios[slug] = append(versions[:i], versions[i+1:]...)
+			if removedActive {
+				s.ensureAtLeastOneActiveLocked(item.ActivatedBy)
+			}
 			return nil
 		}
 	}
@@ -258,20 +274,29 @@ func (s *Service) ActivateGameScenario(ctx context.Context, id, actorID string) 
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	var (
+		foundSlug string
+		foundIdx  = -1
+	)
 	for slug, versions := range s.gameScenarios {
-		active := -1
 		for i := range versions {
 			if versions[i].ID == lookup {
-				active = i
+				foundSlug = slug
+				foundIdx = i
 				break
 			}
 		}
-		if active == -1 {
-			continue
+		if foundIdx >= 0 {
+			break
 		}
-		now := time.Now().UTC()
+	}
+	if foundIdx < 0 {
+		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	now := time.Now().UTC()
+	for slug, versions := range s.gameScenarios {
 		for i := range versions {
-			versions[i].IsActive = i == active
+			versions[i].IsActive = slug == foundSlug && i == foundIdx
 			if versions[i].IsActive {
 				versions[i].ActivatedBy = strings.TrimSpace(actorID)
 				versions[i].ActivatedAt = now
@@ -281,9 +306,8 @@ func (s *Service) ActivateGameScenario(ctx context.Context, id, actorID string) 
 			}
 		}
 		s.gameScenarios[slug] = versions
-		return versions[active], nil
 	}
-	return GameScenario{}, ErrGameScenarioNotFound
+	return s.gameScenarios[foundSlug][foundIdx], nil
 }
 
 func (s *Service) GetActiveGameScenario(ctx context.Context, gameSlug string) (GameScenario, error) {
@@ -298,6 +322,13 @@ func (s *Service) GetActiveGameScenario(ctx context.Context, gameSlug string) (G
 	for _, item := range versions {
 		if item.IsActive {
 			return item, nil
+		}
+	}
+	for _, versions := range s.gameScenarios {
+		for _, item := range versions {
+			if item.IsActive {
+				return item, nil
+			}
 		}
 	}
 	return GameScenario{}, ErrGameScenarioNotFound
@@ -316,9 +347,21 @@ func (g GameScenario) InitialNode() (GameScenarioNode, error) {
 	return GameScenarioNode{}, ErrInvalidGameScenario
 }
 
-func (g GameScenario) ResolveTerminalCondition(stateJSON string) (GameScenarioTerminalCondition, bool, error) {
+func (g GameScenario) ResolveTerminalCondition(nodeID, stateJSON string) (GameScenarioTerminalCondition, bool, error) {
 	state := parseJSONMap(stateJSON)
-	ordered := append([]GameScenarioTerminalCondition(nil), g.TerminalConditions...)
+	ordered := make([]GameScenarioTerminalCondition, 0)
+	lookupNodeID := strings.TrimSpace(nodeID)
+	if lookupNodeID != "" {
+		for _, node := range g.Nodes {
+			if strings.TrimSpace(node.ID) == lookupNodeID {
+				ordered = append(ordered, node.TerminalConditions...)
+				break
+			}
+		}
+	}
+	if len(ordered) == 0 {
+		ordered = append(ordered, g.TerminalConditions...)
+	}
 	sort.SliceStable(ordered, func(i, j int) bool {
 		if ordered[i].Priority == ordered[j].Priority {
 			return strings.TrimSpace(ordered[i].ID) < strings.TrimSpace(ordered[j].ID)
@@ -335,6 +378,33 @@ func (g GameScenario) ResolveTerminalCondition(stateJSON string) (GameScenarioTe
 		}
 	}
 	return GameScenarioTerminalCondition{}, false, nil
+}
+
+func (s *Service) hasActiveGameScenarioLocked() bool {
+	for _, versions := range s.gameScenarios {
+		for _, item := range versions {
+			if item.IsActive {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *Service) ensureAtLeastOneActiveLocked(actorID string) {
+	if s.hasActiveGameScenarioLocked() {
+		return
+	}
+	for slug, versions := range s.gameScenarios {
+		if len(versions) == 0 {
+			continue
+		}
+		versions[0].IsActive = true
+		versions[0].ActivatedBy = strings.TrimSpace(actorID)
+		versions[0].ActivatedAt = time.Now().UTC()
+		s.gameScenarios[slug] = versions
+		return
+	}
 }
 
 func (g GameScenario) ResolveNode(currentNodeID, stateJSON string) (GameScenarioNode, bool, error) {

--- a/internal/prompts/game_scenario_test.go
+++ b/internal/prompts/game_scenario_test.go
@@ -102,3 +102,100 @@ func TestGameScenarioCreateRejectsMissingTransitionCondition(t *testing.T) {
 		t.Fatalf("expected ErrInvalidGameScenario, got %v", err)
 	}
 }
+
+func TestGameScenarioActivateKeepsSingleActiveAcrossSlugs(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	cfg := mustCreateModelConfig(t, svc)
+	rootPkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "root",
+		GameSlug:         "global",
+		LLMModelConfigID: cfg.ID,
+		ActorID:          "admin-1",
+		Steps:            []ScenarioStep{{ID: "root", Name: "root", PromptTemplate: "x", ResponseSchemaJSON: `{}`, Initial: true, Order: 1}},
+	})
+	if err != nil {
+		t.Fatalf("create root package: %v", err)
+	}
+
+	first, err := svc.CreateGameScenario(context.Background(), GameScenarioCreateRequest{
+		Name:          "first",
+		GameSlug:      "global",
+		InitialNodeID: "n1",
+		Nodes:         []GameScenarioNode{{ID: "n1", ScenarioPackageID: rootPkg.ID}},
+		ActorID:       "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateGameScenario first: %v", err)
+	}
+	if !first.IsActive {
+		t.Fatalf("expected first scenario to be active")
+	}
+
+	second, err := svc.CreateGameScenario(context.Background(), GameScenarioCreateRequest{
+		Name:          "second",
+		GameSlug:      "cs2",
+		InitialNodeID: "n2",
+		Nodes:         []GameScenarioNode{{ID: "n2", ScenarioPackageID: rootPkg.ID}},
+		ActorID:       "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateGameScenario second: %v", err)
+	}
+	if second.IsActive {
+		t.Fatalf("expected second scenario to stay inactive before explicit activation")
+	}
+
+	if _, err := svc.ActivateGameScenario(context.Background(), second.ID, "admin-2"); err != nil {
+		t.Fatalf("ActivateGameScenario second: %v", err)
+	}
+	got, err := svc.GetActiveGameScenario(context.Background(), "global")
+	if err != nil {
+		t.Fatalf("GetActiveGameScenario fallback: %v", err)
+	}
+	if got.ID != second.ID {
+		t.Fatalf("expected globally active scenario %s, got %s", second.ID, got.ID)
+	}
+}
+
+func TestGameScenarioResolveTerminalConditionPrefersNodeScope(t *testing.T) {
+	t.Parallel()
+
+	scenario := GameScenario{
+		InitialNodeID: "n1",
+		Nodes: []GameScenarioNode{
+			{
+				ID: "n1",
+				TerminalConditions: []GameScenarioTerminalCondition{
+					{ID: "node-win", Condition: `winner == "ct"`, ResultLabel: "node", Priority: 100},
+				},
+			},
+		},
+		TerminalConditions: []GameScenarioTerminalCondition{
+			{ID: "global-win", Condition: `winner == "ct"`, ResultLabel: "global", Priority: 10},
+		},
+	}
+
+	terminal, ok, err := scenario.ResolveTerminalCondition("n1", `{"winner":"ct"}`)
+	if err != nil {
+		t.Fatalf("ResolveTerminalCondition(node): %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected node terminal condition to match")
+	}
+	if terminal.ID != "node-win" {
+		t.Fatalf("expected node-level terminal condition, got %s", terminal.ID)
+	}
+
+	terminal, ok, err = scenario.ResolveTerminalCondition("missing-node", `{"winner":"ct"}`)
+	if err != nil {
+		t.Fatalf("ResolveTerminalCondition(fallback): %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected fallback terminal condition to match")
+	}
+	if terminal.ID != "global-win" {
+		t.Fatalf("expected global fallback terminal condition, got %s", terminal.ID)
+	}
+}


### PR DESCRIPTION
### Motivation

- Introduce per-node terminal conditions so terminal logic can be scoped to individual nodes instead of only global graph-level conditions.
- Ensure activation and deletion preserve a single active game scenario across all slugs and that there is always at least one active scenario.

### Description

- Add `TerminalConditions` to `GameScenarioNode` in the `prompts` model and to the OpenAPI spec by adding `terminalConditions` on `GameScenarioNode` and a deprecation note for graph-level `terminalConditions` in `GameScenarioCreateRequest`.
- Thread node-level terminal conditions through the router by adding `terminalConditions` to the request structs and converting them in `gameScenarioRequestToCreateRequest`.
- Change terminal resolution to `ResolveTerminalCondition(nodeID, stateJSON string)` which prefers node-scoped conditions and falls back to global conditions, keeping priority ordering and JSON result validation.
- Update scenario execution to pass the resolved node id to terminal resolution by calling `ResolveTerminalCondition(resolvedNode.ID, previousState)` in the worker plan.
- Improve game scenario lifecycle logic: on create use `hasActiveGameScenarioLocked()` to set initial active scenario, on delete call `ensureAtLeastOneActiveLocked()` to preserve at least one active scenario, and refactor `ActivateGameScenario` to correctly locate and activate the requested scenario across slugs and deactivate others; also make `GetActiveGameScenario` fall back to any active scenario if none exist for the requested slug.
- Add validation for node terminal conditions in `validateGameScenarioRequest` to ensure non-empty conditions, valid condition expression, and valid JSON for `ResultStateJSON`.

### Testing

- Ran unit tests in `internal/prompts` including `TestGameScenarioActivateKeepsSingleActiveAcrossSlugs` and `TestGameScenarioResolveTerminalConditionPrefersNodeScope`, and they passed.
- Ran the test suite with `go test ./...` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2387e6c30832c9921fe186dfccdd6)