### PR TITLE
Apply post-step game-scenario transitions and persist node/package metadata

### DIFF
--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -949,13 +949,52 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 	if err != nil {
 		return streamers.LLMDecision{}, err
 	}
-	result.UpdatedStateJSON = enrichScenarioState(result.UpdatedStateJSON, execution.PreviousState, execution.GameScenarioID, pkg.ID, step.ID, execution.TransitionTrace)
+	finalPackageID, finalTransitionTrace := w.resolvePostStepScenarioTransition(ctx, execution, result.UpdatedStateJSON)
+	if strings.TrimSpace(finalPackageID) == "" {
+		finalPackageID = pkg.ID
+	}
+	result.UpdatedStateJSON = enrichScenarioState(result.UpdatedStateJSON, execution.PreviousState, execution.GameScenarioID, finalPackageID, step.ID, finalTransitionTrace)
 	decision, err := w.processStageResult(ctx, activePrompt, result, chunk, runID, streamerID, previousState)
 	if err != nil {
 		return streamers.LLMDecision{}, err
 	}
 	decision.TransitionToStep = step.ID
 	return decision, nil
+}
+
+func (w *Worker) resolvePostStepScenarioTransition(ctx context.Context, execution scenarioExecutionPlan, currentState string) (string, map[string]any) {
+	trace := execution.TransitionTrace
+	currentPackageID := strings.TrimSpace(execution.CurrentPackageID)
+	if currentPackageID == "" {
+		currentPackageID = strings.TrimSpace(execution.StartPackageID)
+	}
+	if strings.TrimSpace(execution.GameScenarioID) == "" {
+		return currentPackageID, trace
+	}
+	gameScenario, err := w.prompts.GetGameScenario(ctx, execution.GameScenarioID)
+	if err != nil {
+		return currentPackageID, trace
+	}
+	currentNodeID := strings.TrimSpace(fmt.Sprint(trace["toNode"]))
+	if currentNodeID == "" {
+		currentNodeID = scenarioStateNodeID(execution.PreviousState)
+	}
+	resolvedNode, _, nodeChanged, err := gameScenario.ResolveNode(currentNodeID, currentState)
+	if err != nil || !nodeChanged {
+		return currentPackageID, trace
+	}
+	nextPackageID := strings.TrimSpace(resolvedNode.ScenarioPackageID)
+	if nextPackageID == "" {
+		nextPackageID = currentPackageID
+	}
+	return nextPackageID, map[string]any{
+		"status":      "accepted",
+		"fromNode":    firstNonEmpty(currentNodeID, strings.TrimSpace(gameScenario.InitialNodeID)),
+		"toNode":      strings.TrimSpace(resolvedNode.ID),
+		"fromPackage": currentPackageID,
+		"toPackage":   nextPackageID,
+		"reason":      "game_scenario_transition_matched",
+	}
 }
 
 func (w *Worker) latestDecisionByStreamer(ctx context.Context, streamerID string) streamers.LLMDecision {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -907,6 +907,59 @@ func TestWorkerProcessStreamerDoesNotSwitchPackageWhenInitialGuardFails(t *testi
 	}
 }
 
+func TestWorkerProcessStreamerAppliesPostStepGameScenarioTransition(t *testing.T) {
+	worker := NewWorker(
+		&fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Now().UTC()}},
+		fakeClassifier{results: map[string]StageClassification{"initial": {Label: "state_updated", Confidence: 0.9, UpdatedStateJSON: `{"game":"cs2"}`}}},
+		fakePromptResolver{
+			gameScenario: prompts.GameScenario{
+				ID:            "game-scenario-1",
+				Name:          "global-to-cs2",
+				GameSlug:      "global",
+				InitialNodeID: "global",
+				Nodes: []prompts.GameScenarioNode{
+					{ID: "global", ScenarioPackageID: "scenario-root"},
+					{ID: "cs2_node", ScenarioPackageID: "scenario-cs2"},
+				},
+				Transitions: []prompts.GameScenarioTransition{
+					{ID: "to_cs2", FromNodeID: "global", ToNodeID: "cs2_node", Condition: `game == "cs2"`, Priority: 1},
+				},
+				IsActive: true,
+			},
+			scenario: prompts.ScenarioPackage{
+				ID:               "scenario-root",
+				GameSlug:         "global",
+				LLMModelConfigID: "cfg-default",
+				Steps: []prompts.ScenarioStep{
+					{ID: "initial", Name: "Initial", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+				},
+			},
+			llmModelConfig: prompts.LLMModelConfig{ID: "cfg-default", Model: "gemini-2.5-flash"},
+		},
+		&InMemoryRunStore{},
+		&fakeDecisionStore{},
+		NewInMemoryLocker(),
+		WorkerConfig{MinConfidence: 0.5},
+	)
+
+	decision, err := worker.ProcessStreamer(context.Background(), "streamer-1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	state := parseJSONMap(decision.UpdatedStateJSON)
+	meta, _ := state["_scenario"].(map[string]any)
+	if meta["gameScenarioNodeId"] != "cs2_node" {
+		t.Fatalf("expected game scenario node transition to cs2_node, got %#v", meta)
+	}
+	if meta["packageId"] != "scenario-cs2" {
+		t.Fatalf("expected package to switch to scenario-cs2 in state metadata, got %#v", meta)
+	}
+	transition, _ := meta["transition"].(map[string]any)
+	if transition["status"] != "accepted" || transition["toNode"] != "cs2_node" {
+		t.Fatalf("expected accepted transition to cs2_node, got %#v", transition)
+	}
+}
+
 func TestResolveGameScenarioSlug(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Motivation
- The worker evaluated game-scenario transitions only before running a step, so state changes produced by the step could miss immediate node/package transitions and not be reflected in persisted `_scenario` metadata.  
- Re-evaluating transitions after the step ensures state-driven movement (for example `game == "cs2"`) is applied immediately.  
- Checklist aligned with M2.1 / `docs/llm_stream_orchestration_plan.md`: [x] recompute transitions after step execution; [x] persist resulting `_scenario.transition` and `packageId`; [ ] expand tests for all package-graph edge cases; [ ] add more observability for reject/no_transition reasons.

### Description
- Recomputed post-step game-scenario transitions by adding `resolvePostStepScenarioTransition` and calling it from `processScenarioPackage` to evaluate the graph against the freshly-updated `UpdatedStateJSON`.  
- Use the resolved package id and transition trace when calling `enrichScenarioState` so `_scenario.packageId` and `_scenario.transition` reflect immediate movement.  
- The post-step resolver fetches the `GameScenario` via `w.prompts.GetGameScenario` and uses `GameScenario.ResolveNode` (falling back to previous node when needed) to decide node/package changes.  
- Added unit test `TestWorkerProcessStreamerAppliesPostStepGameScenarioTransition` verifying root->cs2 node and package movement when a step emits `{"game":"cs2"}`.

### Testing
- Ran `go test ./internal/media ./internal/prompts` and the package-level tests succeeded.  
- Ran full suite `go test ./...` and all tests passed.  
- The new test `TestWorkerProcessStreamerAppliesPostStepGameScenarioTransition` passed as part of the runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4b71c564832ca5cc093266320bf1)