### PR TITLE
Fix formatting in media publisher tests

### DIFF
--- a/internal/media/publisher_test.go
+++ b/internal/media/publisher_test.go
@@ -73,12 +73,12 @@ func TestBunnyChunkPublisherUploadsChunkImmediately(t *testing.T) {
 
 	dir := t.TempDir()
 	publisher := NewBunnyChunkPublisher(BunnyChunkPublisherConfig{
-		OutputDir:      dir,
-		FFmpegBinary:   "ffmpeg",
-		BaseURL:        api.URL,
-		LibraryID:      "lib-1",
-		APIKey:         "key",
-		HTTPTimeout:    time.Second,
+		OutputDir:    dir,
+		FFmpegBinary: "ffmpeg",
+		BaseURL:      api.URL,
+		LibraryID:    "lib-1",
+		APIKey:       "key",
+		HTTPTimeout:  time.Second,
 	})
 
 	chunkA := filepath.Join(dir, "a.mp4")
@@ -126,12 +126,12 @@ func TestBunnyChunkPublisherFinalizeIsNoop(t *testing.T) {
 
 	dir := t.TempDir()
 	publisher := NewBunnyChunkPublisher(BunnyChunkPublisherConfig{
-		OutputDir:      dir,
-		FFmpegBinary:   "ffmpeg",
-		BaseURL:        api.URL,
-		LibraryID:      "lib-1",
-		APIKey:         "key",
-		HTTPTimeout:    time.Second,
+		OutputDir:    dir,
+		FFmpegBinary: "ffmpeg",
+		BaseURL:      api.URL,
+		LibraryID:    "lib-1",
+		APIKey:       "key",
+		HTTPTimeout:  time.Second,
 	})
 	if err := publisher.Finalize(context.Background(), "str-1", time.Now().UTC()); err != nil {
 		t.Fatalf("finalize stream: %v", err)


### PR DESCRIPTION
### Motivation
- The CI format check failed due to unformatted Go code in `internal/media/publisher_test.go`, causing the build to break; this PR applies `gofmt` to resolve the failure and stabilize the build.

### Description
- Run `gofmt -w internal/media/publisher_test.go` and adjust alignment of struct literal fields in two tests (no functional changes to logic or behavior).

### Testing
- Verified formatting with `gofmt -l internal/media/publisher_test.go` (no output) and ran `go test ./internal/media/...` which passed.

Checklist (aligned with docs):
- [x] Fix formatting check / unblock build.
- [ ] `docs/implementation_plan.md` milestone M2.1 tasks (not changed in this PR).
- [ ] `docs/llm_stream_orchestration_plan.md` alignment tasks (not changed in this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb900989f0832cb95b2035f4c6b096)