### PR TITLE
fix: format internal/media worker tests

### DIFF
--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -871,7 +871,7 @@ func TestWorkerProcessStreamerIgnoresScenarioPackageHopTransitions(t *testing.T)
 		&fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Now().UTC()}},
 		fakeClassifier{results: map[string]StageClassification{"initial": {Label: "ok", Confidence: 0.9}}},
 		fakePromptResolver{
-			scenario: rootPackage,
+			scenario:       rootPackage,
 			llmModelConfig: prompts.LLMModelConfig{ID: "cfg-default", Model: "gemini-2.5-flash"},
 		},
 		&InMemoryRunStore{},


### PR DESCRIPTION
### Motivation
- Resolve a CI Verify formatting failure by applying `gofmt` to the tests so the build passes without changing behavior.

### Description
- Run `gofmt -w` on `internal/media/worker_test.go` and commit the formatting-only change (no functional changes to code).

### Testing
- Verified formatting with `gofmt -l internal/media/worker_test.go` and ran `go test ./internal/media`, both commands completed successfully.
- Checklist aligned with implementation plan: [x] CI formatting fix (internal/media/worker_test.go); [ ] Implement scenario-graph v2 runtime (M2.1); [ ] Validate State + transitions on backend; [ ] Complete immediate backend scope from `docs/llm_stream_orchestration_plan.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8dfc8b00832c84c52ca493ae5d7e)