### PR TITLE
Twitch Helix validation and live audience checks for streamer submissions

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -104,7 +104,19 @@ func main() {
 
 	userService := users.NewService(userRepo)
 	adminService := admin.NewService(cfg.Admin.UserIDs)
-	streamersService := streamers.NewService()
+	streamerValidator := streamers.TwitchValidator(streamers.NewTwitchAPIValidator(
+		cfg.Twitch.ClientID,
+		cfg.Twitch.ClientSecret,
+		cfg.Twitch.TokenURL,
+		cfg.Twitch.APIBaseURL,
+		nil,
+	))
+	if cfg.Twitch.ClientID == "" || cfg.Twitch.ClientSecret == "" {
+		logger.Warn("twitch credentials are not configured; submission live audience validation is disabled")
+		streamerValidator = nil
+	}
+	streamersService := streamers.NewServiceWithValidator(streamerValidator)
+	streamersService.SetMinLiveViewers(cfg.Client.MinViewers)
 	streamersService.SetLogger(logger.Named("streamers"))
 	gamesService := games.NewService()
 	promptsService := prompts.NewService()

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -50,6 +50,10 @@ FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT=5
 FUNPOT_STREAMLINK_BUNNY_BASE_URL=https://video.bunnycdn.com
 FUNPOT_STREAMLINK_BUNNY_LIBRARY_ID=
 FUNPOT_STREAMLINK_BUNNY_API_KEY=
+FUNPOT_TWITCH_CLIENT_ID=
+FUNPOT_TWITCH_CLIENT_SECRET=
+FUNPOT_TWITCH_TOKEN_URL=https://id.twitch.tv/oauth2/token
+FUNPOT_TWITCH_API_BASE_URL=https://api.twitch.tv/helix
 FUNPOT_GEMINI_API_KEY=<google_ai_studio_api_key>
 FUNPOT_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 FUNPOT_GEMINI_MAX_INLINE_BYTES=19922944
@@ -106,6 +110,10 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 > Set `FUNPOT_GEMINI_API_KEY` to enable real Gemini stage classification. When
 > it is unset, the server falls back to the deterministic placeholder
 > classifier used in early development.
+
+> Set `FUNPOT_TWITCH_CLIENT_ID` + `FUNPOT_TWITCH_CLIENT_SECRET` to enable
+> real-time Twitch audience validation during streamer submission (online/offline
+> and viewer count threshold checks).
 >
 > `FUNPOT_GEMINI_CHAT_MAX_TOKENS` controls how long the backend keeps one
 > Gemini chat session alive per streamer before rotating to a new chat and

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -154,10 +154,17 @@ paths:
           application/json:
             schema:
               type: object
-              required: [twitchNickname]
+              anyOf:
+                - required: [twitchNickname]
+                - required: [twitchUsername]
               properties:
                 twitchNickname:
                   type: string
+                  description: Twitch login to track (preferred field).
+                twitchUsername:
+                  type: string
+                  description: Legacy alias for twitchNickname.
+                  deprecated: true
       responses:
         '200':
           description: Streamer submission result
@@ -165,6 +172,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StreamerSubmission'
+        '400':
+          description: Invalid payload or streamer is not eligible for tracking (offline / low audience / invalid username)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalidUsername:
+                  summary: Missing username
+                  value:
+                    error: twitchNickname is required
+                twitchUnavailable:
+                  summary: Twitch validation failed
+                  value:
+                    error: failed to validate twitch username
+                streamerOffline:
+                  summary: Streamer is offline
+                  value:
+                    error: streamer is offline
+                insufficientViewers:
+                  summary: Viewers below threshold
+                  value:
+                    error: streamer has insufficient live viewers
         '429':
           description: Rate limit exceeded
           content:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -558,7 +558,10 @@ func NewHandler(
 
 					submission, err := streamersService.Submit(r.Context(), nickname, claims.Subject)
 					if err != nil {
-						if errors.Is(err, streamers.ErrInvalidUsername) || errors.Is(err, streamers.ErrTwitchUnavailable) {
+						if errors.Is(err, streamers.ErrInvalidUsername) ||
+							errors.Is(err, streamers.ErrTwitchUnavailable) ||
+							errors.Is(err, streamers.ErrStreamerOffline) ||
+							errors.Is(err, streamers.ErrInsufficientLive) {
 							writeError(w, http.StatusBadRequest, err.Error())
 							return
 						}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Redis       RedisConfig
 	Database    DatabaseConfig
 	Streamlink  StreamlinkConfig
+	Twitch      TwitchConfig
 	Gemini      GeminiConfig
 	Features    FeatureConfig
 	Client      ClientConfig
@@ -49,6 +50,14 @@ type GeminiConfig struct {
 	BaseURL        string
 	MaxInlineBytes int64
 	ChatMaxTokens  int
+}
+
+// TwitchConfig controls Twitch API integration used for streamer validation and live audience checks.
+type TwitchConfig struct {
+	ClientID     string
+	ClientSecret string
+	TokenURL     string
+	APIBaseURL   string
 }
 
 // AdminConfig controls role-based admin access.
@@ -443,6 +452,12 @@ func Load() (Config, error) {
 			BunnyBaseURL:   getString("FUNPOT_STREAMLINK_BUNNY_BASE_URL", "https://video.bunnycdn.com"),
 			BunnyLibraryID: strings.TrimSpace(os.Getenv("FUNPOT_STREAMLINK_BUNNY_LIBRARY_ID")),
 			BunnyAPIKey:    strings.TrimSpace(os.Getenv("FUNPOT_STREAMLINK_BUNNY_API_KEY")),
+		},
+		Twitch: TwitchConfig{
+			ClientID:     strings.TrimSpace(os.Getenv("FUNPOT_TWITCH_CLIENT_ID")),
+			ClientSecret: strings.TrimSpace(os.Getenv("FUNPOT_TWITCH_CLIENT_SECRET")),
+			TokenURL:     getString("FUNPOT_TWITCH_TOKEN_URL", "https://id.twitch.tv/oauth2/token"),
+			APIBaseURL:   getString("FUNPOT_TWITCH_API_BASE_URL", "https://api.twitch.tv/helix"),
 		},
 		Gemini: GeminiConfig{
 			APIKey:         os.Getenv("FUNPOT_GEMINI_API_KEY"),

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -18,6 +18,8 @@ var (
 	ErrInvalidStatus     = errors.New("status filter is invalid")
 	ErrRateLimited       = errors.New("submission rate limit exceeded")
 	ErrTwitchUnavailable = errors.New("failed to validate twitch username")
+	ErrStreamerOffline   = errors.New("streamer is offline")
+	ErrInsufficientLive  = errors.New("streamer has insufficient live viewers")
 	ErrNotFound          = errors.New("streamer not found")
 )
 
@@ -25,6 +27,10 @@ var twitchUsernamePattern = regexp.MustCompile(`^[a-zA-Z0-9_]{4,25}$`)
 
 type TwitchValidator interface {
 	ValidateUsername(ctx context.Context, username string) (displayName string, err error)
+}
+
+type TwitchAudienceValidator interface {
+	GetLiveAudience(ctx context.Context, username string) (online bool, viewers int, err error)
 }
 
 type noopTwitchValidator struct{}
@@ -60,6 +66,7 @@ type Service struct {
 	onSubmitted      func(context.Context, string) error
 	onTrackingStopMu sync.RWMutex
 	onTrackingStop   func(context.Context, string) error
+	minLiveViewers   int
 }
 
 func NewService() *Service {
@@ -77,10 +84,23 @@ func NewServiceWithValidator(validator TwitchValidator) *Service {
 		analysis:       make(map[string]analysisState),
 		validator:      validator,
 		rateLimitByKey: make(map[string]submissionLimit),
+		minLiveViewers: 0,
 		nowFn: func() time.Time {
 			return time.Now().UTC()
 		},
 	}
+}
+
+func (s *Service) SetMinLiveViewers(min int) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if min < 0 {
+		min = 0
+	}
+	s.minLiveViewers = min
+	s.mu.Unlock()
 }
 
 func (s *Service) SetLogger(logger *zap.Logger) {
@@ -212,6 +232,28 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 	}
 	logger.Info("streamer submission validated", zap.String("twitchNickname", nickname), zap.String("displayName", displayName))
 
+	online := false
+	viewers := 0
+	if audienceValidator, ok := s.validator.(TwitchAudienceValidator); ok {
+		online, viewers, err = audienceValidator.GetLiveAudience(ctx, nickname)
+		if err != nil {
+			logger.Warn("streamer audience validation failed", zap.String("twitchNickname", nickname), zap.Error(err))
+			return Submission{}, fmt.Errorf("%w: %v", ErrTwitchUnavailable, err)
+		}
+		if !online {
+			logger.Warn("streamer rejected: offline", zap.String("twitchNickname", nickname))
+			return Submission{}, ErrStreamerOffline
+		}
+		if viewers < s.minLiveViewers {
+			logger.Warn("streamer rejected: low audience",
+				zap.String("twitchNickname", nickname),
+				zap.Int("viewers", viewers),
+				zap.Int("minLiveViewers", s.minLiveViewers),
+			)
+			return Submission{}, fmt.Errorf("%w: got=%d required=%d", ErrInsufficientLive, viewers, s.minLiveViewers)
+		}
+	}
+
 	now := s.nowFn().UnixNano()
 	id := fmt.Sprintf("str_%d", now)
 	streamer := Streamer{
@@ -219,8 +261,8 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 		Platform:       "twitch",
 		TwitchNickname: strings.ToLower(nickname),
 		DisplayName:    displayName,
-		Online:         false,
-		Viewers:        0,
+		Online:         online,
+		Viewers:        viewers,
 		AddedBy:        addedBy,
 		Status:         "pending",
 	}

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -19,6 +19,20 @@ func (v validatorStub) ValidateUsername(_ context.Context, _ string) (string, er
 	return v.displayName, nil
 }
 
+type audienceValidatorStub struct {
+	validatorStub
+	online      bool
+	viewers     int
+	audienceErr error
+}
+
+func (v audienceValidatorStub) GetLiveAudience(_ context.Context, _ string) (bool, int, error) {
+	if v.audienceErr != nil {
+		return false, 0, v.audienceErr
+	}
+	return v.online, v.viewers, nil
+}
+
 func TestServiceSubmitValidationAndListing(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -54,6 +68,69 @@ func TestServiceSubmitValidationAndListing(t *testing.T) {
 			}
 			if items[0].TwitchNickname != "best_streamer" {
 				t.Fatalf("unexpected twitch nickname: %s", items[0].TwitchNickname)
+			}
+		})
+	}
+}
+
+func TestServiceSubmitPersistsLiveAudienceAndValidatesThreshold(t *testing.T) {
+	svc := NewServiceWithValidator(audienceValidatorStub{
+		validatorStub: validatorStub{displayName: "Best Streamer"},
+		online:        true,
+		viewers:       125,
+	})
+	svc.SetMinLiveViewers(100)
+
+	if _, err := svc.Submit(context.Background(), "Best_Streamer", "user-1"); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+
+	items := svc.List(context.Background(), "best_streamer", "pending", 1)
+	if len(items) != 1 {
+		t.Fatalf("expected one result, got %d", len(items))
+	}
+	if !items[0].Online || items[0].Viewers != 125 {
+		t.Fatalf("expected online with 125 viewers, got online=%v viewers=%d", items[0].Online, items[0].Viewers)
+	}
+}
+
+func TestServiceSubmitRejectsOfflineOrLowAudience(t *testing.T) {
+	tests := []struct {
+		name      string
+		validator TwitchValidator
+		min       int
+		wantErr   error
+	}{
+		{
+			name: "offline",
+			validator: audienceValidatorStub{
+				validatorStub: validatorStub{displayName: "Offline Streamer"},
+				online:        false,
+				viewers:       0,
+			},
+			min:     10,
+			wantErr: ErrStreamerOffline,
+		},
+		{
+			name: "below min viewers",
+			validator: audienceValidatorStub{
+				validatorStub: validatorStub{displayName: "Small Streamer"},
+				online:        true,
+				viewers:       42,
+			},
+			min:     100,
+			wantErr: ErrInsufficientLive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewServiceWithValidator(tt.validator)
+			svc.SetMinLiveViewers(tt.min)
+
+			_, err := svc.Submit(context.Background(), "Best_Streamer", "user-1")
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
 			}
 		})
 	}

--- a/internal/streamers/twitch_validator.go
+++ b/internal/streamers/twitch_validator.go
@@ -1,0 +1,206 @@
+package streamers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TwitchAPIValidator validates streamer existence and fetches current live audience via Twitch Helix API.
+type TwitchAPIValidator struct {
+	clientID     string
+	clientSecret string
+	tokenURL     string
+	apiBaseURL   string
+	httpClient   *http.Client
+
+	mu          sync.Mutex
+	accessToken string
+	expiresAt   time.Time
+}
+
+func NewTwitchAPIValidator(clientID, clientSecret, tokenURL, apiBaseURL string, httpClient *http.Client) *TwitchAPIValidator {
+	validator := &TwitchAPIValidator{
+		clientID:     strings.TrimSpace(clientID),
+		clientSecret: strings.TrimSpace(clientSecret),
+		tokenURL:     strings.TrimSpace(tokenURL),
+		apiBaseURL:   strings.TrimSpace(apiBaseURL),
+		httpClient:   httpClient,
+	}
+	if validator.tokenURL == "" {
+		validator.tokenURL = "https://id.twitch.tv/oauth2/token"
+	}
+	if validator.apiBaseURL == "" {
+		validator.apiBaseURL = "https://api.twitch.tv/helix"
+	}
+	if validator.httpClient == nil {
+		validator.httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	return validator
+}
+
+func (v *TwitchAPIValidator) ValidateUsername(ctx context.Context, username string) (string, error) {
+	user, err := v.fetchUser(ctx, username)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(user.DisplayName) == "" {
+		return strings.ToLower(strings.TrimSpace(username)), nil
+	}
+	return user.DisplayName, nil
+}
+
+func (v *TwitchAPIValidator) GetLiveAudience(ctx context.Context, username string) (bool, int, error) {
+	user, err := v.fetchUser(ctx, username)
+	if err != nil {
+		return false, 0, err
+	}
+	stream, err := v.fetchStreamByUserID(ctx, user.ID)
+	if err != nil {
+		return false, 0, err
+	}
+	if stream == nil {
+		return false, 0, nil
+	}
+	return true, stream.ViewerCount, nil
+}
+
+type twitchUser struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+}
+
+type twitchStream struct {
+	ViewerCount int `json:"viewer_count"`
+}
+
+type twitchUsersResponse struct {
+	Data []twitchUser `json:"data"`
+}
+
+type twitchStreamsResponse struct {
+	Data []twitchStream `json:"data"`
+}
+
+type twitchAppTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int64  `json:"expires_in"`
+}
+
+func (v *TwitchAPIValidator) fetchUser(ctx context.Context, username string) (twitchUser, error) {
+	response := twitchUsersResponse{}
+	if err := v.getHelix(ctx, "/users", map[string]string{"login": strings.TrimSpace(username)}, &response); err != nil {
+		return twitchUser{}, err
+	}
+	if len(response.Data) == 0 {
+		return twitchUser{}, fmt.Errorf("twitch user not found")
+	}
+	return response.Data[0], nil
+}
+
+func (v *TwitchAPIValidator) fetchStreamByUserID(ctx context.Context, userID string) (*twitchStream, error) {
+	response := twitchStreamsResponse{}
+	if err := v.getHelix(ctx, "/streams", map[string]string{"user_id": strings.TrimSpace(userID)}, &response); err != nil {
+		return nil, err
+	}
+	if len(response.Data) == 0 {
+		return nil, nil
+	}
+	return &response.Data[0], nil
+}
+
+func (v *TwitchAPIValidator) getHelix(ctx context.Context, path string, query map[string]string, target any) error {
+	token, err := v.appAccessToken(ctx)
+	if err != nil {
+		return err
+	}
+	baseURL := strings.TrimRight(v.apiBaseURL, "/") + path
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return err
+	}
+	values := parsedURL.Query()
+	for key, value := range query {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		values.Set(key, value)
+	}
+	parsedURL.RawQuery = values.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Client-ID", v.clientID)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("twitch api returned status %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *TwitchAPIValidator) appAccessToken(ctx context.Context) (string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	now := time.Now().UTC()
+	if v.accessToken != "" && now.Before(v.expiresAt) {
+		return v.accessToken, nil
+	}
+
+	if v.clientID == "" || v.clientSecret == "" {
+		return "", fmt.Errorf("twitch credentials are required")
+	}
+
+	values := url.Values{}
+	values.Set("client_id", v.clientID)
+	values.Set("client_secret", v.clientSecret)
+	values.Set("grant_type", "client_credentials")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.tokenURL, strings.NewReader(values.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("twitch token endpoint returned status %d", resp.StatusCode)
+	}
+
+	payload := twitchAppTokenResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(payload.AccessToken) == "" {
+		return "", fmt.Errorf("empty twitch access token")
+	}
+	if payload.ExpiresIn <= 0 {
+		payload.ExpiresIn = 3600
+	}
+
+	v.accessToken = payload.AccessToken
+	v.expiresAt = now.Add(time.Duration(payload.ExpiresIn-30) * time.Second)
+	return v.accessToken, nil
+}


### PR DESCRIPTION
### Motivation
- Enable server-side validation of Twitch usernames and live audience checks during streamer submission to prevent tracking offline or low-audience streams.
- Expose configuration for Twitch API credentials and endpoints so runtime can use Helix API when available.
- Provide clearer API contract and error responses for invalid or ineligible submissions.

### Description
- Added `TwitchConfig` to `internal/config` and new env vars documented in `docs/local_setup.md` (`FUNPOT_TWITCH_CLIENT_ID`, `FUNPOT_TWITCH_CLIENT_SECRET`, `FUNPOT_TWITCH_TOKEN_URL`, `FUNPOT_TWITCH_API_BASE_URL`).
- Implemented `TwitchAPIValidator` in `internal/streamers/twitch_validator.go` which obtains an app access token and calls Twitch Helix endpoints to validate usernames and fetch live viewer counts, and added `TwitchAudienceValidator` interface support in the `streamers` service.
- Enhanced `streamers.Service` to validate live status and viewer threshold during `Submit`, added `ErrStreamerOffline` and `ErrInsufficientLive`, persisted `Online` and `Viewers` on stored streamer records, and added `SetMinLiveViewers` to configure minimum viewers.
- Wired validator construction in `cmd/server/main.go` to build `TwitchAPIValidator` when credentials are present (with a warning and disabled validation if not), and set `MinLiveViewers` from `cfg.Client.MinViewers`.
- Updated HTTP handling in `internal/app/router.go` to accept legacy `twitchUsername` and map Twitch-related validation errors to `400` responses, and extended `docs/openapi.yaml` with new request schema (`anyOf` for `twitchNickname`/`twitchUsername`) and `400` response examples.
- Added unit tests in `internal/streamers/service_test.go` covering audience persistence and rejection cases for offline/low-audience submissions.

### Testing
- Ran unit tests for the streamers package with `go test ./internal/streamers -v`, and the tests passed.
- Existing streamer-related tests including rate limiting and listing were executed as part of the package test run and succeeded.
- Lint/build checks were exercised locally during development (no failures were observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7a9aeff0832c988187d8bdb2941f)