### PR TITLE
Stop tracking when GameScenario terminal condition matches

### DIFF
--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -296,6 +296,10 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 	logger.Info("analysis run created", zap.String("streamerID", id), zap.String("runID", runID))
 
 	lastDecision, err := w.processExecutionPlan(ctx, runID, id, chunk, pkg, execution)
+	if errors.Is(err, ErrTrackingStop) {
+		w.metrics.recordCycle(ctx, id, "tracking_stop")
+		return lastDecision, ErrTrackingStop
+	}
 	if err != nil {
 		if execution.CurrentPackageID != "" && execution.StartPackageID != "" && execution.CurrentPackageID != execution.StartPackageID {
 			rootPkg, rootErr := w.prompts.GetScenarioPackage(ctx, execution.StartPackageID)
@@ -306,6 +310,10 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 				}
 			}
 		}
+	}
+	if errors.Is(err, ErrTrackingStop) {
+		w.metrics.recordCycle(ctx, id, "tracking_stop")
+		return lastDecision, ErrTrackingStop
 	}
 	if err != nil {
 		w.metrics.recordFailure(ctx, id, "execution_plan")
@@ -919,7 +927,62 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 		return streamers.LLMDecision{}, err
 	}
 	decision.TransitionToStep = step.ID
+	decision, stopTracking, err := w.applyGameScenarioTerminalCondition(ctx, execution, finalTransitionTrace, decision)
+	if err != nil {
+		return streamers.LLMDecision{}, err
+	}
+	if stopTracking {
+		return decision, ErrTrackingStop
+	}
 	return decision, nil
+}
+
+func (w *Worker) applyGameScenarioTerminalCondition(ctx context.Context, execution scenarioExecutionPlan, transitionTrace map[string]any, decision streamers.LLMDecision) (streamers.LLMDecision, bool, error) {
+	gameScenarioID := strings.TrimSpace(execution.GameScenarioID)
+	if gameScenarioID == "" {
+		return decision, false, nil
+	}
+	gameScenario, err := w.prompts.GetGameScenario(ctx, gameScenarioID)
+	if err != nil {
+		return decision, false, nil
+	}
+	currentState := strings.TrimSpace(decision.UpdatedStateJSON)
+	currentNodeID := strings.TrimSpace(fmt.Sprint(transitionTrace["toNode"]))
+	if currentNodeID == "" {
+		currentNodeID = scenarioStateNodeID(execution.PreviousState)
+	}
+	_, transitionID, _, err := gameScenario.ResolveNode(currentNodeID, currentState)
+	if err != nil {
+		return streamers.LLMDecision{}, false, err
+	}
+	terminal, matched, err := gameScenario.ResolveTerminalCondition(transitionID, currentState)
+	if err != nil {
+		return streamers.LLMDecision{}, false, err
+	}
+	if !matched {
+		return decision, false, nil
+	}
+	decision.TransitionTerminal = true
+	decision.Label = firstNonEmpty(strings.TrimSpace(terminal.ResultLabel), "tracking_stopped")
+	decision.TransitionOutcome = decision.Label
+	decision.UpdatedStateJSON = enrichScenarioState(
+		mergeJSONState(currentState, terminal.ResultStateJSON),
+		execution.PreviousState,
+		gameScenarioID,
+		scenarioStatePackageID(currentState),
+		decision.Stage,
+		map[string]any{
+			"status":               "terminal_stop",
+			"fromNode":             firstNonEmpty(currentNodeID, strings.TrimSpace(gameScenario.InitialNodeID)),
+			"toNode":               currentNodeID,
+			"fromPackage":          scenarioStatePackageID(currentState),
+			"toPackage":            scenarioStatePackageID(currentState),
+			"reason":               "game_scenario_terminal_condition_matched",
+			"terminalId":           strings.TrimSpace(terminal.ID),
+			"terminalTransitionId": strings.TrimSpace(terminal.TransitionID),
+		},
+	)
+	return decision, true, nil
 }
 
 func (w *Worker) resolvePostStepScenarioTransition(ctx context.Context, execution scenarioExecutionPlan, currentState string) (string, map[string]any) {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -1024,6 +1024,69 @@ func TestWorkerProcessStreamerKeepsCurrentScenarioPackageStepAcrossCycles(t *tes
 	}
 }
 
+func TestWorkerProcessStreamerStopsOnPostStepGameScenarioTerminalCondition(t *testing.T) {
+	worker := NewWorker(
+		&fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Now().UTC()}},
+		fakeClassifier{results: map[string]StageClassification{
+			"faceit": {Label: "state_updated", Confidence: 0.9, UpdatedStateJSON: `{"mode":"faceit","ct_score":2,"t_score":6}`},
+		}},
+		fakePromptResolver{
+			gameScenario: prompts.GameScenario{
+				ID:            "game-scenario-1",
+				Name:          "faceit-terminal",
+				GameSlug:      "global",
+				InitialNodeID: "global",
+				Nodes: []prompts.GameScenarioNode{
+					{ID: "global", ScenarioPackageID: "scenario-root"},
+				},
+				Transitions: []prompts.GameScenarioTransition{
+					{
+						ID:         "stay-faceit",
+						FromNodeID: "global",
+						ToNodeID:   "global",
+						Condition:  `mode == "faceit"`,
+						Priority:   1,
+						TerminalConditions: []prompts.GameScenarioTerminalCondition{
+							{ID: "score-limit", Condition: `ct_score >= 6 | t_score >= 6`, ResultLabel: "match_finished", Priority: 1},
+						},
+					},
+				},
+				IsActive: true,
+			},
+			scenario: prompts.ScenarioPackage{
+				ID:               "scenario-root",
+				GameSlug:         "global",
+				LLMModelConfigID: "cfg-default",
+				Steps: []prompts.ScenarioStep{
+					{ID: "faceit", Name: "Faceit", PromptTemplate: "score", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+				},
+			},
+			llmModelConfig: prompts.LLMModelConfig{ID: "cfg-default", Model: "gemini-2.5-flash"},
+		},
+		&InMemoryRunStore{},
+		&fakeDecisionStore{},
+		NewInMemoryLocker(),
+		WorkerConfig{MinConfidence: 0.5},
+	)
+
+	decision, err := worker.ProcessStreamer(context.Background(), "streamer-1")
+	if !errors.Is(err, ErrTrackingStop) {
+		t.Fatalf("expected ErrTrackingStop, got %v", err)
+	}
+	if !decision.TransitionTerminal {
+		t.Fatalf("expected decision to be terminal")
+	}
+	if decision.Label != "match_finished" {
+		t.Fatalf("expected terminal label match_finished, got %q", decision.Label)
+	}
+	state := parseJSONMap(decision.UpdatedStateJSON)
+	meta, _ := state["_scenario"].(map[string]any)
+	transition, _ := meta["transition"].(map[string]any)
+	if transition["reason"] != "game_scenario_terminal_condition_matched" {
+		t.Fatalf("expected game-scenario terminal trace, got %#v", transition)
+	}
+}
+
 func TestResolveGameScenarioSlug(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Motivation
- Ensure the worker recognizes GameScenario terminal conditions after a step transition and stops further tracking when a terminal condition matches.
- Enrich the decision state and labels when a terminal condition is matched so downstream systems can detect terminal outcomes.

### Description
- Added `applyGameScenarioTerminalCondition` to evaluate post-step terminal conditions against the updated state and to mark decisions as terminal when matched.
- Updated `processScenarioPackage` to call `applyGameScenarioTerminalCondition` after building the decision and to return `ErrTrackingStop` when a terminal condition is matched.
- Propagated `ErrTrackingStop` handling into `ProcessStreamer` to record a `tracking_stop` cycle metric and to return early when tracking should stop.
- Added `TestWorkerProcessStreamerStopsOnPostStepGameScenarioTerminalCondition` to exercise terminal condition matching, decision enrichment, and `ErrTrackingStop` propagation.

### Testing
- Ran the new unit test with `go test ./internal/media -run TestWorkerProcessStreamerStopsOnPostStepGameScenarioTerminalCondition`, which passed.
- Ran package tests for `internal/media` with `go test ./internal/media`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb941e3388832c813dadf9d90c62f3)