### PR TITLE
Support edge-scoped terminal conditions and game-slug resolution from state

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1678,6 +1678,9 @@ components:
       properties:
         id:
           type: string
+        transitionId:
+          type: string
+          description: Optional transition ID for edge-scoped terminal conditions.
         condition:
           type: string
         resultLabel:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -124,6 +124,7 @@ func gameScenarioRequestToCreateRequest(req gameScenarioCreateRequest, actorID s
 		for _, item := range node.TerminalConditions {
 			nodeTerminalConditions = append(nodeTerminalConditions, prompts.GameScenarioTerminalCondition{
 				ID:              item.ID,
+				TransitionID:    item.TransitionID,
 				Condition:       item.Condition,
 				ResultLabel:     item.ResultLabel,
 				ResultStateJSON: item.ResultStateJSON,
@@ -151,6 +152,7 @@ func gameScenarioRequestToCreateRequest(req gameScenarioCreateRequest, actorID s
 	for _, item := range req.TerminalConditions {
 		terminalConditions = append(terminalConditions, prompts.GameScenarioTerminalCondition{
 			ID:              item.ID,
+			TransitionID:    item.TransitionID,
 			Condition:       item.Condition,
 			ResultLabel:     item.ResultLabel,
 			ResultStateJSON: item.ResultStateJSON,
@@ -250,6 +252,7 @@ type gameScenarioTransitionRequest struct {
 
 type gameScenarioTerminalConditionRequest struct {
 	ID              string `json:"id"`
+	TransitionID    string `json:"transitionId"`
 	Condition       string `json:"condition"`
 	ResultLabel     string `json:"resultLabel"`
 	ResultStateJSON string `json:"resultStateJson"`

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -196,9 +196,14 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 		logger.Info("streamer processing lock released", zap.String("streamerID", id), zap.String("lockKey", lockKey))
 	}()
 
-	gameScenario, err := w.prompts.GetActiveGameScenario(ctx, "global")
+	previousState := w.resolvePreviousState(ctx, id)
+	gameScenarioSlug := resolveGameScenarioSlug(previousState)
+	gameScenario, err := w.prompts.GetActiveGameScenario(ctx, gameScenarioSlug)
+	if err != nil && !strings.EqualFold(gameScenarioSlug, "global") {
+		gameScenario, err = w.prompts.GetActiveGameScenario(ctx, "global")
+	}
 	if err != nil {
-		logger.Error("active game scenario lookup failed", zap.String("streamerID", id), zap.String("gameSlug", "global"), zap.Error(err))
+		logger.Error("active game scenario lookup failed", zap.String("streamerID", id), zap.String("gameSlug", gameScenarioSlug), zap.Error(err))
 		w.metrics.recordFailure(ctx, id, "lookup_game_scenario")
 		w.metrics.recordCycle(ctx, id, "failed")
 		return streamers.LLMDecision{}, err
@@ -739,7 +744,7 @@ func (w *Worker) planScenarioExecution(ctx context.Context, streamerID string, g
 	previousState := w.resolvePreviousState(ctx, streamerID)
 	startPackageID := strings.TrimSpace(pkg.ID)
 	currentNodeID := scenarioStateNodeID(previousState)
-	resolvedNode, nodeChanged, err := gameScenario.ResolveNode(currentNodeID, previousState)
+	resolvedNode, matchedTransitionID, nodeChanged, err := gameScenario.ResolveNode(currentNodeID, previousState)
 	if err != nil {
 		return scenarioExecutionPlan{}, err
 	}
@@ -767,7 +772,7 @@ func (w *Worker) planScenarioExecution(ctx context.Context, streamerID string, g
 		transitionTrace["status"] = "accepted"
 		transitionTrace["reason"] = "game_scenario_transition_matched"
 	}
-	if terminal, ok, terminalErr := gameScenario.ResolveTerminalCondition(resolvedNode.ID, previousState); terminalErr != nil {
+	if terminal, ok, terminalErr := gameScenario.ResolveTerminalCondition(resolvedNode.ID, matchedTransitionID, previousState); terminalErr != nil {
 		return scenarioExecutionPlan{}, terminalErr
 	} else if ok {
 		transitionTrace = map[string]any{
@@ -1055,4 +1060,39 @@ func scenarioStateNodeID(stateJSON string) string {
 		return ""
 	}
 	return strings.TrimSpace(fmt.Sprint(meta["gameScenarioNodeId"]))
+}
+
+func resolveGameScenarioSlug(stateJSON string) string {
+	state := parseJSONMap(stateJSON)
+	candidates := []string{
+		valueAsNonNilString(state, "game"),
+		valueAsNonNilString(state, "gameSlug"),
+		valueAsNonNilString(state, "detectedGameKey"),
+	}
+	if nested, ok := state["state"].(map[string]any); ok {
+		candidates = append(candidates,
+			valueAsNonNilString(nested, "game"),
+			valueAsNonNilString(nested, "gameSlug"),
+			valueAsNonNilString(nested, "detectedGameKey"),
+		)
+	}
+	if rawMeta, ok := state["_scenario"]; ok {
+		if meta, ok := rawMeta.(map[string]any); ok {
+			candidates = append(candidates, valueAsNonNilString(meta, "gameSlug"))
+		}
+	}
+	for _, candidate := range candidates {
+		if candidate != "" {
+			return strings.ToLower(candidate)
+		}
+	}
+	return "global"
+}
+
+func valueAsNonNilString(payload map[string]any, key string) string {
+	raw, ok := payload[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(raw))
 }

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -53,6 +53,7 @@ func (f fakeClassifier) Classify(_ context.Context, input StageRequest) (StageCl
 type fakePromptResolver struct {
 	prompts        []prompts.PromptVersion
 	gameScenario   prompts.GameScenario
+	gameScenarios  map[string]prompts.GameScenario
 	scenario       prompts.ScenarioPackage
 	scenariosByID  map[string]prompts.ScenarioPackage
 	scenarioErr    error
@@ -60,7 +61,11 @@ type fakePromptResolver struct {
 	llmConfigErr   error
 }
 
-func (f fakePromptResolver) GetActiveGameScenario(_ context.Context, _ string) (prompts.GameScenario, error) {
+func (f fakePromptResolver) GetActiveGameScenario(_ context.Context, gameSlug string) (prompts.GameScenario, error) {
+	lookup := strings.TrimSpace(gameSlug)
+	if item, ok := f.gameScenarios[lookup]; ok {
+		return item, nil
+	}
 	if strings.TrimSpace(f.gameScenario.ID) != "" {
 		return f.gameScenario, nil
 	}
@@ -883,5 +888,29 @@ func TestWorkerProcessStreamerDoesNotSwitchPackageWhenInitialGuardFails(t *testi
 	transition, _ := meta["transition"].(map[string]any)
 	if transition["status"] != "rejected" {
 		t.Fatalf("expected rejected transition trace, got %#v", transition)
+	}
+}
+
+func TestResolveGameScenarioSlug(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		state string
+		want  string
+	}{
+		{name: "top-level game", state: `{"game":"cs2"}`, want: "cs2"},
+		{name: "nested state game slug", state: `{"state":{"gameSlug":"dota2"}}`, want: "dota2"},
+		{name: "scenario meta fallback", state: `{"_scenario":{"gameSlug":"valorant"}}`, want: "valorant"},
+		{name: "default global", state: `{}`, want: "global"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveGameScenarioSlug(tc.state); got != tc.want {
+				t.Fatalf("resolveGameScenarioSlug(%s) = %q, want %q", tc.state, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/prompts/game_scenario.go
+++ b/internal/prompts/game_scenario.go
@@ -32,6 +32,7 @@ type GameScenarioTransition struct {
 
 type GameScenarioTerminalCondition struct {
 	ID              string `json:"id"`
+	TransitionID    string `json:"transitionId,omitempty"`
 	Condition       string `json:"condition"`
 	ResultLabel     string `json:"resultLabel,omitempty"`
 	ResultStateJSON string `json:"resultStateJson,omitempty"`
@@ -125,6 +126,14 @@ func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScena
 			return fmt.Errorf("%w: transition target package %s has no initial step", ErrInvalidGameScenario, toNode.ScenarioPackageID)
 		}
 	}
+	transitionIDs := make(map[string]struct{}, len(req.Transitions))
+	for _, tr := range req.Transitions {
+		id := strings.TrimSpace(tr.ID)
+		if id == "" {
+			continue
+		}
+		transitionIDs[id] = struct{}{}
+	}
 	for _, tc := range req.TerminalConditions {
 		if strings.TrimSpace(tc.Condition) == "" {
 			return fmt.Errorf("%w: terminal condition is required", ErrInvalidGameScenario)
@@ -134,6 +143,11 @@ func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScena
 		}
 		if strings.TrimSpace(tc.ResultStateJSON) != "" && !isValidJSON(tc.ResultStateJSON) {
 			return fmt.Errorf("%w: terminal resultStateJson must be valid json", ErrInvalidGameScenario)
+		}
+		if transitionID := strings.TrimSpace(tc.TransitionID); transitionID != "" {
+			if _, ok := transitionIDs[transitionID]; !ok {
+				return fmt.Errorf("%w: terminal transitionId %s not found", ErrInvalidGameScenario, transitionID)
+			}
 		}
 	}
 	return nil
@@ -347,11 +361,19 @@ func (g GameScenario) InitialNode() (GameScenarioNode, error) {
 	return GameScenarioNode{}, ErrInvalidGameScenario
 }
 
-func (g GameScenario) ResolveTerminalCondition(nodeID, stateJSON string) (GameScenarioTerminalCondition, bool, error) {
+func (g GameScenario) ResolveTerminalCondition(nodeID, transitionID, stateJSON string) (GameScenarioTerminalCondition, bool, error) {
 	state := parseJSONMap(stateJSON)
 	ordered := make([]GameScenarioTerminalCondition, 0)
+	lookupTransitionID := strings.TrimSpace(transitionID)
+	if lookupTransitionID != "" {
+		for _, terminal := range g.TerminalConditions {
+			if strings.TrimSpace(terminal.TransitionID) == lookupTransitionID {
+				ordered = append(ordered, terminal)
+			}
+		}
+	}
 	lookupNodeID := strings.TrimSpace(nodeID)
-	if lookupNodeID != "" {
+	if len(ordered) == 0 && lookupNodeID != "" {
 		for _, node := range g.Nodes {
 			if strings.TrimSpace(node.ID) == lookupNodeID {
 				ordered = append(ordered, node.TerminalConditions...)
@@ -360,7 +382,12 @@ func (g GameScenario) ResolveTerminalCondition(nodeID, stateJSON string) (GameSc
 		}
 	}
 	if len(ordered) == 0 {
-		ordered = append(ordered, g.TerminalConditions...)
+		for _, terminal := range g.TerminalConditions {
+			if strings.TrimSpace(terminal.TransitionID) != "" {
+				continue
+			}
+			ordered = append(ordered, terminal)
+		}
 	}
 	sort.SliceStable(ordered, func(i, j int) bool {
 		if ordered[i].Priority == ordered[j].Priority {
@@ -407,11 +434,11 @@ func (s *Service) ensureAtLeastOneActiveLocked(actorID string) {
 	}
 }
 
-func (g GameScenario) ResolveNode(currentNodeID, stateJSON string) (GameScenarioNode, bool, error) {
+func (g GameScenario) ResolveNode(currentNodeID, stateJSON string) (GameScenarioNode, string, bool, error) {
 	activeNodeID := strings.TrimSpace(currentNodeID)
 	if activeNodeID == "" {
 		initial, err := g.InitialNode()
-		return initial, true, err
+		return initial, "", true, err
 	}
 	nodeByID := make(map[string]GameScenarioNode, len(g.Nodes))
 	for _, node := range g.Nodes {
@@ -420,7 +447,7 @@ func (g GameScenario) ResolveNode(currentNodeID, stateJSON string) (GameScenario
 	currentNode, ok := nodeByID[activeNodeID]
 	if !ok {
 		initial, err := g.InitialNode()
-		return initial, true, err
+		return initial, "", true, err
 	}
 	state := parseJSONMap(stateJSON)
 	ordered := append([]GameScenarioTransition(nil), g.Transitions...)
@@ -438,7 +465,7 @@ func (g GameScenario) ResolveNode(currentNodeID, stateJSON string) (GameScenario
 		}
 		matched, err := evaluateCondition(tr.Condition, state)
 		if err != nil {
-			return GameScenarioNode{}, false, err
+			return GameScenarioNode{}, "", false, err
 		}
 		if !matched {
 			continue
@@ -446,11 +473,11 @@ func (g GameScenario) ResolveNode(currentNodeID, stateJSON string) (GameScenario
 		targetID := strings.TrimSpace(tr.ToNodeID)
 		next, exists := nodeByID[targetID]
 		if !exists {
-			return GameScenarioNode{}, false, ErrInvalidGameScenario
+			return GameScenarioNode{}, "", false, ErrInvalidGameScenario
 		}
-		return next, targetID != strings.TrimSpace(currentNode.ID), nil
+		return next, strings.TrimSpace(tr.ID), targetID != strings.TrimSpace(currentNode.ID), nil
 	}
-	return currentNode, false, nil
+	return currentNode, "", false, nil
 }
 
 func isValidJSON(raw string) bool {

--- a/internal/prompts/game_scenario_test.go
+++ b/internal/prompts/game_scenario_test.go
@@ -103,6 +103,40 @@ func TestGameScenarioCreateRejectsMissingTransitionCondition(t *testing.T) {
 	}
 }
 
+func TestGameScenarioCreateRejectsUnknownTerminalTransition(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	cfg := mustCreateModelConfig(t, svc)
+	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "root",
+		GameSlug:         "global",
+		LLMModelConfigID: cfg.ID,
+		ActorID:          "admin-1",
+		Steps:            []ScenarioStep{{ID: "root", Name: "root", PromptTemplate: "x", ResponseSchemaJSON: `{}`, Initial: true, Order: 1}},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+
+	_, err = svc.CreateGameScenario(context.Background(), GameScenarioCreateRequest{
+		Name:          "invalid-terminal-transition",
+		GameSlug:      "cs2",
+		InitialNodeID: "n1",
+		Nodes:         []GameScenarioNode{{ID: "n1", ScenarioPackageID: pkg.ID}},
+		TerminalConditions: []GameScenarioTerminalCondition{
+			{TransitionID: "missing-edge", Condition: `winner == "ct"`, Priority: 1},
+		},
+		ActorID: "admin-1",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !errors.Is(err, ErrInvalidGameScenario) {
+		t.Fatalf("expected ErrInvalidGameScenario, got %v", err)
+	}
+}
+
 func TestGameScenarioActivateKeepsSingleActiveAcrossSlugs(t *testing.T) {
 	t.Parallel()
 
@@ -177,7 +211,7 @@ func TestGameScenarioResolveTerminalConditionPrefersNodeScope(t *testing.T) {
 		},
 	}
 
-	terminal, ok, err := scenario.ResolveTerminalCondition("n1", `{"winner":"ct"}`)
+	terminal, ok, err := scenario.ResolveTerminalCondition("n1", "", `{"winner":"ct"}`)
 	if err != nil {
 		t.Fatalf("ResolveTerminalCondition(node): %v", err)
 	}
@@ -188,7 +222,7 @@ func TestGameScenarioResolveTerminalConditionPrefersNodeScope(t *testing.T) {
 		t.Fatalf("expected node-level terminal condition, got %s", terminal.ID)
 	}
 
-	terminal, ok, err = scenario.ResolveTerminalCondition("missing-node", `{"winner":"ct"}`)
+	terminal, ok, err = scenario.ResolveTerminalCondition("missing-node", "", `{"winner":"ct"}`)
 	if err != nil {
 		t.Fatalf("ResolveTerminalCondition(fallback): %v", err)
 	}
@@ -197,5 +231,31 @@ func TestGameScenarioResolveTerminalConditionPrefersNodeScope(t *testing.T) {
 	}
 	if terminal.ID != "global-win" {
 		t.Fatalf("expected global fallback terminal condition, got %s", terminal.ID)
+	}
+}
+
+func TestGameScenarioResolveTerminalConditionPrefersTransitionScope(t *testing.T) {
+	t.Parallel()
+
+	scenario := GameScenario{
+		InitialNodeID: "n1",
+		Transitions: []GameScenarioTransition{
+			{ID: "edge-1", FromNodeID: "n1", ToNodeID: "n2", Condition: `winner == "ct"`, Priority: 100},
+		},
+		TerminalConditions: []GameScenarioTerminalCondition{
+			{ID: "edge-win", TransitionID: "edge-1", Condition: `winner == "ct"`, ResultLabel: "edge", Priority: 200},
+			{ID: "global-win", Condition: `winner == "ct"`, ResultLabel: "global", Priority: 10},
+		},
+	}
+
+	terminal, ok, err := scenario.ResolveTerminalCondition("n2", "edge-1", `{"winner":"ct"}`)
+	if err != nil {
+		t.Fatalf("ResolveTerminalCondition(edge): %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected edge terminal condition to match")
+	}
+	if terminal.ID != "edge-win" {
+		t.Fatalf("expected edge-level terminal condition, got %s", terminal.ID)
 	}
 }


### PR DESCRIPTION
### Motivation

- Allow terminal conditions to be scoped to specific transitions (edges) so terminal logic can trigger on particular transition matches.
- Select the appropriate game scenario by detecting a game slug from the streamer's previous state instead of always using the global scenario.
- Ensure schema, validation, and request/response mappings carry the new `transitionId` where applicable.

### Description

- Add `transitionId` to `GameScenarioTerminalCondition` in the OpenAPI (`docs/openapi.yaml`) and internal model types, and propagate it through request types and router converters (e.g. mapping request `transitionId` into prompt models).  
- Update `GameScenario` logic: add transition-aware behavior by returning the matched transition ID from `ResolveNode`, accept that `transitionId` in `ResolveTerminalCondition`, and prefer transition-scoped terminal conditions first, then node-scoped, then global-scoped conditions.  
- Validate terminal conditions during creation: `validateGameScenarioRequest` now rejects terminal conditions that reference unknown transition IDs.  
- Worker changes: resolve a game scenario slug from previous state via `resolveGameScenarioSlug`, fetch scenario by that slug and fall back to `global` when needed, and thread the matched transition ID into `planScenarioExecution` so terminal resolution can use edge scope.  
- Add helper functions `resolveGameScenarioSlug` and `valueAsNonNilString`, update test fakes to support game-scenario lookup by slug, and wire `transitionId` fields in router request structs and mapping helpers.  
- Add unit tests for slug resolution (`TestResolveGameScenarioSlug`), terminal-transition validation (`TestGameScenarioCreateRejectsUnknownTerminalTransition`), and preference for transition-scoped terminal conditions (`TestGameScenarioResolveTerminalConditionPrefersTransitionScope`).

### Testing

- Ran unit tests with `go test ./...` and confirmed all tests passed, including the new tests `TestResolveGameScenarioSlug`, `TestGameScenarioCreateRejectsUnknownTerminalTransition`, and `TestGameScenarioResolveTerminalConditionPrefersTransitionScope`.
- Existing scenario and worker tests were executed and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c1ba4224832cb3decea55395b26b)