### PR TITLE
Upload Bunny video fragments per LLM response and attach to admin history

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -200,7 +200,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - When Streamlink reports that a Twitch URL has no playable streams (for example, the stream ended or is offline), the scheduler treats that cycle as a graceful skip instead of a hard worker failure and retries on the next 10-second window.
 - `GET /api/streamers/{streamerId}/status` – returns the latest aggregated LLM match-session / state-tracker status for a streamer, including full chronological LLM call history (`history`) with request/response payloads per decision.
 - `DELETE /api/streamers/{streamerId}/tracking` – stops the active Streamlink/LLM tracking loop for a streamer and returns the updated `stopped` status so the client can disable the tracking button immediately.
-- `GET /api/admin/streamers/{streamerId}/llm-history?page=1&pageSize=20` – admin timeline endpoint with paginated LLM decision history (step name, LLM response, global state delta, event timestamps) plus uploaded Bunny video metadata for the streamer.
+- `GET /api/admin/streamers/{streamerId}/llm-history?page=1&pageSize=20` – admin timeline endpoint with paginated LLM decision history (step name, LLM response, global state delta, event timestamps). Each LLM event now carries its own Bunny video fragment URL in `videoData`, plus the endpoint returns uploaded Bunny video metadata for the streamer.
 - `DELETE /api/admin/streamers/{streamerId}/llm-history` – admin cleanup endpoint that deletes persisted LLM decision history and removes tracked Bunny videos for the streamer.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
 - `GET /api/admin/games` – admin-only endpoint listing all configured games.

--- a/internal/app/router_admin_streamers_history_test.go
+++ b/internal/app/router_admin_streamers_history_test.go
@@ -54,9 +54,9 @@ func TestAdminStreamerHistoryGetWithPagination(t *testing.T) {
 	)
 
 	for _, req := range []streamers.RecordDecisionRequest{
-		{RunID: "run-1", StreamerID: "str-1", Stage: "root_detect", Label: "cs_detected", Confidence: 0.9, UpdatedStateJSON: `{"state":{"game":"cs2"}}`},
-		{RunID: "run-1", StreamerID: "str-1", Stage: "mode_detect", Label: "competitive", Confidence: 0.8, UpdatedStateJSON: `{"state":{"mode":"competitive"}}`},
-		{RunID: "run-1", StreamerID: "str-1", Stage: "state_tracker", Label: "score_update", Confidence: 0.7, UpdatedStateJSON: `{"state":{"ct":10,"t":8}}`},
+		{RunID: "run-1", StreamerID: "str-1", Stage: "root_detect", Label: "cs_detected", Confidence: 0.9, UpdatedStateJSON: `{"state":{"game":"cs2"}}`, ChunkRef: "https://player.mediadelivery.net/play/lib-1/video-0"},
+		{RunID: "run-1", StreamerID: "str-1", Stage: "mode_detect", Label: "competitive", Confidence: 0.8, UpdatedStateJSON: `{"state":{"mode":"competitive"}}`, ChunkRef: "https://player.mediadelivery.net/play/lib-1/video-1"},
+		{RunID: "run-1", StreamerID: "str-1", Stage: "state_tracker", Label: "score_update", Confidence: 0.7, UpdatedStateJSON: `{"state":{"ct":10,"t":8}}`, ChunkRef: "https://player.mediadelivery.net/play/lib-1/video-2"},
 	} {
 		if _, err := streamersService.RecordLLMDecision(context.Background(), req); err != nil {
 			t.Fatalf("RecordLLMDecision() error = %v", err)
@@ -85,6 +85,9 @@ func TestAdminStreamerHistoryGetWithPagination(t *testing.T) {
 	item, _ := items[0].(map[string]any)
 	if item["stepName"] != "state_tracker" {
 		t.Fatalf("expected state_tracker step, got %#v", item["stepName"])
+	}
+	if item["videoData"] != "https://player.mediadelivery.net/play/lib-1/video-2" {
+		t.Fatalf("expected item videoData, got %#v", item["videoData"])
 	}
 	videos, ok := payload["videos"].([]any)
 	if !ok || len(videos) != 1 {

--- a/internal/media/publisher.go
+++ b/internal/media/publisher.go
@@ -75,76 +75,41 @@ func NewBunnyChunkPublisher(cfg BunnyChunkPublisherConfig) *BunnyChunkPublisher 
 	}
 }
 
-func (p *BunnyChunkPublisher) Publish(ctx context.Context, streamerID string, chunk ChunkRef) error {
+func (p *BunnyChunkPublisher) Publish(ctx context.Context, streamerID string, chunk ChunkRef) (UploadedVideo, error) {
 	if p == nil {
-		return nil
+		return UploadedVideo{}, nil
 	}
 	if strings.TrimSpace(p.cfg.LibraryID) == "" || strings.TrimSpace(p.cfg.APIKey) == "" {
-		return nil
+		return UploadedVideo{}, nil
 	}
 	chunkPath := strings.TrimSpace(chunk.Reference)
 	if chunkPath == "" {
-		return fmt.Errorf("publish chunk: empty chunk reference")
+		return UploadedVideo{}, fmt.Errorf("publish chunk: empty chunk reference")
 	}
-
-	segmentsDir := filepath.Join(p.cfg.OutputDir, sanitizeToken(streamerID), "segments")
-	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
-		return err
-	}
-	nextIndex, err := p.nextSegmentIndex(segmentsDir)
+	videoID, title, err := p.createVideo(ctx, streamerID, chunk.CapturedAt)
 	if err != nil {
-		return err
+		return UploadedVideo{}, err
 	}
-	segmentPath := filepath.Join(segmentsDir, fmt.Sprintf("%09d.mp4", nextIndex))
-	if err := os.Rename(chunkPath, segmentPath); err != nil {
-		return err
+	if err := p.uploadVideo(ctx, videoID, chunkPath); err != nil {
+		return UploadedVideo{}, err
 	}
-
-	return nil
+	uploaded := UploadedVideo{
+		ID:        videoID,
+		Title:     title,
+		URL:       bunnyPlaybackURL(p.cfg.LibraryID, videoID),
+		CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	p.appendUploadedVideo(ctx, streamerID, uploaded)
+	return uploaded, nil
 }
 
 func (p *BunnyChunkPublisher) Finalize(ctx context.Context, streamerID string, capturedAt time.Time) error {
 	if p == nil {
 		return nil
 	}
-	if strings.TrimSpace(p.cfg.LibraryID) == "" || strings.TrimSpace(p.cfg.APIKey) == "" {
-		return nil
-	}
-	segmentsDir := filepath.Join(p.cfg.OutputDir, sanitizeToken(streamerID), "segments")
-	segments, err := p.listSegments(segmentsDir)
-	if err != nil {
-		if errorsIsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	if len(segments) == 0 {
-		return nil
-	}
-	windowPath, err := p.concatSegments(ctx, streamerID, segmentsDir, segments)
-	if err != nil {
-		return err
-	}
-	defer os.Remove(windowPath) //nolint:errcheck
-
-	videoID, title, err := p.createVideo(ctx, streamerID, capturedAt)
-	if err != nil {
-		return err
-	}
-	if err := p.uploadVideo(ctx, videoID, windowPath); err != nil {
-		return err
-	}
-	p.appendUploadedVideo(ctx, streamerID, UploadedVideo{
-		ID:        videoID,
-		Title:     title,
-		URL:       bunnyPlaybackURL(p.cfg.LibraryID, videoID),
-		CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
-	})
-	for _, segment := range segments {
-		_ = os.Remove(segment)
-	}
-	_ = os.RemoveAll(segmentsDir)
-	_ = os.Remove(filepath.Join(p.cfg.OutputDir, sanitizeToken(streamerID)))
+	_ = ctx
+	_ = streamerID
+	_ = capturedAt
 	return nil
 }
 

--- a/internal/media/publisher_test.go
+++ b/internal/media/publisher_test.go
@@ -55,7 +55,7 @@ func (f *fakePublishRunner) Run(_ context.Context, _ io.Writer, _ io.Writer, nam
 	return nil
 }
 
-func TestBunnyChunkPublisherUploadsOnlyOnFinalize(t *testing.T) {
+func TestBunnyChunkPublisherUploadsChunkImmediately(t *testing.T) {
 	uploadCalls := 0
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -71,13 +71,10 @@ func TestBunnyChunkPublisherUploadsOnlyOnFinalize(t *testing.T) {
 	}))
 	defer api.Close()
 
-	runner := &fakePublishRunner{}
 	dir := t.TempDir()
 	publisher := NewBunnyChunkPublisher(BunnyChunkPublisherConfig{
 		OutputDir:      dir,
 		FFmpegBinary:   "ffmpeg",
-		Runner:         runner,
-		AggregateCount: 2,
 		BaseURL:        api.URL,
 		LibraryID:      "lib-1",
 		APIKey:         "key",
@@ -88,48 +85,30 @@ func TestBunnyChunkPublisherUploadsOnlyOnFinalize(t *testing.T) {
 	if err := os.WriteFile(chunkA, []byte("A"), 0o644); err != nil {
 		t.Fatalf("write chunkA: %v", err)
 	}
-	if err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkA, CapturedAt: time.Now().UTC()}); err != nil {
+	uploadedA, err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkA, CapturedAt: time.Now().UTC()})
+	if err != nil {
 		t.Fatalf("publish first chunk: %v", err)
 	}
-	if uploadCalls != 0 {
-		t.Fatalf("uploadCalls = %d, want 0 before batch ready", uploadCalls)
+	if uploadCalls != 1 {
+		t.Fatalf("uploadCalls = %d, want 1 after first publish", uploadCalls)
+	}
+	if uploadedA.URL == "" {
+		t.Fatalf("uploadedA.URL is empty")
 	}
 
 	chunkB := filepath.Join(dir, "b.mp4")
 	if err := os.WriteFile(chunkB, []byte("B"), 0o644); err != nil {
 		t.Fatalf("write chunkB: %v", err)
 	}
-	if err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkB, CapturedAt: time.Now().UTC()}); err != nil {
+	if _, err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkB, CapturedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("publish second chunk: %v", err)
 	}
-	if uploadCalls != 0 {
-		t.Fatalf("uploadCalls = %d, want 0 before finalize", uploadCalls)
-	}
-	if err := publisher.Finalize(context.Background(), "str-1", time.Now().UTC()); err != nil {
-		t.Fatalf("finalize stream: %v", err)
-	}
-	if uploadCalls != 1 {
-		t.Fatalf("uploadCalls = %d, want 1 after finalize", uploadCalls)
-	}
-	segmentsDir := filepath.Join(dir, "str-1", "segments")
-	if _, err := os.Stat(segmentsDir); !os.IsNotExist(err) {
-		t.Fatalf("segments dir should be removed after finalize, stat err=%v", err)
+	if uploadCalls != 2 {
+		t.Fatalf("uploadCalls = %d, want 2 after second publish", uploadCalls)
 	}
 }
 
-func TestBunnyChunkPublisherConcatListUsesAbsolutePaths(t *testing.T) {
-	originalWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	testWD := t.TempDir()
-	if err := os.Chdir(testWD); err != nil {
-		t.Fatalf("chdir test wd: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(originalWD)
-	})
-
+func TestBunnyChunkPublisherFinalizeIsNoop(t *testing.T) {
 	uploadCalls := 0
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -145,57 +124,20 @@ func TestBunnyChunkPublisherConcatListUsesAbsolutePaths(t *testing.T) {
 	}))
 	defer api.Close()
 
-	runner := &fakePublishRunner{}
+	dir := t.TempDir()
 	publisher := NewBunnyChunkPublisher(BunnyChunkPublisherConfig{
-		OutputDir:      "tmp/stream_chunks",
+		OutputDir:      dir,
 		FFmpegBinary:   "ffmpeg",
-		Runner:         runner,
-		AggregateCount: 2,
 		BaseURL:        api.URL,
 		LibraryID:      "lib-1",
 		APIKey:         "key",
 		HTTPTimeout:    time.Second,
 	})
-
-	if err := os.MkdirAll("tmp/input", 0o755); err != nil {
-		t.Fatalf("mkdir input: %v", err)
-	}
-	chunkA := filepath.Join("tmp/input", "a.mp4")
-	if err := os.WriteFile(chunkA, []byte("A"), 0o644); err != nil {
-		t.Fatalf("write chunkA: %v", err)
-	}
-	if err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkA, CapturedAt: time.Now().UTC()}); err != nil {
-		t.Fatalf("publish first chunk: %v", err)
-	}
-
-	chunkB := filepath.Join("tmp/input", "b.mp4")
-	if err := os.WriteFile(chunkB, []byte("B"), 0o644); err != nil {
-		t.Fatalf("write chunkB: %v", err)
-	}
-	if err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkB, CapturedAt: time.Now().UTC()}); err != nil {
-		t.Fatalf("publish second chunk: %v", err)
-	}
 	if err := publisher.Finalize(context.Background(), "str-1", time.Now().UTC()); err != nil {
 		t.Fatalf("finalize stream: %v", err)
 	}
-	if uploadCalls != 1 {
-		t.Fatalf("uploadCalls = %d, want 1", uploadCalls)
-	}
-	if len(runner.concatInputs) == 0 {
-		t.Fatalf("concatInputs is empty")
-	}
-	for _, line := range strings.Split(runner.concatInputs[len(runner.concatInputs)-1], "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		if !strings.HasPrefix(line, "file '") {
-			t.Fatalf("concat line = %q, want prefix file '", line)
-		}
-		pathValue := strings.TrimSuffix(strings.TrimPrefix(line, "file '"), "'")
-		if !filepath.IsAbs(pathValue) {
-			t.Fatalf("concat path = %q, want absolute path", pathValue)
-		}
+	if uploadCalls != 0 {
+		t.Fatalf("uploadCalls = %d, want 0 for finalize noop", uploadCalls)
 	}
 }
 
@@ -303,12 +245,10 @@ func TestBunnyChunkPublisherCreateVideoTitleIncludesStreamerAndDayFolders(t *tes
 	}))
 	defer api.Close()
 
-	runner := &fakePublishRunner{}
 	dir := t.TempDir()
 	publisher := NewBunnyChunkPublisher(BunnyChunkPublisherConfig{
 		OutputDir:    dir,
 		FFmpegBinary: "ffmpeg",
-		Runner:       runner,
 		BaseURL:      api.URL,
 		LibraryID:    "lib-1",
 		APIKey:       "key",
@@ -322,12 +262,9 @@ func TestBunnyChunkPublisherCreateVideoTitleIncludesStreamerAndDayFolders(t *tes
 	if err := os.WriteFile(chunkA, []byte("A"), 0o644); err != nil {
 		t.Fatalf("write chunkA: %v", err)
 	}
-	if err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkA, CapturedAt: time.Now().UTC()}); err != nil {
-		t.Fatalf("publish chunk: %v", err)
-	}
 	at := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
-	if err := publisher.Finalize(context.Background(), "str-1", at); err != nil {
-		t.Fatalf("finalize: %v", err)
+	if _, err := publisher.Publish(context.Background(), "str-1", ChunkRef{Reference: chunkA, CapturedAt: at}); err != nil {
+		t.Fatalf("publish chunk: %v", err)
 	}
 	if !strings.HasPrefix(title, "str-1_best_streamer/2026-04-10/") {
 		t.Fatalf("title = %q, want folder prefix", title)

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -99,7 +99,7 @@ type Locker interface {
 }
 
 type ChunkPublisher interface {
-	Publish(ctx context.Context, streamerID string, chunk ChunkRef) error
+	Publish(ctx context.Context, streamerID string, chunk ChunkRef) (UploadedVideo, error)
 }
 
 type ChunkFinalizer interface {
@@ -311,14 +311,6 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 		w.metrics.recordFailure(ctx, id, "execution_plan")
 		w.metrics.recordCycle(ctx, id, "failed")
 		return streamers.LLMDecision{}, err
-	}
-	if w.chunkPublisher != nil {
-		if err := w.chunkPublisher.Publish(ctx, id, chunk); err != nil {
-			logger.Error("chunk publish failed", zap.String("streamerID", id), zap.String("chunkRef", chunk.Reference), zap.Error(err))
-			w.metrics.recordFailure(ctx, id, "publish_chunk")
-			w.metrics.recordCycle(ctx, id, "failed")
-			return streamers.LLMDecision{}, err
-		}
 	}
 	w.metrics.recordCycle(ctx, id, "completed")
 	logger.Info("streamer processing cycle completed", zap.String("streamerID", id), zap.String("runID", runID), zap.String("finalStage", lastDecision.Stage), zap.String("finalLabel", lastDecision.Label), zap.Float64("finalConfidence", lastDecision.Confidence))
@@ -961,7 +953,18 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 		finalPackageID = pkg.ID
 	}
 	result.UpdatedStateJSON = enrichScenarioState(result.UpdatedStateJSON, execution.PreviousState, execution.GameScenarioID, finalPackageID, step.ID, finalTransitionTrace)
-	decision, err := w.processStageResult(ctx, activePrompt, result, chunk, runID, streamerID, previousState)
+	decisionChunk := chunk
+	if w.chunkPublisher != nil {
+		uploadedVideo, publishErr := w.chunkPublisher.Publish(ctx, streamerID, chunk)
+		if publishErr != nil {
+			w.metrics.recordFailure(ctx, streamerID, "publish_chunk")
+			return streamers.LLMDecision{}, publishErr
+		}
+		if strings.TrimSpace(uploadedVideo.URL) != "" {
+			decisionChunk.Reference = strings.TrimSpace(uploadedVideo.URL)
+		}
+	}
+	decision, err := w.processStageResult(ctx, activePrompt, result, decisionChunk, runID, streamerID, previousState)
 	if err != nil {
 		return streamers.LLMDecision{}, err
 	}

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -207,8 +207,9 @@ type flakyClassifier struct {
 }
 
 type fakeChunkPublisher struct {
-	err   error
-	calls int
+	err      error
+	calls    int
+	uploaded UploadedVideo
 }
 
 func (f *flakyClassifier) Classify(_ context.Context, input StageRequest) (StageClassification, error) {
@@ -225,9 +226,9 @@ func (f *flakyClassifier) Classify(_ context.Context, input StageRequest) (Stage
 	return f.result, nil
 }
 
-func (f *fakeChunkPublisher) Publish(_ context.Context, _ string, _ ChunkRef) error {
+func (f *fakeChunkPublisher) Publish(_ context.Context, _ string, _ ChunkRef) (UploadedVideo, error) {
 	f.calls++
-	return f.err
+	return f.uploaded, f.err
 }
 
 func (s *fakeDecisionStore) RecordLLMDecision(_ context.Context, req streamers.RecordDecisionRequest) (streamers.LLMDecision, error) {
@@ -452,13 +453,20 @@ func TestWorkerProcessStreamerRetriesStageClassification(t *testing.T) {
 }
 
 func TestWorkerProcessStreamerPublishesChunkAfterAnalysis(t *testing.T) {
-	publisher := &fakeChunkPublisher{}
-	worker := NewWorker(&fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, fakeClassifier{results: map[string]StageClassification{"custom": {Label: "ok", Confidence: 0.9}}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, &InMemoryRunStore{}, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5, ChunkPublisher: publisher})
+	publisher := &fakeChunkPublisher{uploaded: UploadedVideo{URL: "https://player.mediadelivery.net/play/lib-1/video-1"}}
+	decisions := &fakeDecisionStore{}
+	worker := NewWorker(&fakeCapture{chunk: ChunkRef{Reference: "chunk-1"}}, fakeClassifier{results: map[string]StageClassification{"custom": {Label: "ok", Confidence: 0.9}}}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, &InMemoryRunStore{}, decisions, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5, ChunkPublisher: publisher})
 	if _, err := worker.ProcessStreamer(context.Background(), "str-1"); err != nil {
 		t.Fatalf("ProcessStreamer() error = %v", err)
 	}
 	if publisher.calls != 1 {
 		t.Fatalf("publisher calls = %d, want 1", publisher.calls)
+	}
+	if len(decisions.items) != 1 {
+		t.Fatalf("recorded decisions = %d, want 1", len(decisions.items))
+	}
+	if decisions.items[0].ChunkRef != publisher.uploaded.URL {
+		t.Fatalf("decision chunkRef = %q, want uploaded URL", decisions.items[0].ChunkRef)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Change runtime behavior so each LLM response is paired with its captured video fragment uploaded to Bunny immediately instead of waiting for end-of-stream concatenation. 
- Expose per-request fragment links in Admin Event History so each LLM call is visible together with its `videoData` playback URL. 
- Preserve existing cleanup semantics so the admin delete endpoint still removes all persisted Bunny videos for a streamer.

### Description
- Updated publisher to upload individual chunks on `Publish` and return an `UploadedVideo` result, and made `Finalize` a no-op to remove delayed concatenation behavior. 
- Changed `ChunkPublisher` signature to return `(UploadedVideo, error)` and updated worker orchestration to call `Publish` immediately after an LLM response and replace the decision `ChunkRef`/`videoData` with the uploaded playback URL when available. 
- Updated unit tests to reflect immediate upload behavior: `internal/media/publisher_test.go` and `internal/media/worker_test.go` now assert uploads occur per-chunk and that recorded LLM decisions reference the uploaded URL, and `internal/app/router_admin_streamers_history_test.go` now verifies per-event `videoData`. 
- Documentation updated in `docs/local_setup.md` to note that each LLM event carries its Bunny fragment URL in `videoData`. 
- Checklist (aligned to `docs/implementation_plan.md` M2.1 and `docs/llm_stream_orchestration_plan.md`):
  - [x] Stream fragments are uploaded per LLM call and `Publish` returns fragment metadata. 
  - [x] Worker replaces stored decision `videoData` with the uploaded Bunny playback URL when upload succeeds. 
  - [x] Admin history endpoint shows per-event `videoData` and cleanup still deletes Bunny videos. 
  - [ ] Add explicit API/DTO field for `videoFragment` (currently reusing `videoData`).

### Testing
- Ran the full test suite with `go test ./...` and all tests passed. 
- Updated and ran unit tests covering publisher behavior and worker orchestration and they succeeded. 
- Verified `internal/app` admin history tests that assert event-level `videoData` resolved to the uploaded playback URL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8cffeb74832c952cd516d99a2d9c)