### PR TITLE
Validate transition and terminal IDs in game scenario requests and add unit tests

### DIFF
--- a/internal/prompts/game_scenario.go
+++ b/internal/prompts/game_scenario.go
@@ -99,6 +99,9 @@ func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScena
 		return fmt.Errorf("%w: initialNodeId must reference existing node", ErrInvalidGameScenario)
 	}
 	for _, tr := range req.Transitions {
+		if strings.TrimSpace(tr.ID) == "" {
+			return fmt.Errorf("%w: transition id is required", ErrInvalidGameScenario)
+		}
 		if _, ok := nodeIDs[strings.TrimSpace(tr.FromNodeID)]; !ok {
 			return fmt.Errorf("%w: transition fromNodeId %s not found", ErrInvalidGameScenario, tr.FromNodeID)
 		}
@@ -122,6 +125,9 @@ func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScena
 	}
 	for _, tr := range req.Transitions {
 		for _, tc := range tr.TerminalConditions {
+			if strings.TrimSpace(tc.ID) == "" {
+				return fmt.Errorf("%w: transition %s terminal id is required", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
+			}
 			if strings.TrimSpace(tc.Condition) == "" {
 				return fmt.Errorf("%w: transition %s terminal condition is required", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
 			}

--- a/internal/prompts/game_scenario_test.go
+++ b/internal/prompts/game_scenario_test.go
@@ -122,6 +122,38 @@ func TestGameScenarioCreateRejectsMissingTransitionCondition(t *testing.T) {
 	}
 }
 
+func TestGameScenarioCreateRejectsMissingTransitionID(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	cfg := mustCreateModelConfig(t, svc)
+	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "root",
+		GameSlug:         "global",
+		LLMModelConfigID: cfg.ID,
+		ActorID:          "admin-1",
+		Steps:            []ScenarioStep{{ID: "root", Name: "root", PromptTemplate: "x", ResponseSchemaJSON: `{}`, Initial: true, Order: 1}},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+
+	_, err = svc.CreateGameScenario(context.Background(), GameScenarioCreateRequest{
+		Name:          "invalid-transition-id",
+		GameSlug:      "cs2",
+		InitialNodeID: "n1",
+		Nodes:         []GameScenarioNode{{ID: "n1", ScenarioPackageID: pkg.ID}},
+		Transitions:   []GameScenarioTransition{{FromNodeID: "n1", ToNodeID: "n1", Condition: `winner == "ct"`, Priority: 1}},
+		ActorID:       "admin-1",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !errors.Is(err, ErrInvalidGameScenario) {
+		t.Fatalf("expected ErrInvalidGameScenario, got %v", err)
+	}
+}
+
 func TestGameScenarioCreateRejectsTerminalWithoutOutcomes(t *testing.T) {
 	t.Parallel()
 
@@ -151,6 +183,47 @@ func TestGameScenarioCreateRejectsTerminalWithoutOutcomes(t *testing.T) {
 			Priority:   1,
 			TerminalConditions: []GameScenarioTerminalCondition{
 				{Condition: `winner == "ct"`, DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomesCount: 0, Priority: 1},
+			},
+		}},
+		ActorID: "admin-1",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !errors.Is(err, ErrInvalidGameScenario) {
+		t.Fatalf("expected ErrInvalidGameScenario, got %v", err)
+	}
+}
+
+func TestGameScenarioCreateRejectsTerminalWithoutID(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+	cfg := mustCreateModelConfig(t, svc)
+	pkg, err := svc.CreateScenarioPackage(context.Background(), ScenarioPackageCreateRequest{
+		Name:             "root",
+		GameSlug:         "global",
+		LLMModelConfigID: cfg.ID,
+		ActorID:          "admin-1",
+		Steps:            []ScenarioStep{{ID: "root", Name: "root", PromptTemplate: "x", ResponseSchemaJSON: `{}`, Initial: true, Order: 1}},
+	})
+	if err != nil {
+		t.Fatalf("create scenario package: %v", err)
+	}
+
+	_, err = svc.CreateGameScenario(context.Background(), GameScenarioCreateRequest{
+		Name:          "invalid-terminal-id",
+		GameSlug:      "cs2",
+		InitialNodeID: "n1",
+		Nodes:         []GameScenarioNode{{ID: "n1", ScenarioPackageID: pkg.ID}},
+		Transitions: []GameScenarioTransition{{
+			ID:         "tr-1",
+			FromNodeID: "n1",
+			ToNodeID:   "n1",
+			Condition:  `winner == "ct"`,
+			Priority:   1,
+			TerminalConditions: []GameScenarioTerminalCondition{
+				{Condition: `winner == "ct"`, DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomesCount: 1, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt-1", Title: map[string]string{"ru": "Опция"}}}, Priority: 1},
 			},
 		}},
 		ActorID: "admin-1",


### PR DESCRIPTION
### Motivation
- Ensure transitions and terminal conditions always include explicit non-empty IDs to avoid ambiguous references in game scenario definitions. 
- Strengthen request validation to catch missing IDs early when creating game scenarios.

### Description
- Added a non-empty trimmed `ID` check for each transition in `validateGameScenarioRequest` that returns `ErrInvalidGameScenario` when missing. 
- Added a non-empty trimmed `ID` check for each terminal condition in transitions in `validateGameScenarioRequest` that returns `ErrInvalidGameScenario` including the transition context. 
- Left existing validation logic intact for transition conditions, target package initial step, terminal outcomes, default language, game title, and outcome template IDs.

### Testing
- Added unit tests `TestGameScenarioCreateRejectsMissingTransitionID` and `TestGameScenarioCreateRejectsTerminalWithoutID` in `internal/prompts/game_scenario_test.go`. 
- Ran `go test ./...` and all tests, including the new ones, passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef46ddc97c832c9af1e24a8a36e5af)