### PR TITLE
fix: format internal/media worker test

### DIFF
--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -964,9 +964,9 @@ func TestWorkerProcessStreamerKeepsCurrentScenarioPackageStepAcrossCycles(t *tes
 	worker := NewWorker(
 		&fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Now().UTC()}},
 		fakeClassifier{results: map[string]StageClassification{
-			"root_detect":       {Label: "state_updated", Confidence: 0.9, UpdatedStateJSON: `{"game":"cs2"}`},
-			"cs2_mode":          {Label: "state_updated", Confidence: 0.9, UpdatedStateJSON: `{"mode":"matchmaking-5vs5","ct_score":1,"t_score":0}`},
-			"matchmaking-5vs5":  {Label: "state_updated", Confidence: 0.9, UpdatedStateJSON: `{"mode":"matchmaking-5vs5","ct_score":2,"t_score":0}`},
+			"root_detect":      {Label: "state_updated", Confidence: 0.9, UpdatedStateJSON: `{"game":"cs2"}`},
+			"cs2_mode":         {Label: "state_updated", Confidence: 0.9, UpdatedStateJSON: `{"mode":"matchmaking-5vs5","ct_score":1,"t_score":0}`},
+			"matchmaking-5vs5": {Label: "state_updated", Confidence: 0.9, UpdatedStateJSON: `{"mode":"matchmaking-5vs5","ct_score":2,"t_score":0}`},
 		}},
 		fakePromptResolver{
 			gameScenario: prompts.GameScenario{


### PR DESCRIPTION
### Motivation
- Fix failing CI formatting check by reformatting `internal/media/worker_test.go` with `gofmt`, restoring CI build stability.
- Checklist: [x] M2.1 CI formatting/quality fix; [ ] other M2.1 milestones; [ ] align with `docs/llm_stream_orchestration_plan.md` (no changes made).

### Description
- Applied `gofmt -w` to `internal/media/worker_test.go`, normalizing whitespace and aligning entries in the `map[string]StageClassification` literal.
- This is a test-only formatting change with no functional or API modifications.

### Testing
- Ran `gofmt -l internal/media/worker_test.go` which produced no output indicating the file is formatted.
- Ran `go test ./internal/media -run Test -count=1` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5d503b48832cae2fc7bdbddb09c1)