### PR TITLE
Add in-memory wallet service with API endpoints for withdraw and admin adjust (idempotent)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -356,6 +356,33 @@ paths:
         default:
           $ref: '#/components/responses/Error'
 
+  /api/admin/wallet/adjust:
+    post:
+      summary: Adjust user wallet balance (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminWalletAdjustRequest'
+      responses:
+        '200':
+          description: Wallet adjustment applied (or idempotent replay)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminWalletAdjustResponse'
+        default:
+          $ref: '#/components/responses/Error'
+
   /api/admin/games:
     get:
       summary: List games (admin)
@@ -2065,6 +2092,29 @@ components:
         status:
           type: string
           enum: [pending, processing, done, rejected]
+        newBalance:
+          type: integer
+    AdminWalletAdjustRequest:
+      type: object
+      required: [userId, deltaINT, reason]
+      properties:
+        userId:
+          type: string
+        deltaINT:
+          type: integer
+          description: Signed amount in internal currency units. Positive = credit, negative = debit.
+        reason:
+          type: string
+        currency:
+          type: string
+    AdminWalletAdjustResponse:
+      type: object
+      required: [entry, newBalance]
+      properties:
+        entry:
+          $ref: '#/components/schemas/WalletEntry'
+        newBalance:
+          type: integer
     ReferralSummary:
       type: object
       properties:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -23,6 +23,7 @@ import (
 	"github.com/funpot/funpot-go-core/internal/prompts"
 	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
+	"github.com/funpot/funpot-go-core/internal/wallet"
 )
 
 type readinessState struct {
@@ -286,6 +287,17 @@ type adminUserUpsertRequest struct {
 	LanguageCode string `json:"languageCode"`
 }
 
+type withdrawRequest struct {
+	AmountINT int64 `json:"amountINT"`
+}
+
+type adminWalletAdjustRequest struct {
+	UserID   string `json:"userId"`
+	DeltaINT int64  `json:"deltaINT"`
+	Reason   string `json:"reason"`
+	Currency string `json:"currency,omitempty"`
+}
+
 type adminHistoryEvent struct {
 	EventTime        string  `json:"eventTime"`
 	StepName         string  `json:"stepName"`
@@ -358,6 +370,8 @@ func NewHandler(
 	})
 
 	if authService != nil {
+		walletService := wallet.NewService()
+
 		mux.HandleFunc("/api/auth/telegram", func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				w.WriteHeader(http.StatusMethodNotAllowed)
@@ -677,6 +691,131 @@ func NewHandler(
 				return
 			}
 			writeJSON(w, http.StatusOK, clientConfig)
+		})))
+
+		mux.Handle("/api/wallet", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			claims, ok := auth.ClaimsFromContext(r.Context())
+			if !ok {
+				writeError(w, http.StatusUnauthorized, "missing auth claims")
+				return
+			}
+			writeJSON(w, http.StatusOK, walletService.Get(claims.Subject))
+		})))
+
+		mux.Handle("/api/wallet/withdraw", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			claims, ok := auth.ClaimsFromContext(r.Context())
+			if !ok {
+				writeError(w, http.StatusUnauthorized, "missing auth claims")
+				return
+			}
+			idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+			if idempotencyKey == "" {
+				writeError(w, http.StatusBadRequest, wallet.ErrIdempotencyRequired.Error())
+				return
+			}
+			defer r.Body.Close() //nolint:errcheck
+			body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "failed to read request body")
+				return
+			}
+			var req withdrawRequest
+			if err := decodeJSONStrict(body, &req); err != nil {
+				writeError(w, http.StatusBadRequest, "invalid request body")
+				return
+			}
+			_, newBalance, err := walletService.Post(wallet.PostRequest{
+				UserID:         claims.Subject,
+				Type:           wallet.EntryTypeDebit,
+				Amount:         req.AmountINT,
+				Currency:       "FPC",
+				Reason:         "withdraw",
+				IdempotencyKey: idempotencyKey,
+				ActorID:        claims.Subject,
+			})
+			if err != nil {
+				switch {
+				case errors.Is(err, wallet.ErrInvalidAmount), errors.Is(err, wallet.ErrIdempotencyRequired):
+					writeError(w, http.StatusBadRequest, err.Error())
+				case errors.Is(err, wallet.ErrInsufficientFunds):
+					writeError(w, http.StatusConflict, err.Error())
+				default:
+					logger.Error("failed to withdraw from wallet", zap.String("userID", claims.Subject), zap.Error(err))
+					writeError(w, http.StatusInternalServerError, "failed to withdraw")
+				}
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status":     "done",
+				"newBalance": newBalance,
+			})
+		})))
+
+		mux.Handle("/api/admin/wallet/adjust", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !requireAdmin(w, r, adminService) {
+				writeError(w, http.StatusForbidden, "admin role is required")
+				return
+			}
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			claims, ok := auth.ClaimsFromContext(r.Context())
+			if !ok {
+				writeError(w, http.StatusUnauthorized, "missing auth claims")
+				return
+			}
+			idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+			if idempotencyKey == "" {
+				writeError(w, http.StatusBadRequest, wallet.ErrIdempotencyRequired.Error())
+				return
+			}
+			defer r.Body.Close() //nolint:errcheck
+			body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "failed to read request body")
+				return
+			}
+			var req adminWalletAdjustRequest
+			if err := decodeJSONStrict(body, &req); err != nil {
+				writeError(w, http.StatusBadRequest, "invalid request body")
+				return
+			}
+			entry, newBalance, err := walletService.Adjust(wallet.AdjustRequest{
+				UserID:         req.UserID,
+				Delta:          req.DeltaINT,
+				Reason:         req.Reason,
+				Currency:       req.Currency,
+				IdempotencyKey: idempotencyKey,
+				ActorID:        claims.Subject,
+			})
+			if err != nil {
+				switch {
+				case errors.Is(err, wallet.ErrInvalidAmount),
+					errors.Is(err, wallet.ErrInvalidDelta),
+					errors.Is(err, wallet.ErrUserIDRequired),
+					errors.Is(err, wallet.ErrIdempotencyRequired):
+					writeError(w, http.StatusBadRequest, err.Error())
+				case errors.Is(err, wallet.ErrInsufficientFunds):
+					writeError(w, http.StatusConflict, err.Error())
+				default:
+					logger.Error("failed to apply admin wallet adjustment", zap.String("userID", req.UserID), zap.String("actorID", claims.Subject), zap.Error(err))
+					writeError(w, http.StatusInternalServerError, "failed to adjust wallet")
+				}
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"entry":      entry,
+				"newBalance": newBalance,
+			})
 		})))
 
 		if streamersService != nil {

--- a/internal/app/router_wallet_test.go
+++ b/internal/app/router_wallet_test.go
@@ -1,0 +1,135 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/funpot/funpot-go-core/internal/admin"
+	"github.com/funpot/funpot-go-core/internal/users"
+)
+
+func TestWalletAdminAdjustAndWithdrawIdempotency(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		users.NewService(users.NewInMemoryRepository()),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+	adminToken := buildToken(t, "admin-1")
+	userToken := buildToken(t, "user-1")
+
+	adjustBody := []byte(`{"userId":"user-1","deltaINT":100,"reason":"manual grant"}`)
+	adjustReq := httptest.NewRequest(http.MethodPost, "/api/admin/wallet/adjust", bytes.NewReader(adjustBody))
+	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
+	adjustReq.Header.Set("Idempotency-Key", "adj-1")
+	adjustRes := httptest.NewRecorder()
+	handler.ServeHTTP(adjustRes, adjustReq)
+	if adjustRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", adjustRes.Code, adjustRes.Body.String())
+	}
+
+	replayReq := httptest.NewRequest(http.MethodPost, "/api/admin/wallet/adjust", bytes.NewReader(adjustBody))
+	replayReq.Header.Set("Authorization", "Bearer "+adminToken)
+	replayReq.Header.Set("Idempotency-Key", "adj-1")
+	replayRes := httptest.NewRecorder()
+	handler.ServeHTTP(replayRes, replayReq)
+	if replayRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", replayRes.Code, replayRes.Body.String())
+	}
+
+	walletReq := httptest.NewRequest(http.MethodGet, "/api/wallet", nil)
+	walletReq.Header.Set("Authorization", "Bearer "+userToken)
+	walletRes := httptest.NewRecorder()
+	handler.ServeHTTP(walletRes, walletReq)
+	if walletRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", walletRes.Code, walletRes.Body.String())
+	}
+
+	var walletPayload struct {
+		Balance int64 `json:"balance"`
+		History []struct {
+			Type string `json:"type"`
+		} `json:"history"`
+	}
+	if err := json.Unmarshal(walletRes.Body.Bytes(), &walletPayload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if walletPayload.Balance != 100 {
+		t.Fatalf("expected balance 100, got %d", walletPayload.Balance)
+	}
+	if len(walletPayload.History) != 1 {
+		t.Fatalf("expected history length 1 after idempotent replay, got %d", len(walletPayload.History))
+	}
+
+	withdrawBody := []byte(`{"amountINT":30}`)
+	withdrawReq := httptest.NewRequest(http.MethodPost, "/api/wallet/withdraw", bytes.NewReader(withdrawBody))
+	withdrawReq.Header.Set("Authorization", "Bearer "+userToken)
+	withdrawReq.Header.Set("Idempotency-Key", "w-1")
+	withdrawRes := httptest.NewRecorder()
+	handler.ServeHTTP(withdrawRes, withdrawReq)
+	if withdrawRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", withdrawRes.Code, withdrawRes.Body.String())
+	}
+
+	withdrawReplayReq := httptest.NewRequest(http.MethodPost, "/api/wallet/withdraw", bytes.NewReader(withdrawBody))
+	withdrawReplayReq.Header.Set("Authorization", "Bearer "+userToken)
+	withdrawReplayReq.Header.Set("Idempotency-Key", "w-1")
+	withdrawReplayRes := httptest.NewRecorder()
+	handler.ServeHTTP(withdrawReplayRes, withdrawReplayReq)
+	if withdrawReplayRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", withdrawReplayRes.Code, withdrawReplayRes.Body.String())
+	}
+
+	walletReqAfter := httptest.NewRequest(http.MethodGet, "/api/wallet", nil)
+	walletReqAfter.Header.Set("Authorization", "Bearer "+userToken)
+	walletResAfter := httptest.NewRecorder()
+	handler.ServeHTTP(walletResAfter, walletReqAfter)
+	if walletResAfter.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", walletResAfter.Code, walletResAfter.Body.String())
+	}
+	if err := json.Unmarshal(walletResAfter.Body.Bytes(), &walletPayload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if walletPayload.Balance != 70 {
+		t.Fatalf("expected balance 70 after idempotent withdraw replay, got %d", walletPayload.Balance)
+	}
+}
+
+func TestAdminWalletAdjustRequiresAdmin(t *testing.T) {
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		users.NewService(users.NewInMemoryRepository()),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/wallet/adjust", bytes.NewReader([]byte(`{"userId":"user-1","deltaINT":10,"reason":"test"}`)))
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	req.Header.Set("Idempotency-Key", "adj-1")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", res.Code)
+	}
+}

--- a/internal/wallet/service.go
+++ b/internal/wallet/service.go
@@ -1,0 +1,188 @@
+package wallet
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	ErrUserIDRequired      = errors.New("user id is required")
+	ErrInvalidAmount       = errors.New("amount must be a positive integer")
+	ErrInvalidDelta        = errors.New("delta must not be zero")
+	ErrIdempotencyRequired = errors.New("idempotency key is required")
+	ErrInsufficientFunds   = errors.New("insufficient funds")
+)
+
+type EntryType string
+
+const (
+	EntryTypeCredit EntryType = "credit"
+	EntryTypeDebit  EntryType = "debit"
+)
+
+type Entry struct {
+	ID             string    `json:"id"`
+	UserID         string    `json:"-"`
+	Type           EntryType `json:"type"`
+	Amount         int64     `json:"amount"`
+	Currency       string    `json:"currency"`
+	Reason         string    `json:"reason"`
+	IdempotencyKey string    `json:"-"`
+	ActorID        string    `json:"-"`
+	CreatedAt      time.Time `json:"createdAt"`
+}
+
+type Wallet struct {
+	Balance int64   `json:"balance"`
+	History []Entry `json:"history"`
+}
+
+type PostRequest struct {
+	UserID         string
+	Type           EntryType
+	Amount         int64
+	Currency       string
+	Reason         string
+	IdempotencyKey string
+	ActorID        string
+}
+
+type AdjustRequest struct {
+	UserID         string
+	Delta          int64
+	Currency       string
+	Reason         string
+	IdempotencyKey string
+	ActorID        string
+}
+
+type account struct {
+	Balance           int64
+	Entries           []Entry
+	ProcessedByIdemID map[string]Entry
+}
+
+type Service struct {
+	mu       sync.RWMutex
+	now      func() time.Time
+	accounts map[string]*account
+}
+
+func NewService() *Service {
+	return &Service{
+		now:      time.Now,
+		accounts: make(map[string]*account),
+	}
+}
+
+func (s *Service) Post(req PostRequest) (Entry, int64, error) {
+	userID := strings.TrimSpace(req.UserID)
+	if userID == "" {
+		return Entry{}, 0, ErrUserIDRequired
+	}
+	if req.Amount <= 0 {
+		return Entry{}, 0, ErrInvalidAmount
+	}
+	if strings.TrimSpace(req.IdempotencyKey) == "" {
+		return Entry{}, 0, ErrIdempotencyRequired
+	}
+	if req.Type != EntryTypeCredit && req.Type != EntryTypeDebit {
+		return Entry{}, 0, errors.New("wallet entry type is invalid")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	acct := s.ensureAccountLocked(userID)
+	if existing, ok := acct.ProcessedByIdemID[req.IdempotencyKey]; ok {
+		return existing, acct.Balance, nil
+	}
+
+	if req.Type == EntryTypeDebit && acct.Balance < req.Amount {
+		return Entry{}, acct.Balance, ErrInsufficientFunds
+	}
+
+	now := s.now().UTC()
+	entry := Entry{
+		ID:             uuid.NewString(),
+		UserID:         userID,
+		Type:           req.Type,
+		Amount:         req.Amount,
+		Currency:       normalizeCurrency(req.Currency),
+		Reason:         strings.TrimSpace(req.Reason),
+		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
+		ActorID:        strings.TrimSpace(req.ActorID),
+		CreatedAt:      now,
+	}
+
+	if entry.Type == EntryTypeCredit {
+		acct.Balance += entry.Amount
+	} else {
+		acct.Balance -= entry.Amount
+	}
+
+	acct.Entries = append(acct.Entries, entry)
+	acct.ProcessedByIdemID[entry.IdempotencyKey] = entry
+	return entry, acct.Balance, nil
+}
+
+func (s *Service) Adjust(req AdjustRequest) (Entry, int64, error) {
+	if req.Delta == 0 {
+		return Entry{}, 0, ErrInvalidDelta
+	}
+	t := EntryTypeCredit
+	amount := req.Delta
+	if req.Delta < 0 {
+		t = EntryTypeDebit
+		amount = -req.Delta
+	}
+	return s.Post(PostRequest{
+		UserID:         req.UserID,
+		Type:           t,
+		Amount:         amount,
+		Currency:       req.Currency,
+		Reason:         req.Reason,
+		IdempotencyKey: req.IdempotencyKey,
+		ActorID:        req.ActorID,
+	})
+}
+
+func (s *Service) Get(userID string) Wallet {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	acct, ok := s.accounts[strings.TrimSpace(userID)]
+	if !ok {
+		return Wallet{Balance: 0, History: []Entry{}}
+	}
+
+	history := append([]Entry(nil), acct.Entries...)
+	sort.Slice(history, func(i, j int) bool {
+		return history[i].CreatedAt.After(history[j].CreatedAt)
+	})
+
+	return Wallet{Balance: acct.Balance, History: history}
+}
+
+func (s *Service) ensureAccountLocked(userID string) *account {
+	acct, ok := s.accounts[userID]
+	if ok {
+		return acct
+	}
+	acct = &account{ProcessedByIdemID: make(map[string]Entry)}
+	s.accounts[userID] = acct
+	return acct
+}
+
+func normalizeCurrency(currency string) string {
+	trimmed := strings.TrimSpace(currency)
+	if trimmed == "" {
+		return "FPC"
+	}
+	return strings.ToUpper(trimmed)
+}

--- a/internal/wallet/service_test.go
+++ b/internal/wallet/service_test.go
@@ -1,0 +1,48 @@
+package wallet
+
+import "testing"
+
+func TestServicePostIdempotentAndInsufficientFunds(t *testing.T) {
+	svc := NewService()
+
+	entry, balance, err := svc.Post(PostRequest{UserID: "u1", Type: EntryTypeCredit, Amount: 100, IdempotencyKey: "k1", Reason: "init"})
+	if err != nil {
+		t.Fatalf("Post(credit) error = %v", err)
+	}
+	if balance != 100 {
+		t.Fatalf("expected balance 100, got %d", balance)
+	}
+
+	again, againBalance, err := svc.Post(PostRequest{UserID: "u1", Type: EntryTypeCredit, Amount: 100, IdempotencyKey: "k1", Reason: "init"})
+	if err != nil {
+		t.Fatalf("Post(credit idempotent) error = %v", err)
+	}
+	if againBalance != 100 {
+		t.Fatalf("expected idempotent balance 100, got %d", againBalance)
+	}
+	if again.ID != entry.ID {
+		t.Fatalf("expected same entry id for idempotent replay")
+	}
+
+	_, _, err = svc.Post(PostRequest{UserID: "u1", Type: EntryTypeDebit, Amount: 200, IdempotencyKey: "k2", Reason: "withdraw"})
+	if err == nil {
+		t.Fatalf("expected insufficient funds error")
+	}
+}
+
+func TestServiceAdjustDebitAndCredit(t *testing.T) {
+	svc := NewService()
+	if _, _, err := svc.Adjust(AdjustRequest{UserID: "u1", Delta: 50, IdempotencyKey: "adj-1", Reason: "grant"}); err != nil {
+		t.Fatalf("Adjust(credit) error = %v", err)
+	}
+	if _, _, err := svc.Adjust(AdjustRequest{UserID: "u1", Delta: -20, IdempotencyKey: "adj-2", Reason: "penalty"}); err != nil {
+		t.Fatalf("Adjust(debit) error = %v", err)
+	}
+	wallet := svc.Get("u1")
+	if wallet.Balance != 30 {
+		t.Fatalf("expected balance 30, got %d", wallet.Balance)
+	}
+	if len(wallet.History) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(wallet.History))
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a simple in-memory wallet to track user balances and history and enable programmatic credits/debits. 
- Expose user-facing and admin-facing wallet operations via HTTP with idempotency to avoid duplicate side effects. 
- Document the new API surface in the OpenAPI spec. 

### Description
- Add a new `internal/wallet` package implementing `Service` with `Post`, `Adjust`, and `Get` methods, idempotency handling, and basic in-memory accounts. 
- Wire the wallet into the HTTP router by adding `GET /api/wallet`, `POST /api/wallet/withdraw`, and admin-only `POST /api/admin/wallet/adjust` endpoints, all requiring an `Idempotency-Key` header for mutating requests. 
- Add request/response DTOs in `router.go` and update `docs/openapi.yaml` with `AdminWalletAdjustRequest`, `AdminWalletAdjustResponse`, and response fields like `newBalance`. 
- Implement validation and error mapping for common wallet errors (e.g. `ErrInsufficientFunds`, `ErrInvalidAmount`, `ErrIdempotencyRequired`) and normalize currency default to `FPC`. 

### Testing
- Added unit tests `TestServicePostIdempotentAndInsufficientFunds` and `TestServiceAdjustDebitAndCredit` under `internal/wallet`, and handler tests `TestWalletAdminAdjustAndWithdrawIdempotency` and `TestAdminWalletAdjustRequiresAdmin` under `internal/app`. 
- Ran the added tests (via `go test ./internal/wallet` and `go test ./internal/app`) and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec80918ce4832cabc9f772c0c757f7)