### PR TITLE
docs: sync game-scenario OpenAPI contract with backend validation

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1856,11 +1856,12 @@ components:
           type: string
     GameScenarioTransition:
       type: object
-      required: [fromNodeId, toNodeId, condition, priority]
+      required: [id, fromNodeId, toNodeId, condition, priority]
       additionalProperties: false
       properties:
         id:
           type: string
+          minLength: 1
         fromNodeId:
           type: string
         toNodeId:
@@ -1877,15 +1878,17 @@ components:
             $ref: '#/components/schemas/GameScenarioTerminalCondition'
     GameScenarioTerminalCondition:
       type: object
-      required: [condition, defaultLanguage, outcomesCount]
+      required: [id, condition, gameTitle, defaultLanguage, outcomesCount, outcomeTemplates]
       additionalProperties: false
       properties:
         id:
           type: string
+          minLength: 1
         condition:
           type: string
         gameTitle:
           type: object
+          minProperties: 1
           additionalProperties:
             type: string
         defaultLanguage:
@@ -1896,6 +1899,7 @@ components:
           minimum: 1
         outcomeTemplates:
           type: array
+          minItems: 1
           items:
             $ref: '#/components/schemas/GameScenarioOutcomeTemplate'
         priority:
@@ -1903,13 +1907,15 @@ components:
           minimum: 1
     GameScenarioOutcomeTemplate:
       type: object
-      required: [id]
+      required: [id, title]
       additionalProperties: false
       properties:
         id:
           type: string
+          minLength: 1
         title:
           type: object
+          minProperties: 1
           additionalProperties:
             type: string
     GameScenarioCreateRequest:


### PR DESCRIPTION
### Motivation
- The backend enforces stricter validation for game-scenario payloads than the OpenAPI schema declared, causing a contract/runtime mismatch that can make valid client requests rejected by runtime validation.
- Align the public API contract so admin clients and integrations can validate payloads before sending them and avoid confusing runtime rejections.
- Checklist (aligned with M2.1 and scenario-graph v2 plan):
  - [x] Confirm presence of game-scenario admin routes (list/create/get/update/delete/activate) in runtime and OpenAPI.
  - [x] Align OpenAPI contract fields for game-scenarios to match current runtime validation.
  - [ ] Implement package→package orchestration and terminal finish conditions in runtime (follow-up task per docs/llm_stream_orchestration_plan.md).

### Description
- Updated `docs/openapi.yaml` to require `id` for `GameScenarioTransition` and added `minLength: 1` to ensure non-empty IDs.
- Tightened `GameScenarioTerminalCondition` schema to require `id`, `gameTitle`, and `outcomeTemplates`, added `minProperties: 1` for `gameTitle`, and `minItems: 1` for `outcomeTemplates` to mirror runtime checks.
- Tightened `GameScenarioOutcomeTemplate` to require `title` and added `minLength`/`minProperties` constraints for IDs and localized title maps.
- These changes are documentation/spec updates only; runtime behavior/validation code remains unchanged and already enforces the same rules.

### Testing
- Ran `go test ./internal/app -run TestAdminLLMGameScenarioRoutes -count=1` and it passed (`ok`).
- Ran `go test ./internal/prompts -run TestGameScenario -count=1` and it passed (`ok`).
- No other automated tests were modified; this PR updates only the OpenAPI spec to match existing runtime validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4ab2a224832caf13140ef0c1fca8)