### PR TITLE
Prefer transition-scoped terminal conditions, add global fallback and evaluator helper

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1668,7 +1668,7 @@ components:
           minimum: 1
         terminalConditions:
           type: array
-          description: Transition-scoped terminal conditions evaluated only when this transition is matched.
+          description: Terminal conditions attached to a transition. Runtime first evaluates terminal conditions from the matched transition, then falls back to evaluating terminal conditions from other transitions globally when no matched-transition terminal condition succeeds.
           items:
             $ref: '#/components/schemas/GameScenarioTerminalCondition'
     GameScenarioTerminalCondition:

--- a/internal/prompts/game_scenario.go
+++ b/internal/prompts/game_scenario.go
@@ -385,29 +385,56 @@ func (g GameScenario) InitialNode() (GameScenarioNode, error) {
 func (g GameScenario) ResolveTerminalCondition(transitionID, stateJSON string) (GameScenarioTerminalCondition, bool, error) {
 	state := parseJSONMap(stateJSON)
 	lookupTransitionID := strings.TrimSpace(transitionID)
-	if lookupTransitionID == "" {
-		return GameScenarioTerminalCondition{}, false, nil
-	}
-	ordered := make([]GameScenarioTerminalCondition, 0)
-	for _, tr := range g.Transitions {
-		if strings.TrimSpace(tr.ID) == lookupTransitionID {
-			for _, terminal := range tr.TerminalConditions {
-				terminal.TransitionID = lookupTransitionID
-				ordered = append(ordered, terminal)
+	orderedForTransition := make([]GameScenarioTerminalCondition, 0)
+	if lookupTransitionID != "" {
+		for _, tr := range g.Transitions {
+			if strings.TrimSpace(tr.ID) == lookupTransitionID {
+				for _, terminal := range tr.TerminalConditions {
+					terminal.TransitionID = lookupTransitionID
+					orderedForTransition = append(orderedForTransition, terminal)
+				}
+				break
 			}
-			break
 		}
 	}
-	if len(ordered) == 0 {
+	if terminal, ok, err := evaluateOrderedTerminals(orderedForTransition, state); err != nil {
+		return GameScenarioTerminalCondition{}, false, err
+	} else if ok {
+		return terminal, true, nil
+	}
+
+	orderedGlobal := make([]GameScenarioTerminalCondition, 0)
+	for _, tr := range g.Transitions {
+		transitionRef := strings.TrimSpace(tr.ID)
+		if transitionRef == lookupTransitionID {
+			continue
+		}
+		for _, terminal := range tr.TerminalConditions {
+			terminal.TransitionID = transitionRef
+			orderedGlobal = append(orderedGlobal, terminal)
+		}
+	}
+	if terminal, ok, err := evaluateOrderedTerminals(orderedGlobal, state); err != nil {
+		return GameScenarioTerminalCondition{}, false, err
+	} else if ok {
+		return terminal, true, nil
+	}
+	return GameScenarioTerminalCondition{}, false, nil
+}
+
+func evaluateOrderedTerminals(items []GameScenarioTerminalCondition, state map[string]any) (GameScenarioTerminalCondition, bool, error) {
+	if len(items) == 0 {
 		return GameScenarioTerminalCondition{}, false, nil
 	}
-	sort.SliceStable(ordered, func(i, j int) bool {
-		if ordered[i].Priority == ordered[j].Priority {
-			return strings.TrimSpace(ordered[i].ID) < strings.TrimSpace(ordered[j].ID)
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].Priority == items[j].Priority {
+			left := strings.TrimSpace(items[i].TransitionID) + ":" + strings.TrimSpace(items[i].ID)
+			right := strings.TrimSpace(items[j].TransitionID) + ":" + strings.TrimSpace(items[j].ID)
+			return left < right
 		}
-		return ordered[i].Priority > ordered[j].Priority
+		return items[i].Priority > items[j].Priority
 	})
-	for _, terminal := range ordered {
+	for _, terminal := range items {
 		ok, err := evaluateCondition(terminal.Condition, state)
 		if err != nil {
 			return GameScenarioTerminalCondition{}, false, err

--- a/internal/prompts/game_scenario_test.go
+++ b/internal/prompts/game_scenario_test.go
@@ -208,7 +208,7 @@ func TestGameScenarioActivateKeepsSingleActiveAcrossSlugs(t *testing.T) {
 	}
 }
 
-func TestGameScenarioResolveTerminalConditionRequiresTransitionMatch(t *testing.T) {
+func TestGameScenarioResolveTerminalConditionFallsBackToGlobalScope(t *testing.T) {
 	t.Parallel()
 
 	scenario := GameScenario{
@@ -231,11 +231,14 @@ func TestGameScenarioResolveTerminalConditionRequiresTransitionMatch(t *testing.
 	if err != nil {
 		t.Fatalf("ResolveTerminalCondition(no-transition): %v", err)
 	}
-	if ok {
-		t.Fatalf("expected no terminal match without transition")
+	if !ok {
+		t.Fatalf("expected global terminal match without transition")
 	}
-	if terminal.ID != "" {
-		t.Fatalf("expected empty terminal, got %s", terminal.ID)
+	if terminal.ID != "edge-win" {
+		t.Fatalf("expected global terminal match edge-win, got %s", terminal.ID)
+	}
+	if terminal.TransitionID != "edge-1" {
+		t.Fatalf("expected transition reference edge-1, got %s", terminal.TransitionID)
 	}
 }
 
@@ -268,5 +271,49 @@ func TestGameScenarioResolveTerminalConditionPrefersTransitionScope(t *testing.T
 	}
 	if terminal.ID != "edge-win-high" {
 		t.Fatalf("expected edge-level terminal condition, got %s", terminal.ID)
+	}
+}
+
+func TestGameScenarioResolveTerminalConditionPrefersMatchedTransitionBeforeGlobal(t *testing.T) {
+	t.Parallel()
+
+	scenario := GameScenario{
+		InitialNodeID: "n1",
+		Transitions: []GameScenarioTransition{
+			{
+				ID:         "edge-1",
+				FromNodeID: "n1",
+				ToNodeID:   "n2",
+				Condition:  `winner == "ct"`,
+				Priority:   100,
+				TerminalConditions: []GameScenarioTerminalCondition{
+					{ID: "edge-win-local", Condition: `winner == "ct"`, ResultLabel: "local", Priority: 10},
+				},
+			},
+			{
+				ID:         "edge-2",
+				FromNodeID: "n2",
+				ToNodeID:   "n3",
+				Condition:  `winner == "ct"`,
+				Priority:   90,
+				TerminalConditions: []GameScenarioTerminalCondition{
+					{ID: "edge-win-global", Condition: `winner == "ct"`, ResultLabel: "global", Priority: 999},
+				},
+			},
+		},
+	}
+
+	terminal, ok, err := scenario.ResolveTerminalCondition("edge-1", `{"winner":"ct"}`)
+	if err != nil {
+		t.Fatalf("ResolveTerminalCondition(edge): %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected terminal condition to match")
+	}
+	if terminal.ID != "edge-win-local" {
+		t.Fatalf("expected transition-scoped terminal to be preferred, got %s", terminal.ID)
+	}
+	if terminal.TransitionID != "edge-1" {
+		t.Fatalf("expected transition reference edge-1, got %s", terminal.TransitionID)
 	}
 }


### PR DESCRIPTION
### Motivation

- Ensure runtime evaluates terminal conditions attached to a matched transition first and then falls back to global transition-scoped terminal conditions when no matched-transition terminal succeeds.
- Clarify the OpenAPI documentation for `terminalConditions` to reflect runtime evaluation order.

### Description

- Change `GameScenario.ResolveTerminalCondition` to first collect and evaluate terminal conditions from the matched transition (when a `transitionID` is provided) and then fall back to evaluating terminal conditions from other transitions globally when no matched-transition terminal condition succeeds.
- Extract the terminal evaluation and ordering logic into a helper `evaluateOrderedTerminals(items []GameScenarioTerminalCondition, state map[string]any)` and use `TransitionID` as part of tie-breaking ordering keys.
- Update sorting to prefer higher `priority` and break ties using `TransitionID:ID` string ordering to ensure deterministic ordering across transitions.
- Update `docs/openapi.yaml` description for `terminalConditions` to document the evaluation order change.

### Testing

- Ran unit tests in the prompts package covering terminal resolution, including `TestGameScenarioResolveTerminalConditionFallsBackToGlobalScope`, `TestGameScenarioResolveTerminalConditionPrefersTransitionScope`, and `TestGameScenarioResolveTerminalConditionPrefersMatchedTransitionBeforeGlobal`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb81fd7704832cbf9965a7b0f10123)