### PR TITLE
Clarify videoData description in OpenAPI spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1253,7 +1253,7 @@ components:
           type: integer
         videoData:
           type: string
-          description: Static placeholder string `video-data` returned for each decision entry.
+          description: Media reference for the analyzed chunk (for example a playback URL or storage reference).
         requestRef:
           type: string
         responseRef:


### PR DESCRIPTION
### Motivation
- Clarify the meaning of the `videoData` field in the API schema so it reflects that the value is a media reference rather than a static placeholder.

### Description
- Updated `docs/openapi.yaml` to change the `videoData` component description to: "Media reference for the analyzed chunk (for example a playback URL or storage reference)."

### Testing
- Ran OpenAPI schema linting/validation against `docs/openapi.yaml` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb92830c00832cb465ac86f32633b0)