### PR TITLE
Move game scenario terminal conditions to transitions and update validation/consumers

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1650,11 +1650,6 @@ components:
           type: string
         scenarioPackageId:
           type: string
-        terminalConditions:
-          type: array
-          description: Terminal conditions scoped to this node (branch).
-          items:
-            $ref: '#/components/schemas/GameScenarioTerminalCondition'
     GameScenarioTransition:
       type: object
       required: [fromNodeId, toNodeId, condition, priority]
@@ -1671,6 +1666,11 @@ components:
         priority:
           type: integer
           minimum: 1
+        terminalConditions:
+          type: array
+          description: Transition-scoped terminal conditions evaluated only when this transition is matched.
+          items:
+            $ref: '#/components/schemas/GameScenarioTerminalCondition'
     GameScenarioTerminalCondition:
       type: object
       required: [condition]
@@ -1678,9 +1678,6 @@ components:
       properties:
         id:
           type: string
-        transitionId:
-          type: string
-          description: Optional transition ID for edge-scoped terminal conditions.
         condition:
           type: string
         resultLabel:
@@ -1711,11 +1708,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/GameScenarioTransition'
-        terminalConditions:
-          type: array
-          description: Deprecated graph-wide terminal conditions; prefer node-level terminalConditions.
-          items:
-            $ref: '#/components/schemas/GameScenarioTerminalCondition'
     GameScenario:
       allOf:
         - $ref: '#/components/schemas/GameScenarioCreateRequest'

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -120,53 +120,40 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 func gameScenarioRequestToCreateRequest(req gameScenarioCreateRequest, actorID string) prompts.GameScenarioCreateRequest {
 	nodes := make([]prompts.GameScenarioNode, 0, len(req.Nodes))
 	for _, node := range req.Nodes {
-		nodeTerminalConditions := make([]prompts.GameScenarioTerminalCondition, 0, len(node.TerminalConditions))
-		for _, item := range node.TerminalConditions {
-			nodeTerminalConditions = append(nodeTerminalConditions, prompts.GameScenarioTerminalCondition{
+		nodes = append(nodes, prompts.GameScenarioNode{
+			ID:                node.ID,
+			Alias:             node.Alias,
+			ScenarioPackageID: node.ScenarioPackageID,
+		})
+	}
+	transitions := make([]prompts.GameScenarioTransition, 0, len(req.Transitions))
+	for _, tr := range req.Transitions {
+		terminalConditions := make([]prompts.GameScenarioTerminalCondition, 0, len(tr.TerminalConditions))
+		for _, item := range tr.TerminalConditions {
+			terminalConditions = append(terminalConditions, prompts.GameScenarioTerminalCondition{
 				ID:              item.ID,
-				TransitionID:    item.TransitionID,
 				Condition:       item.Condition,
 				ResultLabel:     item.ResultLabel,
 				ResultStateJSON: item.ResultStateJSON,
 				Priority:        item.Priority,
 			})
 		}
-		nodes = append(nodes, prompts.GameScenarioNode{
-			ID:                 node.ID,
-			Alias:              node.Alias,
-			ScenarioPackageID:  node.ScenarioPackageID,
-			TerminalConditions: nodeTerminalConditions,
-		})
-	}
-	transitions := make([]prompts.GameScenarioTransition, 0, len(req.Transitions))
-	for _, tr := range req.Transitions {
 		transitions = append(transitions, prompts.GameScenarioTransition{
-			ID:         tr.ID,
-			FromNodeID: tr.FromNodeID,
-			ToNodeID:   tr.ToNodeID,
-			Condition:  tr.Condition,
-			Priority:   tr.Priority,
-		})
-	}
-	terminalConditions := make([]prompts.GameScenarioTerminalCondition, 0, len(req.TerminalConditions))
-	for _, item := range req.TerminalConditions {
-		terminalConditions = append(terminalConditions, prompts.GameScenarioTerminalCondition{
-			ID:              item.ID,
-			TransitionID:    item.TransitionID,
-			Condition:       item.Condition,
-			ResultLabel:     item.ResultLabel,
-			ResultStateJSON: item.ResultStateJSON,
-			Priority:        item.Priority,
+			ID:                 tr.ID,
+			FromNodeID:         tr.FromNodeID,
+			ToNodeID:           tr.ToNodeID,
+			Condition:          tr.Condition,
+			Priority:           tr.Priority,
+			TerminalConditions: terminalConditions,
 		})
 	}
 	return prompts.GameScenarioCreateRequest{
-		Name:               req.Name,
-		GameSlug:           req.GameSlug,
-		InitialNodeID:      req.InitialNodeID,
-		Nodes:              nodes,
-		Transitions:        transitions,
-		TerminalConditions: terminalConditions,
-		ActorID:            actorID,
+		Name:          req.Name,
+		GameSlug:      req.GameSlug,
+		InitialNodeID: req.InitialNodeID,
+		Nodes:         nodes,
+		Transitions:   transitions,
+		ActorID:       actorID,
 	}
 }
 
@@ -236,23 +223,22 @@ type scenarioPackageCreateRequest struct {
 }
 
 type gameScenarioNodeRequest struct {
-	ID                 string                                 `json:"id"`
-	Alias              string                                 `json:"alias"`
-	ScenarioPackageID  string                                 `json:"scenarioPackageId"`
-	TerminalConditions []gameScenarioTerminalConditionRequest `json:"terminalConditions"`
+	ID                string `json:"id"`
+	Alias             string `json:"alias"`
+	ScenarioPackageID string `json:"scenarioPackageId"`
 }
 
 type gameScenarioTransitionRequest struct {
-	ID         string `json:"id"`
-	FromNodeID string `json:"fromNodeId"`
-	ToNodeID   string `json:"toNodeId"`
-	Condition  string `json:"condition"`
-	Priority   int    `json:"priority"`
+	ID                 string                                 `json:"id"`
+	FromNodeID         string                                 `json:"fromNodeId"`
+	ToNodeID           string                                 `json:"toNodeId"`
+	Condition          string                                 `json:"condition"`
+	Priority           int                                    `json:"priority"`
+	TerminalConditions []gameScenarioTerminalConditionRequest `json:"terminalConditions"`
 }
 
 type gameScenarioTerminalConditionRequest struct {
 	ID              string `json:"id"`
-	TransitionID    string `json:"transitionId"`
 	Condition       string `json:"condition"`
 	ResultLabel     string `json:"resultLabel"`
 	ResultStateJSON string `json:"resultStateJson"`
@@ -260,12 +246,11 @@ type gameScenarioTerminalConditionRequest struct {
 }
 
 type gameScenarioCreateRequest struct {
-	Name               string                                 `json:"name"`
-	GameSlug           string                                 `json:"gameSlug"`
-	InitialNodeID      string                                 `json:"initialNodeId"`
-	Nodes              []gameScenarioNodeRequest              `json:"nodes"`
-	Transitions        []gameScenarioTransitionRequest        `json:"transitions"`
-	TerminalConditions []gameScenarioTerminalConditionRequest `json:"terminalConditions"`
+	Name          string                          `json:"name"`
+	GameSlug      string                          `json:"gameSlug"`
+	InitialNodeID string                          `json:"initialNodeId"`
+	Nodes         []gameScenarioNodeRequest       `json:"nodes"`
+	Transitions   []gameScenarioTransitionRequest `json:"transitions"`
 }
 
 type llmModelConfigUpsertRequest struct {

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -267,10 +267,12 @@ func TestAdminLLMGameScenarioRoutes(t *testing.T) {
 			{"id": "node-target", "alias": "Target Node", "scenarioPackageId": targetPkg.ID},
 		},
 		"transitions": []map[string]any{
-			{"id": "tr-1", "fromNodeId": "node-root", "toNodeId": "node-target", "condition": `game == "cs2"`, "priority": 10},
-		},
-		"terminalConditions": []map[string]any{
-			{"id": "tm-1", "condition": `winner == "ct" && side == "ct"`, "resultLabel": "ct_win", "resultStateJson": `{"result":"win"}`, "priority": 100},
+			{
+				"id": "tr-1", "fromNodeId": "node-root", "toNodeId": "node-target", "condition": `game == "cs2"`, "priority": 10,
+				"terminalConditions": []map[string]any{
+					{"id": "tm-1", "condition": `winner == "ct" && side == "ct"`, "resultLabel": "ct_win", "resultStateJson": `{"result":"win"}`, "priority": 100},
+				},
+			},
 		},
 	})
 	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/game-scenarios", bytes.NewReader(createBody))

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -788,7 +788,7 @@ func (w *Worker) planScenarioExecution(ctx context.Context, streamerID string, g
 		transitionTrace["status"] = "accepted"
 		transitionTrace["reason"] = "game_scenario_transition_matched"
 	}
-	if terminal, ok, terminalErr := gameScenario.ResolveTerminalCondition(resolvedNode.ID, matchedTransitionID, previousState); terminalErr != nil {
+	if terminal, ok, terminalErr := gameScenario.ResolveTerminalCondition(matchedTransitionID, previousState); terminalErr != nil {
 		return scenarioExecutionPlan{}, terminalErr
 	} else if ok {
 		transitionTrace = map[string]any{

--- a/internal/prompts/game_scenario.go
+++ b/internal/prompts/game_scenario.go
@@ -16,18 +16,18 @@ var (
 )
 
 type GameScenarioNode struct {
-	ID                 string                          `json:"id"`
-	Alias              string                          `json:"alias"`
-	ScenarioPackageID  string                          `json:"scenarioPackageId"`
-	TerminalConditions []GameScenarioTerminalCondition `json:"terminalConditions,omitempty"`
+	ID                string `json:"id"`
+	Alias             string `json:"alias"`
+	ScenarioPackageID string `json:"scenarioPackageId"`
 }
 
 type GameScenarioTransition struct {
-	ID         string `json:"id"`
-	FromNodeID string `json:"fromNodeId"`
-	ToNodeID   string `json:"toNodeId"`
-	Condition  string `json:"condition"`
-	Priority   int    `json:"priority"`
+	ID                 string                          `json:"id"`
+	FromNodeID         string                          `json:"fromNodeId"`
+	ToNodeID           string                          `json:"toNodeId"`
+	Condition          string                          `json:"condition"`
+	Priority           int                             `json:"priority"`
+	TerminalConditions []GameScenarioTerminalCondition `json:"terminalConditions,omitempty"`
 }
 
 type GameScenarioTerminalCondition struct {
@@ -40,29 +40,27 @@ type GameScenarioTerminalCondition struct {
 }
 
 type GameScenario struct {
-	ID                 string                          `json:"id"`
-	Name               string                          `json:"name"`
-	GameSlug           string                          `json:"gameSlug"`
-	Version            int                             `json:"version"`
-	IsActive           bool                            `json:"isActive"`
-	InitialNodeID      string                          `json:"initialNodeId"`
-	Nodes              []GameScenarioNode              `json:"nodes"`
-	Transitions        []GameScenarioTransition        `json:"transitions"`
-	TerminalConditions []GameScenarioTerminalCondition `json:"terminalConditions"`
-	CreatedBy          string                          `json:"createdBy"`
-	ActivatedBy        string                          `json:"activatedBy,omitempty"`
-	CreatedAt          time.Time                       `json:"createdAt"`
-	ActivatedAt        time.Time                       `json:"activatedAt,omitempty"`
+	ID            string                   `json:"id"`
+	Name          string                   `json:"name"`
+	GameSlug      string                   `json:"gameSlug"`
+	Version       int                      `json:"version"`
+	IsActive      bool                     `json:"isActive"`
+	InitialNodeID string                   `json:"initialNodeId"`
+	Nodes         []GameScenarioNode       `json:"nodes"`
+	Transitions   []GameScenarioTransition `json:"transitions"`
+	CreatedBy     string                   `json:"createdBy"`
+	ActivatedBy   string                   `json:"activatedBy,omitempty"`
+	CreatedAt     time.Time                `json:"createdAt"`
+	ActivatedAt   time.Time                `json:"activatedAt,omitempty"`
 }
 
 type GameScenarioCreateRequest struct {
-	Name               string
-	GameSlug           string
-	InitialNodeID      string
-	Nodes              []GameScenarioNode
-	Transitions        []GameScenarioTransition
-	TerminalConditions []GameScenarioTerminalCondition
-	ActorID            string
+	Name          string
+	GameSlug      string
+	InitialNodeID string
+	Nodes         []GameScenarioNode
+	Transitions   []GameScenarioTransition
+	ActorID       string
 }
 
 func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScenarioCreateRequest) error {
@@ -87,17 +85,6 @@ func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScena
 		}
 		if _, err := pkg.InitialStep(); err != nil {
 			return fmt.Errorf("%w: package %s has no valid initial step", ErrInvalidGameScenario, node.ScenarioPackageID)
-		}
-		for _, tc := range node.TerminalConditions {
-			if strings.TrimSpace(tc.Condition) == "" {
-				return fmt.Errorf("%w: node %s terminal condition is required", ErrInvalidGameScenario, nodeID)
-			}
-			if err := validateScenarioCondition(tc.Condition); err != nil {
-				return fmt.Errorf("%w: node %s terminal condition: %v", ErrInvalidGameScenario, nodeID, err)
-			}
-			if strings.TrimSpace(tc.ResultStateJSON) != "" && !isValidJSON(tc.ResultStateJSON) {
-				return fmt.Errorf("%w: node %s terminal resultStateJson must be valid json", ErrInvalidGameScenario, nodeID)
-			}
 		}
 		nodeIDs[nodeID] = node
 	}
@@ -126,27 +113,16 @@ func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScena
 			return fmt.Errorf("%w: transition target package %s has no initial step", ErrInvalidGameScenario, toNode.ScenarioPackageID)
 		}
 	}
-	transitionIDs := make(map[string]struct{}, len(req.Transitions))
 	for _, tr := range req.Transitions {
-		id := strings.TrimSpace(tr.ID)
-		if id == "" {
-			continue
-		}
-		transitionIDs[id] = struct{}{}
-	}
-	for _, tc := range req.TerminalConditions {
-		if strings.TrimSpace(tc.Condition) == "" {
-			return fmt.Errorf("%w: terminal condition is required", ErrInvalidGameScenario)
-		}
-		if err := validateScenarioCondition(tc.Condition); err != nil {
-			return fmt.Errorf("%w: terminal condition: %v", ErrInvalidGameScenario, err)
-		}
-		if strings.TrimSpace(tc.ResultStateJSON) != "" && !isValidJSON(tc.ResultStateJSON) {
-			return fmt.Errorf("%w: terminal resultStateJson must be valid json", ErrInvalidGameScenario)
-		}
-		if transitionID := strings.TrimSpace(tc.TransitionID); transitionID != "" {
-			if _, ok := transitionIDs[transitionID]; !ok {
-				return fmt.Errorf("%w: terminal transitionId %s not found", ErrInvalidGameScenario, transitionID)
+		for _, tc := range tr.TerminalConditions {
+			if strings.TrimSpace(tc.Condition) == "" {
+				return fmt.Errorf("%w: transition %s terminal condition is required", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
+			}
+			if err := validateScenarioCondition(tc.Condition); err != nil {
+				return fmt.Errorf("%w: transition %s terminal condition: %v", ErrInvalidGameScenario, strings.TrimSpace(tr.ID), err)
+			}
+			if strings.TrimSpace(tc.ResultStateJSON) != "" && !isValidJSON(tc.ResultStateJSON) {
+				return fmt.Errorf("%w: transition %s terminal resultStateJson must be valid json", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
 			}
 		}
 	}
@@ -180,16 +156,15 @@ func (s *Service) CreateGameScenario(ctx context.Context, req GameScenarioCreate
 	s.counter++
 	versions := s.gameScenarios[req.GameSlug]
 	item := GameScenario{
-		ID:                 fmt.Sprintf("game-scenario-%d", s.counter),
-		Name:               strings.TrimSpace(req.Name),
-		GameSlug:           strings.TrimSpace(req.GameSlug),
-		Version:            len(versions) + 1,
-		InitialNodeID:      strings.TrimSpace(req.InitialNodeID),
-		Nodes:              append([]GameScenarioNode(nil), req.Nodes...),
-		Transitions:        append([]GameScenarioTransition(nil), req.Transitions...),
-		TerminalConditions: append([]GameScenarioTerminalCondition(nil), req.TerminalConditions...),
-		CreatedBy:          strings.TrimSpace(req.ActorID),
-		CreatedAt:          now,
+		ID:            fmt.Sprintf("game-scenario-%d", s.counter),
+		Name:          strings.TrimSpace(req.Name),
+		GameSlug:      strings.TrimSpace(req.GameSlug),
+		Version:       len(versions) + 1,
+		InitialNodeID: strings.TrimSpace(req.InitialNodeID),
+		Nodes:         append([]GameScenarioNode(nil), req.Nodes...),
+		Transitions:   append([]GameScenarioTransition(nil), req.Transitions...),
+		CreatedBy:     strings.TrimSpace(req.ActorID),
+		CreatedAt:     now,
 	}
 	if !s.hasActiveGameScenarioLocked() {
 		item.IsActive = true
@@ -239,7 +214,6 @@ func (s *Service) UpdateGameScenario(ctx context.Context, id string, req GameSce
 			updated.InitialNodeID = strings.TrimSpace(req.InitialNodeID)
 			updated.Nodes = append([]GameScenarioNode(nil), req.Nodes...)
 			updated.Transitions = append([]GameScenarioTransition(nil), req.Transitions...)
-			updated.TerminalConditions = append([]GameScenarioTerminalCondition(nil), req.TerminalConditions...)
 			if updated.GameSlug != slug {
 				updated.IsActive = false
 				updated.ActivatedBy = ""
@@ -361,33 +335,24 @@ func (g GameScenario) InitialNode() (GameScenarioNode, error) {
 	return GameScenarioNode{}, ErrInvalidGameScenario
 }
 
-func (g GameScenario) ResolveTerminalCondition(nodeID, transitionID, stateJSON string) (GameScenarioTerminalCondition, bool, error) {
+func (g GameScenario) ResolveTerminalCondition(transitionID, stateJSON string) (GameScenarioTerminalCondition, bool, error) {
 	state := parseJSONMap(stateJSON)
-	ordered := make([]GameScenarioTerminalCondition, 0)
 	lookupTransitionID := strings.TrimSpace(transitionID)
-	if lookupTransitionID != "" {
-		for _, terminal := range g.TerminalConditions {
-			if strings.TrimSpace(terminal.TransitionID) == lookupTransitionID {
+	if lookupTransitionID == "" {
+		return GameScenarioTerminalCondition{}, false, nil
+	}
+	ordered := make([]GameScenarioTerminalCondition, 0)
+	for _, tr := range g.Transitions {
+		if strings.TrimSpace(tr.ID) == lookupTransitionID {
+			for _, terminal := range tr.TerminalConditions {
+				terminal.TransitionID = lookupTransitionID
 				ordered = append(ordered, terminal)
 			}
-		}
-	}
-	lookupNodeID := strings.TrimSpace(nodeID)
-	if len(ordered) == 0 && lookupNodeID != "" {
-		for _, node := range g.Nodes {
-			if strings.TrimSpace(node.ID) == lookupNodeID {
-				ordered = append(ordered, node.TerminalConditions...)
-				break
-			}
+			break
 		}
 	}
 	if len(ordered) == 0 {
-		for _, terminal := range g.TerminalConditions {
-			if strings.TrimSpace(terminal.TransitionID) != "" {
-				continue
-			}
-			ordered = append(ordered, terminal)
-		}
+		return GameScenarioTerminalCondition{}, false, nil
 	}
 	sort.SliceStable(ordered, func(i, j int) bool {
 		if ordered[i].Priority == ordered[j].Priority {

--- a/internal/prompts/game_scenario_test.go
+++ b/internal/prompts/game_scenario_test.go
@@ -44,9 +44,17 @@ func TestGameScenarioCRUD(t *testing.T) {
 			{ID: "n1", ScenarioPackageID: rootPkg.ID},
 			{ID: "n2", ScenarioPackageID: nextPkg.ID},
 		},
-		Transitions:        []GameScenarioTransition{{FromNodeID: "n1", ToNodeID: "n2", Condition: `game == "cs2"`, Priority: 10}},
-		TerminalConditions: []GameScenarioTerminalCondition{{Condition: `winner == "ct"`, ResultLabel: "ct_win", ResultStateJSON: `{"result":"win"}`, Priority: 100}},
-		ActorID:            "admin-1",
+		Transitions: []GameScenarioTransition{{
+			ID:         "tr-1",
+			FromNodeID: "n1",
+			ToNodeID:   "n2",
+			Condition:  `game == "cs2"`,
+			Priority:   10,
+			TerminalConditions: []GameScenarioTerminalCondition{
+				{ID: "tm-1", Condition: `winner == "ct"`, ResultLabel: "ct_win", ResultStateJSON: `{"result":"win"}`, Priority: 100},
+			},
+		}},
+		ActorID: "admin-1",
 	})
 	if err != nil {
 		t.Fatalf("CreateGameScenario() error = %v", err)
@@ -103,7 +111,7 @@ func TestGameScenarioCreateRejectsMissingTransitionCondition(t *testing.T) {
 	}
 }
 
-func TestGameScenarioCreateRejectsUnknownTerminalTransition(t *testing.T) {
+func TestGameScenarioCreateRejectsInvalidTransitionTerminalJSON(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService()
@@ -120,13 +128,20 @@ func TestGameScenarioCreateRejectsUnknownTerminalTransition(t *testing.T) {
 	}
 
 	_, err = svc.CreateGameScenario(context.Background(), GameScenarioCreateRequest{
-		Name:          "invalid-terminal-transition",
+		Name:          "invalid-transition-terminal-json",
 		GameSlug:      "cs2",
 		InitialNodeID: "n1",
 		Nodes:         []GameScenarioNode{{ID: "n1", ScenarioPackageID: pkg.ID}},
-		TerminalConditions: []GameScenarioTerminalCondition{
-			{TransitionID: "missing-edge", Condition: `winner == "ct"`, Priority: 1},
-		},
+		Transitions: []GameScenarioTransition{{
+			ID:         "tr-1",
+			FromNodeID: "n1",
+			ToNodeID:   "n1",
+			Condition:  `winner == "ct"`,
+			Priority:   1,
+			TerminalConditions: []GameScenarioTerminalCondition{
+				{Condition: `winner == "ct"`, ResultStateJSON: `{"broken"`, Priority: 1},
+			},
+		}},
 		ActorID: "admin-1",
 	})
 	if err == nil {
@@ -193,44 +208,34 @@ func TestGameScenarioActivateKeepsSingleActiveAcrossSlugs(t *testing.T) {
 	}
 }
 
-func TestGameScenarioResolveTerminalConditionPrefersNodeScope(t *testing.T) {
+func TestGameScenarioResolveTerminalConditionRequiresTransitionMatch(t *testing.T) {
 	t.Parallel()
 
 	scenario := GameScenario{
 		InitialNodeID: "n1",
-		Nodes: []GameScenarioNode{
+		Transitions: []GameScenarioTransition{
 			{
-				ID: "n1",
+				ID:         "edge-1",
+				FromNodeID: "n1",
+				ToNodeID:   "n2",
+				Condition:  `winner == "ct"`,
+				Priority:   100,
 				TerminalConditions: []GameScenarioTerminalCondition{
-					{ID: "node-win", Condition: `winner == "ct"`, ResultLabel: "node", Priority: 100},
+					{ID: "edge-win", Condition: `winner == "ct"`, ResultLabel: "edge", Priority: 100},
 				},
 			},
 		},
-		TerminalConditions: []GameScenarioTerminalCondition{
-			{ID: "global-win", Condition: `winner == "ct"`, ResultLabel: "global", Priority: 10},
-		},
 	}
 
-	terminal, ok, err := scenario.ResolveTerminalCondition("n1", "", `{"winner":"ct"}`)
+	terminal, ok, err := scenario.ResolveTerminalCondition("", `{"winner":"ct"}`)
 	if err != nil {
-		t.Fatalf("ResolveTerminalCondition(node): %v", err)
+		t.Fatalf("ResolveTerminalCondition(no-transition): %v", err)
 	}
-	if !ok {
-		t.Fatalf("expected node terminal condition to match")
+	if ok {
+		t.Fatalf("expected no terminal match without transition")
 	}
-	if terminal.ID != "node-win" {
-		t.Fatalf("expected node-level terminal condition, got %s", terminal.ID)
-	}
-
-	terminal, ok, err = scenario.ResolveTerminalCondition("missing-node", "", `{"winner":"ct"}`)
-	if err != nil {
-		t.Fatalf("ResolveTerminalCondition(fallback): %v", err)
-	}
-	if !ok {
-		t.Fatalf("expected fallback terminal condition to match")
-	}
-	if terminal.ID != "global-win" {
-		t.Fatalf("expected global fallback terminal condition, got %s", terminal.ID)
+	if terminal.ID != "" {
+		t.Fatalf("expected empty terminal, got %s", terminal.ID)
 	}
 }
 
@@ -240,22 +245,28 @@ func TestGameScenarioResolveTerminalConditionPrefersTransitionScope(t *testing.T
 	scenario := GameScenario{
 		InitialNodeID: "n1",
 		Transitions: []GameScenarioTransition{
-			{ID: "edge-1", FromNodeID: "n1", ToNodeID: "n2", Condition: `winner == "ct"`, Priority: 100},
-		},
-		TerminalConditions: []GameScenarioTerminalCondition{
-			{ID: "edge-win", TransitionID: "edge-1", Condition: `winner == "ct"`, ResultLabel: "edge", Priority: 200},
-			{ID: "global-win", Condition: `winner == "ct"`, ResultLabel: "global", Priority: 10},
+			{
+				ID:         "edge-1",
+				FromNodeID: "n1",
+				ToNodeID:   "n2",
+				Condition:  `winner == "ct"`,
+				Priority:   100,
+				TerminalConditions: []GameScenarioTerminalCondition{
+					{ID: "edge-win-high", Condition: `winner == "ct"`, ResultLabel: "edge", Priority: 200},
+					{ID: "edge-win-low", Condition: `winner == "ct"`, ResultLabel: "edge-low", Priority: 10},
+				},
+			},
 		},
 	}
 
-	terminal, ok, err := scenario.ResolveTerminalCondition("n2", "edge-1", `{"winner":"ct"}`)
+	terminal, ok, err := scenario.ResolveTerminalCondition("edge-1", `{"winner":"ct"}`)
 	if err != nil {
 		t.Fatalf("ResolveTerminalCondition(edge): %v", err)
 	}
 	if !ok {
 		t.Fatalf("expected edge terminal condition to match")
 	}
-	if terminal.ID != "edge-win" {
+	if terminal.ID != "edge-win-high" {
 		t.Fatalf("expected edge-level terminal condition, got %s", terminal.ID)
 	}
 }


### PR DESCRIPTION
### Motivation

- Simplify and clarify terminal condition scoping by attaching them to transitions instead of nodes or a deprecated graph-wide list.
- Ensure terminal conditions are evaluated only when a transition matches and to centralize validation and resolution behavior.

### Description

- Updated the OpenAPI spec to remove `terminalConditions` from `GameScenarioNode` and `GameScenarioCreateRequest` and add `terminalConditions` to `GameScenarioTransition` with a descriptive comment.
- Modified request/handler mapping in `internal/app/router.go` to marshal/unmarshal transition-scoped terminal conditions and removed node-level terminal condition handling.
- Refactored domain types in `internal/prompts/game_scenario.go` to move terminal conditions into `GameScenarioTransition`, removed global/node-scoped terminal lists from `GameScenario` and `GameScenarioCreateRequest`, and changed `ResolveTerminalCondition` to accept a `transitionID` and evaluate transition-scoped terminal conditions only.
- Updated `internal/media/worker.go` to call the new `ResolveTerminalCondition` signature and adjusted logic for handling terminal matches.
- Adjusted and added tests in `internal/prompts/game_scenario_test.go` and `internal/app/router_admin_llm_test.go` to reflect the new transition-scoped terminal conditions and to validate JSON and condition validation behavior.

### Testing

- Ran unit tests in the modified packages, including `internal/prompts` and `internal/app` scenario tests, with updated expectations for transition-scoped terminal conditions. 
- Executed `go test ./...` to verify changes compile and tests pass. 
- All modified and related tests succeeded after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb65995928832c8d38c00721cc435c)