### PR TITLE
Persist Game Scenarios to Postgres and enable full CRUD/activation

### DIFF
--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -298,6 +298,40 @@ func TestAdminLLMGameScenarioRoutes(t *testing.T) {
 	if getRes.Code != http.StatusOK {
 		t.Fatalf("game scenario get status=%d body=%s", getRes.Code, getRes.Body.String())
 	}
+	var loaded map[string]any
+	if err := json.Unmarshal(getRes.Body.Bytes(), &loaded); err != nil {
+		t.Fatalf("decode game scenario: %v", err)
+	}
+	if loaded["name"] != "cs2 game scenario" {
+		t.Fatalf("expected original name, got %#v", loaded["name"])
+	}
+
+	updateBody, _ := json.Marshal(map[string]any{
+		"name":          "cs2 game scenario updated",
+		"gameSlug":      "cs2",
+		"initialNodeId": "node-target",
+		"nodes": []map[string]any{
+			{"id": "node-root", "alias": "Root Node", "scenarioPackageId": rootPkg.ID},
+			{"id": "node-target", "alias": "Target Node", "scenarioPackageId": targetPkg.ID},
+		},
+		"transitions": []map[string]any{
+			{"id": "tr-2", "fromNodeId": "node-target", "toNodeId": "node-root", "condition": `game == "cs2"`, "priority": 9},
+		},
+	})
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/admin/llm/game-scenarios/"+id, bytes.NewReader(updateBody))
+	updateReq.Header.Set("Authorization", "Bearer "+adminToken)
+	updateRes := httptest.NewRecorder()
+	handler.ServeHTTP(updateRes, updateReq)
+	if updateRes.Code != http.StatusOK {
+		t.Fatalf("game scenario update status=%d body=%s", updateRes.Code, updateRes.Body.String())
+	}
+	var updated map[string]any
+	if err := json.Unmarshal(updateRes.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode updated game scenario: %v", err)
+	}
+	if updated["name"] != "cs2 game scenario updated" {
+		t.Fatalf("expected updated name, got %#v", updated["name"])
+	}
 
 	activateReq := httptest.NewRequest(http.MethodPost, "/api/admin/llm/game-scenarios/"+id+"/activate", nil)
 	activateReq.Header.Set("Authorization", "Bearer "+adminToken)
@@ -305,5 +339,13 @@ func TestAdminLLMGameScenarioRoutes(t *testing.T) {
 	handler.ServeHTTP(activateRes, activateReq)
 	if activateRes.Code != http.StatusOK {
 		t.Fatalf("game scenario activate status=%d body=%s", activateRes.Code, activateRes.Body.String())
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/admin/llm/game-scenarios/"+id, nil)
+	deleteReq.Header.Set("Authorization", "Bearer "+adminToken)
+	deleteRes := httptest.NewRecorder()
+	handler.ServeHTTP(deleteRes, deleteReq)
+	if deleteRes.Code != http.StatusNoContent {
+		t.Fatalf("game scenario delete status=%d body=%s", deleteRes.Code, deleteRes.Body.String())
 	}
 }

--- a/internal/prompts/game_scenario.go
+++ b/internal/prompts/game_scenario.go
@@ -130,7 +130,12 @@ func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScena
 }
 
 func (s *Service) ListGameScenarios(ctx context.Context) []GameScenario {
-	_ = ctx
+	if s.gameScenarioStore != nil {
+		items, err := s.gameScenarioStore.List(ctx)
+		if err == nil {
+			return items
+		}
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	items := make([]GameScenario, 0)
@@ -149,6 +154,22 @@ func (s *Service) ListGameScenarios(ctx context.Context) []GameScenario {
 func (s *Service) CreateGameScenario(ctx context.Context, req GameScenarioCreateRequest) (GameScenario, error) {
 	if err := s.validateGameScenarioRequest(ctx, req); err != nil {
 		return GameScenario{}, err
+	}
+	if s.gameScenarioStore != nil {
+		item := GameScenario{
+			Name:          strings.TrimSpace(req.Name),
+			GameSlug:      strings.TrimSpace(req.GameSlug),
+			InitialNodeID: strings.TrimSpace(req.InitialNodeID),
+			Nodes:         append([]GameScenarioNode(nil), req.Nodes...),
+			Transitions:   append([]GameScenarioTransition(nil), req.Transitions...),
+			CreatedBy:     strings.TrimSpace(req.ActorID),
+			CreatedAt:     time.Now().UTC(),
+		}
+		created, err := s.gameScenarioStore.Create(ctx, item)
+		if err != nil {
+			return GameScenario{}, err
+		}
+		return created, nil
 	}
 	now := time.Now().UTC()
 	s.mu.Lock()
@@ -176,10 +197,12 @@ func (s *Service) CreateGameScenario(ctx context.Context, req GameScenarioCreate
 }
 
 func (s *Service) GetGameScenario(ctx context.Context, id string) (GameScenario, error) {
-	_ = ctx
 	lookup := strings.TrimSpace(id)
 	if lookup == "" {
 		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	if s.gameScenarioStore != nil {
+		return s.gameScenarioStore.GetByID(ctx, lookup)
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -200,6 +223,18 @@ func (s *Service) UpdateGameScenario(ctx context.Context, id string, req GameSce
 	lookup := strings.TrimSpace(id)
 	if lookup == "" {
 		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	if s.gameScenarioStore != nil {
+		current, err := s.gameScenarioStore.GetByID(ctx, lookup)
+		if err != nil {
+			return GameScenario{}, err
+		}
+		current.Name = strings.TrimSpace(req.Name)
+		current.GameSlug = strings.TrimSpace(req.GameSlug)
+		current.InitialNodeID = strings.TrimSpace(req.InitialNodeID)
+		current.Nodes = append([]GameScenarioNode(nil), req.Nodes...)
+		current.Transitions = append([]GameScenarioTransition(nil), req.Transitions...)
+		return s.gameScenarioStore.Update(ctx, current)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -231,10 +266,12 @@ func (s *Service) UpdateGameScenario(ctx context.Context, id string, req GameSce
 }
 
 func (s *Service) DeleteGameScenario(ctx context.Context, id string) error {
-	_ = ctx
 	lookup := strings.TrimSpace(id)
 	if lookup == "" {
 		return ErrGameScenarioNotFound
+	}
+	if s.gameScenarioStore != nil {
+		return s.gameScenarioStore.Delete(ctx, lookup)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -255,10 +292,12 @@ func (s *Service) DeleteGameScenario(ctx context.Context, id string) error {
 }
 
 func (s *Service) ActivateGameScenario(ctx context.Context, id, actorID string) (GameScenario, error) {
-	_ = ctx
 	lookup := strings.TrimSpace(id)
 	if lookup == "" {
 		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	if s.gameScenarioStore != nil {
+		return s.gameScenarioStore.SetActive(ctx, lookup, strings.TrimSpace(actorID), time.Now().UTC())
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -299,10 +338,18 @@ func (s *Service) ActivateGameScenario(ctx context.Context, id, actorID string) 
 }
 
 func (s *Service) GetActiveGameScenario(ctx context.Context, gameSlug string) (GameScenario, error) {
-	_ = ctx
 	lookup := strings.TrimSpace(gameSlug)
 	if lookup == "" {
 		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	if s.gameScenarioStore != nil {
+		item, err := s.gameScenarioStore.GetActiveByGameSlug(ctx, lookup)
+		if err == nil {
+			return item, nil
+		}
+		if !errors.Is(err, ErrGameScenarioNotFound) {
+			return GameScenario{}, err
+		}
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/prompts/game_scenario_postgres.go
+++ b/internal/prompts/game_scenario_postgres.go
@@ -1,0 +1,299 @@
+package prompts
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type gameScenarioStore interface {
+	List(context.Context) ([]GameScenario, error)
+	Create(context.Context, GameScenario) (GameScenario, error)
+	Update(context.Context, GameScenario) (GameScenario, error)
+	Delete(context.Context, string) error
+	SetActive(context.Context, string, string, time.Time) (GameScenario, error)
+	GetByID(context.Context, string) (GameScenario, error)
+	GetActiveByGameSlug(context.Context, string) (GameScenario, error)
+}
+
+type PostgresGameScenarioStore struct {
+	db *sql.DB
+}
+
+func NewPostgresGameScenarioStore(db *sql.DB) *PostgresGameScenarioStore {
+	return &PostgresGameScenarioStore{db: db}
+}
+
+func (s *PostgresGameScenarioStore) List(ctx context.Context) ([]GameScenario, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, name, version, game_slug, is_active, initial_node_id,
+       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
+FROM llm_game_scenarios
+ORDER BY game_slug ASC, version DESC, created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	items := make([]GameScenario, 0)
+	for rows.Next() {
+		item, err := scanGameScenario(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (s *PostgresGameScenarioStore) Create(ctx context.Context, item GameScenario) (GameScenario, error) {
+	if item.ID == "" {
+		item.ID = "game-scenario-" + uuid.NewString()
+	}
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = time.Now().UTC()
+	}
+	if strings.TrimSpace(item.GameSlug) == "" {
+		item.GameSlug = "global"
+	}
+
+	var version int
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(version), 0) + 1 FROM llm_game_scenarios WHERE game_slug = $1`, item.GameSlug).Scan(&version); err != nil {
+		return GameScenario{}, err
+	}
+	item.Version = version
+
+	var hasActive bool
+	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM llm_game_scenarios WHERE is_active = TRUE)`).Scan(&hasActive); err != nil {
+		return GameScenario{}, err
+	}
+	if !hasActive {
+		item.IsActive = true
+		item.ActivatedBy = item.CreatedBy
+		item.ActivatedAt = item.CreatedAt
+	}
+
+	nodesJSON, transitionsJSON, err := encodeGameScenarioPayload(item)
+	if err != nil {
+		return GameScenario{}, err
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO llm_game_scenarios (
+	id, game_slug, name, version, is_active, initial_node_id,
+	nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11, $12)`,
+		item.ID, item.GameSlug, item.Name, item.Version, item.IsActive, item.InitialNodeID,
+		nodesJSON, transitionsJSON, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt),
+	)
+	if err != nil {
+		return GameScenario{}, err
+	}
+	return item, nil
+}
+
+func (s *PostgresGameScenarioStore) Update(ctx context.Context, item GameScenario) (GameScenario, error) {
+	nodesJSON, transitionsJSON, err := encodeGameScenarioPayload(item)
+	if err != nil {
+		return GameScenario{}, err
+	}
+
+	res, err := s.db.ExecContext(ctx, `
+UPDATE llm_game_scenarios
+SET game_slug = $2,
+	name = $3,
+	is_active = $4,
+	initial_node_id = $5,
+	nodes_json = $6::jsonb,
+	transitions_json = $7::jsonb,
+	activated_by = $8,
+	activated_at = $9
+WHERE id = $1`,
+		item.ID, item.GameSlug, item.Name, item.IsActive, item.InitialNodeID,
+		nodesJSON, transitionsJSON, item.ActivatedBy, nullableTime(item.ActivatedAt),
+	)
+	if err != nil {
+		return GameScenario{}, err
+	}
+	if affected, _ := res.RowsAffected(); affected == 0 {
+		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	return s.GetByID(ctx, item.ID)
+}
+
+func (s *PostgresGameScenarioStore) Delete(ctx context.Context, id string) error {
+	item, err := s.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	res, err := tx.ExecContext(ctx, `DELETE FROM llm_game_scenarios WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	if affected, _ := res.RowsAffected(); affected == 0 {
+		return ErrGameScenarioNotFound
+	}
+
+	if item.IsActive {
+		var replacementID string
+		err = tx.QueryRowContext(ctx, `
+SELECT id
+FROM llm_game_scenarios
+ORDER BY created_at DESC, id DESC
+LIMIT 1`).Scan(&replacementID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if replacementID != "" {
+			now := time.Now().UTC()
+			if _, err := tx.ExecContext(ctx, `UPDATE llm_game_scenarios SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1`, replacementID, item.ActivatedBy, now); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *PostgresGameScenarioStore) SetActive(ctx context.Context, id string, actorID string, now time.Time) (GameScenario, error) {
+	if _, err := s.GetByID(ctx, id); err != nil {
+		return GameScenario{}, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return GameScenario{}, err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(ctx, `UPDATE llm_game_scenarios SET is_active = FALSE, activated_by = '', activated_at = NULL WHERE is_active = TRUE`); err != nil {
+		return GameScenario{}, err
+	}
+	res, err := tx.ExecContext(ctx, `UPDATE llm_game_scenarios SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1`, id, actorID, now)
+	if err != nil {
+		return GameScenario{}, err
+	}
+	if affected, _ := res.RowsAffected(); affected == 0 {
+		return GameScenario{}, ErrGameScenarioNotFound
+	}
+
+	if err := tx.Commit(); err != nil {
+		return GameScenario{}, err
+	}
+	return s.GetByID(ctx, id)
+}
+
+func (s *PostgresGameScenarioStore) GetByID(ctx context.Context, id string) (GameScenario, error) {
+	row := s.db.QueryRowContext(ctx, `
+SELECT id, name, version, game_slug, is_active, initial_node_id,
+       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
+FROM llm_game_scenarios
+WHERE id = $1`, id)
+	item, err := scanGameScenario(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	return item, err
+}
+
+func (s *PostgresGameScenarioStore) GetActiveByGameSlug(ctx context.Context, gameSlug string) (GameScenario, error) {
+	row := s.db.QueryRowContext(ctx, `
+SELECT id, name, version, game_slug, is_active, initial_node_id,
+       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
+FROM llm_game_scenarios
+WHERE game_slug = $1 AND is_active = TRUE
+LIMIT 1`, gameSlug)
+	item, err := scanGameScenario(row)
+	if err == nil {
+		return item, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return GameScenario{}, err
+	}
+	fallback := s.db.QueryRowContext(ctx, `
+SELECT id, name, version, game_slug, is_active, initial_node_id,
+       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
+FROM llm_game_scenarios
+WHERE is_active = TRUE
+ORDER BY created_at DESC, id DESC
+LIMIT 1`)
+	item, err = scanGameScenario(fallback)
+	if errors.Is(err, sql.ErrNoRows) {
+		return GameScenario{}, ErrGameScenarioNotFound
+	}
+	return item, err
+}
+
+type gameScenarioScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanGameScenario(scanner gameScenarioScanner) (GameScenario, error) {
+	var item GameScenario
+	var activatedAt sql.NullTime
+	var nodesRaw []byte
+	var transitionsRaw []byte
+	err := scanner.Scan(
+		&item.ID,
+		&item.Name,
+		&item.Version,
+		&item.GameSlug,
+		&item.IsActive,
+		&item.InitialNodeID,
+		&nodesRaw,
+		&transitionsRaw,
+		&item.CreatedBy,
+		&item.ActivatedBy,
+		&item.CreatedAt,
+		&activatedAt,
+	)
+	if err != nil {
+		return GameScenario{}, err
+	}
+	if len(nodesRaw) > 0 {
+		if err := json.Unmarshal(nodesRaw, &item.Nodes); err != nil {
+			return GameScenario{}, fmt.Errorf("unmarshal nodes_json: %w", err)
+		}
+	}
+	if len(transitionsRaw) > 0 {
+		if err := json.Unmarshal(transitionsRaw, &item.Transitions); err != nil {
+			return GameScenario{}, fmt.Errorf("unmarshal transitions_json: %w", err)
+		}
+	}
+	if activatedAt.Valid {
+		item.ActivatedAt = activatedAt.Time
+	}
+	return item, nil
+}
+
+func encodeGameScenarioPayload(item GameScenario) ([]byte, []byte, error) {
+	nodesJSON, err := json.Marshal(item.Nodes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal nodes_json: %w", err)
+	}
+	transitionsJSON, err := json.Marshal(item.Transitions)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal transitions_json: %w", err)
+	}
+	return nodesJSON, transitionsJSON, nil
+}

--- a/internal/prompts/game_scenario_postgres_test.go
+++ b/internal/prompts/game_scenario_postgres_test.go
@@ -1,0 +1,120 @@
+package prompts
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPostgresGameScenarioStoreCreate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresGameScenarioStore(db)
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(version), 0) + 1 FROM llm_game_scenarios WHERE game_slug = $1`)).
+		WithArgs("cs2").
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (SELECT 1 FROM llm_game_scenarios WHERE is_active = TRUE)`)).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectExec(regexp.QuoteMeta(`
+INSERT INTO llm_game_scenarios (
+	id, game_slug, name, version, is_active, initial_node_id,
+	nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11, $12)`)).
+		WithArgs(
+			sqlmock.AnyArg(),
+			"cs2",
+			"scenario",
+			1,
+			true,
+			"n1",
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			"admin",
+			"admin",
+			now,
+			now,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	item, err := store.Create(context.Background(), GameScenario{
+		Name:          "scenario",
+		GameSlug:      "cs2",
+		InitialNodeID: "n1",
+		Nodes:         []GameScenarioNode{{ID: "n1", ScenarioPackageID: "pkg-1"}},
+		CreatedBy:     "admin",
+		CreatedAt:     now,
+	})
+	if err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+	if !item.IsActive {
+		t.Fatalf("expected first scenario to be active")
+	}
+	if item.Version != 1 {
+		t.Fatalf("expected version 1, got %d", item.Version)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestPostgresGameScenarioStoreGetActiveByGameSlugFallsBackToGlobal(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresGameScenarioStore(db)
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	nodes := `[{"id":"n1","scenarioPackageId":"pkg-1"}]`
+	transitions := `[]`
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, name, version, game_slug, is_active, initial_node_id,
+       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
+FROM llm_game_scenarios
+WHERE game_slug = $1 AND is_active = TRUE
+LIMIT 1`)).
+		WithArgs("dota2").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "version", "game_slug", "is_active", "initial_node_id",
+			"nodes_json", "transitions_json", "created_by", "activated_by", "created_at", "activated_at",
+		}))
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, name, version, game_slug, is_active, initial_node_id,
+       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
+FROM llm_game_scenarios
+WHERE is_active = TRUE
+ORDER BY created_at DESC, id DESC
+LIMIT 1`)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "version", "game_slug", "is_active", "initial_node_id",
+			"nodes_json", "transitions_json", "created_by", "activated_by", "created_at", "activated_at",
+		}).AddRow("game-scenario-1", "scenario", 1, "cs2", true, "n1", []byte(nodes), []byte(transitions), "admin", "admin", now, now))
+
+	item, err := store.GetActiveByGameSlug(context.Background(), "dota2")
+	if err != nil {
+		t.Fatalf("store.GetActiveByGameSlug: %v", err)
+	}
+	if item.ID != "game-scenario-1" {
+		t.Fatalf("unexpected id: %s", item.ID)
+	}
+	if item.GameSlug != "cs2" {
+		t.Fatalf("unexpected game slug: %s", item.GameSlug)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/internal/prompts/service.go
+++ b/internal/prompts/service.go
@@ -7,14 +7,15 @@ import (
 
 // Service stores scenario-graph v2 configuration in memory and model configs in configured store.
 type Service struct {
-	mu               sync.RWMutex
-	counter          int
-	configCounter    int
-	scenarioPackages map[string][]ScenarioPackage
-	gameScenarios    map[string][]GameScenario
-	modelConfigs     map[string]LLMModelConfig
-	modelConfigStore modelConfigStore
-	scenarioStore    scenarioPackageStore
+	mu                sync.RWMutex
+	counter           int
+	configCounter     int
+	scenarioPackages  map[string][]ScenarioPackage
+	gameScenarios     map[string][]GameScenario
+	modelConfigs      map[string]LLMModelConfig
+	modelConfigStore  modelConfigStore
+	scenarioStore     scenarioPackageStore
+	gameScenarioStore gameScenarioStore
 }
 
 func NewService() *Service {
@@ -30,6 +31,7 @@ func NewPostgresService(db *sql.DB) *Service {
 	if db != nil {
 		svc.modelConfigStore = NewPostgresModelConfigStore(db)
 		svc.scenarioStore = NewPostgresScenarioPackageStore(db)
+		svc.gameScenarioStore = NewPostgresGameScenarioStore(db)
 	}
 	return svc
 }

--- a/migrations/0013_llm_game_scenarios.down.sql
+++ b/migrations/0013_llm_game_scenarios.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS llm_game_scenarios;

--- a/migrations/0013_llm_game_scenarios.up.sql
+++ b/migrations/0013_llm_game_scenarios.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS llm_game_scenarios (
+    id TEXT PRIMARY KEY,
+    game_slug TEXT NOT NULL,
+    name TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT FALSE,
+    initial_node_id TEXT NOT NULL,
+    nodes_json JSONB NOT NULL,
+    transitions_json JSONB NOT NULL,
+    created_by TEXT NOT NULL,
+    activated_by TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    activated_at TIMESTAMPTZ NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_game_scenarios_game_slug_version ON llm_game_scenarios (game_slug, version DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_game_scenarios_active ON llm_game_scenarios (is_active);


### PR DESCRIPTION
### Motivation
- Admin edits to Game scenarios were lost/overwritten due to the runtime using in-memory state, causing stale UI payloads to reappear after changes; persistent storage is required.
- Provide reliable admin CRUD and activation behavior for game scenarios in production while keeping in-memory behavior for local/test runs.
- Checklist (aligned to `docs/implementation_plan.md` M2.1 and `docs/llm_stream_orchestration_plan.md`):
  - [x] Add persistent storage and migrations for game scenarios.
  - [x] Wire service to prefer DB-backed store when configured while keeping in-memory fallback.
  - [ ] Frontend visual/UX synchronization and graph UI (out of scope for this change).

### Description
- Added a Postgres-backed store for `GameScenario` with full CRUD and activation semantics in `internal/prompts/game_scenario_postgres.go` and exposed it via a `gameScenarioStore` interface.
- Wired the new store into `prompts.Service` in `internal/prompts/service.go` via `NewPostgresService`, preserving the in-memory implementation as a fallback when no DB is configured.
- Updated service-level methods in `internal/prompts/game_scenario.go` (`List/Get/Create/Update/Delete/Activate/GetActive`) to route through the DB store when present, otherwise use existing in-memory logic.
- Added migration files `migrations/0013_llm_game_scenarios.up.sql` and `migrations/0013_llm_game_scenarios.down.sql` to create/drop the `llm_game_scenarios` table and indexes.
- Expanded tests: added `internal/prompts/game_scenario_postgres_test.go` (sqlmock tests for create and active-fallback) and extended `internal/app/router_admin_llm_test.go` to cover update and delete paths for the admin game-scenarios endpoints.

### Testing
- Ran unit tests for the modified packages: `go test ./internal/prompts ./internal/app` which passed (ok).
- Ran full test suite `go test ./...` which completed successfully (ok).
- New/updated tests added: `internal/prompts/game_scenario_postgres_test.go` and extended `internal/app/router_admin_llm_test.go`, both executed as part of `go test` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7ac444ac832caa963a10e50e19a3)