### PR TITLE
Emit live-event when game scenario terminal condition matches and add logging/tests

### DIFF
--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -904,7 +904,6 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 	entering := execution.Entering
 	previousState := execution.PreviousState
 	logger.Info("scenario step selected", zap.String("streamerID", streamerID), zap.String("scenarioPackageID", pkg.ID), zap.String("stepID", step.ID), zap.Int("segmentSeconds", step.SegmentSeconds), zap.Int("maxRequests", step.MaxRequests))
-	w.emitLiveEventFromTerminal(ctx, streamerID, execution)
 	if strings.TrimSpace(pkg.LLMModelConfigID) == "" {
 		return streamers.LLMDecision{}, prompts.ErrInvalidScenarioModelRef
 	}
@@ -964,11 +963,18 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 	return decision, nil
 }
 
-func (w *Worker) emitLiveEventFromTerminal(ctx context.Context, streamerID string, execution scenarioExecutionPlan) {
-	if w == nil || w.liveEvents == nil || !execution.HasMatchedTerminal {
-		return
+func (w *Worker) emitLiveEventFromTerminal(ctx context.Context, streamerID, scenarioID, transitionID string, terminal prompts.GameScenarioTerminalCondition) error {
+	if w == nil || w.liveEvents == nil {
+		return nil
 	}
-	terminal := execution.MatchedTerminal
+	logger := w.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if strings.TrimSpace(terminal.ID) == "" {
+		logger.Debug("skip live-event emit because terminal condition is empty", zap.String("streamerID", streamerID), zap.String("scenarioID", strings.TrimSpace(scenarioID)))
+		return nil
+	}
 	outcomes := make([]events.Option, 0, len(terminal.OutcomeTemplates))
 	for _, item := range terminal.OutcomeTemplates {
 		outcomes = append(outcomes, events.Option{
@@ -980,16 +986,26 @@ func (w *Worker) emitLiveEventFromTerminal(ctx context.Context, streamerID strin
 	if duration <= 0 {
 		duration = 5 * time.Minute
 	}
-	_, _ = w.liveEvents.CreateLiveEvent(ctx, events.CreateLiveEventRequest{
+	created, err := w.liveEvents.CreateLiveEvent(ctx, events.CreateLiveEventRequest{
 		StreamerID:      streamerID,
-		ScenarioID:      strings.TrimSpace(execution.GameScenarioID),
-		TransitionID:    strings.TrimSpace(execution.TransitionID),
+		ScenarioID:      strings.TrimSpace(scenarioID),
+		TransitionID:    strings.TrimSpace(transitionID),
 		TerminalID:      strings.TrimSpace(terminal.ID),
 		Title:           terminal.GameTitle,
 		DefaultLanguage: strings.TrimSpace(terminal.DefaultLanguage),
 		Options:         outcomes,
 		Duration:        duration,
 	})
+	if err != nil {
+		if errors.Is(err, events.ErrAlreadyActive) {
+			logger.Debug("live-event already active for terminal", zap.String("streamerID", streamerID), zap.String("scenarioID", strings.TrimSpace(scenarioID)), zap.String("transitionID", strings.TrimSpace(transitionID)), zap.String("terminalID", strings.TrimSpace(terminal.ID)))
+			return nil
+		}
+		logger.Error("failed to create live-event from terminal", zap.String("streamerID", streamerID), zap.String("scenarioID", strings.TrimSpace(scenarioID)), zap.String("transitionID", strings.TrimSpace(transitionID)), zap.String("terminalID", strings.TrimSpace(terminal.ID)), zap.Error(err))
+		return err
+	}
+	logger.Debug("live-event created from terminal", zap.String("streamerID", streamerID), zap.String("scenarioID", strings.TrimSpace(scenarioID)), zap.String("transitionID", strings.TrimSpace(transitionID)), zap.String("terminalID", strings.TrimSpace(terminal.ID)), zap.String("eventID", strings.TrimSpace(created.ID)), zap.Int("outcomesCount", len(created.Options)))
+	return nil
 }
 
 func (w *Worker) applyGameScenarioTerminalCondition(ctx context.Context, execution scenarioExecutionPlan, transitionTrace map[string]any, decision streamers.LLMDecision) (streamers.LLMDecision, bool, error) {
@@ -1015,7 +1031,16 @@ func (w *Worker) applyGameScenarioTerminalCondition(ctx context.Context, executi
 		return streamers.LLMDecision{}, false, err
 	}
 	if !matched {
+		if w.logger != nil {
+			w.logger.Debug("game-scenario terminal condition not matched", zap.String("streamerID", decision.StreamerID), zap.String("gameScenarioID", gameScenarioID), zap.String("transitionID", strings.TrimSpace(transitionID)), zap.String("stage", decision.Stage))
+		}
 		return decision, false, nil
+	}
+	if w.logger != nil {
+		w.logger.Debug("game-scenario terminal condition matched", zap.String("streamerID", decision.StreamerID), zap.String("gameScenarioID", gameScenarioID), zap.String("transitionID", strings.TrimSpace(transitionID)), zap.String("terminalID", strings.TrimSpace(terminal.ID)), zap.String("stage", decision.Stage))
+	}
+	if err := w.emitLiveEventFromTerminal(ctx, decision.StreamerID, gameScenarioID, strings.TrimSpace(transitionID), terminal); err != nil {
+		return streamers.LLMDecision{}, false, err
 	}
 	decision.UpdatedStateJSON = enrichScenarioState(currentState, execution.PreviousState, gameScenarioID, scenarioStatePackageID(currentState), decision.Stage, map[string]any{
 		"status":               "terminal_condition_matched",

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/funpot/funpot-go-core/internal/events"
 	"github.com/funpot/funpot-go-core/internal/prompts"
 	"github.com/funpot/funpot-go-core/internal/streamers"
 )
@@ -212,6 +213,11 @@ type fakeChunkPublisher struct {
 	uploaded UploadedVideo
 }
 
+type fakeLiveEventStore struct {
+	reqs []events.CreateLiveEventRequest
+	err  error
+}
+
 func (f *flakyClassifier) Classify(_ context.Context, input StageRequest) (StageClassification, error) {
 	if f.calls == nil {
 		f.calls = map[string]int{}
@@ -229,6 +235,19 @@ func (f *flakyClassifier) Classify(_ context.Context, input StageRequest) (Stage
 func (f *fakeChunkPublisher) Publish(_ context.Context, _ string, _ ChunkRef) (UploadedVideo, error) {
 	f.calls++
 	return f.uploaded, f.err
+}
+
+func (f *fakeLiveEventStore) CreateLiveEvent(_ context.Context, req events.CreateLiveEventRequest) (events.LiveEvent, error) {
+	f.reqs = append(f.reqs, req)
+	if f.err != nil {
+		return events.LiveEvent{}, f.err
+	}
+	return events.LiveEvent{
+		ID:         "event-1",
+		ScenarioID: req.ScenarioID,
+		TerminalID: req.TerminalID,
+		Options:    req.Options,
+	}, nil
 }
 
 func (s *fakeDecisionStore) RecordLLMDecision(_ context.Context, req streamers.RecordDecisionRequest) (streamers.LLMDecision, error) {
@@ -1025,6 +1044,7 @@ func TestWorkerProcessStreamerKeepsCurrentScenarioPackageStepAcrossCycles(t *tes
 }
 
 func TestWorkerProcessStreamerStopsOnPostStepGameScenarioTerminalCondition(t *testing.T) {
+	liveEvents := &fakeLiveEventStore{}
 	worker := NewWorker(
 		&fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Now().UTC()}},
 		fakeClassifier{results: map[string]StageClassification{
@@ -1077,7 +1097,7 @@ func TestWorkerProcessStreamerStopsOnPostStepGameScenarioTerminalCondition(t *te
 		&InMemoryRunStore{},
 		&fakeDecisionStore{},
 		NewInMemoryLocker(),
-		WorkerConfig{MinConfidence: 0.5},
+		WorkerConfig{MinConfidence: 0.5, LiveEvents: liveEvents},
 	)
 
 	decision, err := worker.ProcessStreamer(context.Background(), "streamer-1")
@@ -1089,6 +1109,15 @@ func TestWorkerProcessStreamerStopsOnPostStepGameScenarioTerminalCondition(t *te
 	transition, _ := meta["transition"].(map[string]any)
 	if transition["reason"] != "game_scenario_terminal_condition_matched" {
 		t.Fatalf("expected game-scenario terminal trace, got %#v", transition)
+	}
+	if len(liveEvents.reqs) != 1 {
+		t.Fatalf("expected one live-event emit on terminal match, got %d", len(liveEvents.reqs))
+	}
+	if liveEvents.reqs[0].TerminalID != "score-limit" {
+		t.Fatalf("expected terminal score-limit, got %#v", liveEvents.reqs[0])
+	}
+	if len(liveEvents.reqs[0].Options) != 2 {
+		t.Fatalf("expected 2 outcome options, got %#v", liveEvents.reqs[0].Options)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Ensure that when a game scenario terminal condition is matched a live-event is created and failures are handled instead of silently ignoring creation errors.

### Description

- Refactor `emitLiveEventFromTerminal` to accept `streamerID`, `scenarioID`, `transitionID`, and `terminal` and return an `error` while adding debug/error logging and handling `events.ErrAlreadyActive`.
- Stop emitting live events from `processScenarioPackage` and instead invoke `emitLiveEventFromTerminal` from `applyGameScenarioTerminalCondition` after a terminal condition is matched and log whether a match occurred.
- Improve logging around terminal condition matching and enrich state with terminal metadata via `enrichScenarioState` as before.
- Add a `fakeLiveEventStore` test double, import `events` in tests, and update `TestWorkerProcessStreamerStopsOnPostStepGameScenarioTerminalCondition` to assert that a live-event was created with the expected `TerminalID` and outcome options.

### Testing

- Ran unit tests in the `internal/media` package including `TestWorkerProcessStreamerStopsOnPostStepGameScenarioTerminalCondition`, and they passed.
- Executed `go test ./internal/media` to validate the new `fakeLiveEventStore` behavior and related flow, and the run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3332a764832c87668652b21a619b)