### PR TITLE
Emit live-event on game scenario transition and separate terminal handling

### DIFF
--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -937,6 +938,9 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 		finalPackageID = pkg.ID
 	}
 	result.UpdatedStateJSON = enrichScenarioState(result.UpdatedStateJSON, execution.PreviousState, execution.GameScenarioID, finalPackageID, step.ID, finalTransitionTrace)
+	if err := w.emitLiveEventFromScenarioTransition(ctx, streamerID, execution.GameScenarioID, finalTransitionTrace); err != nil {
+		return streamers.LLMDecision{}, err
+	}
 	decisionChunk := chunk
 	if w.chunkPublisher != nil {
 		uploadedVideo, publishErr := w.chunkPublisher.Publish(ctx, streamerID, chunk)
@@ -1039,9 +1043,7 @@ func (w *Worker) applyGameScenarioTerminalCondition(ctx context.Context, executi
 	if w.logger != nil {
 		w.logger.Debug("game-scenario terminal condition matched", zap.String("streamerID", decision.StreamerID), zap.String("gameScenarioID", gameScenarioID), zap.String("transitionID", strings.TrimSpace(transitionID)), zap.String("terminalID", strings.TrimSpace(terminal.ID)), zap.String("stage", decision.Stage))
 	}
-	if err := w.emitLiveEventFromTerminal(ctx, decision.StreamerID, gameScenarioID, strings.TrimSpace(transitionID), terminal); err != nil {
-		return streamers.LLMDecision{}, false, err
-	}
+	decision.TransitionTerminal = true
 	decision.UpdatedStateJSON = enrichScenarioState(currentState, execution.PreviousState, gameScenarioID, scenarioStatePackageID(currentState), decision.Stage, map[string]any{
 		"status":               "terminal_condition_matched",
 		"fromNode":             firstNonEmpty(currentNodeID, strings.TrimSpace(gameScenario.InitialNodeID)),
@@ -1072,7 +1074,7 @@ func (w *Worker) resolvePostStepScenarioTransition(ctx context.Context, executio
 	if currentNodeID == "" {
 		currentNodeID = scenarioStateNodeID(execution.PreviousState)
 	}
-	resolvedNode, _, nodeChanged, err := gameScenario.ResolveNode(currentNodeID, currentState)
+	resolvedNode, transitionID, nodeChanged, err := gameScenario.ResolveNode(currentNodeID, currentState)
 	if err != nil || !nodeChanged {
 		return currentPackageID, trace
 	}
@@ -1081,13 +1083,66 @@ func (w *Worker) resolvePostStepScenarioTransition(ctx context.Context, executio
 		nextPackageID = currentPackageID
 	}
 	return nextPackageID, map[string]any{
-		"status":      "accepted",
-		"fromNode":    firstNonEmpty(currentNodeID, strings.TrimSpace(gameScenario.InitialNodeID)),
-		"toNode":      strings.TrimSpace(resolvedNode.ID),
-		"fromPackage": currentPackageID,
-		"toPackage":   nextPackageID,
-		"reason":      "game_scenario_transition_matched",
+		"status":       "accepted",
+		"fromNode":     firstNonEmpty(currentNodeID, strings.TrimSpace(gameScenario.InitialNodeID)),
+		"toNode":       strings.TrimSpace(resolvedNode.ID),
+		"fromPackage":  currentPackageID,
+		"toPackage":    nextPackageID,
+		"transitionId": strings.TrimSpace(transitionID),
+		"reason":       "game_scenario_transition_matched",
 	}
+}
+
+func (w *Worker) emitLiveEventFromScenarioTransition(ctx context.Context, streamerID, scenarioID string, transitionTrace map[string]any) error {
+	if w == nil || w.liveEvents == nil {
+		return nil
+	}
+	if strings.TrimSpace(scenarioID) == "" {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(fmt.Sprint(transitionTrace["status"])), "accepted") {
+		return nil
+	}
+	transitionID := strings.TrimSpace(fmt.Sprint(transitionTrace["transitionId"]))
+	if transitionID == "" {
+		return nil
+	}
+	gameScenario, err := w.prompts.GetGameScenario(ctx, strings.TrimSpace(scenarioID))
+	if err != nil {
+		return err
+	}
+	terminal, ok := selectTransitionTerminalTemplate(gameScenario, transitionID)
+	if !ok {
+		return nil
+	}
+	return w.emitLiveEventFromTerminal(ctx, streamerID, scenarioID, transitionID, terminal)
+}
+
+func selectTransitionTerminalTemplate(gameScenario prompts.GameScenario, transitionID string) (prompts.GameScenarioTerminalCondition, bool) {
+	target := strings.TrimSpace(transitionID)
+	if target == "" {
+		return prompts.GameScenarioTerminalCondition{}, false
+	}
+	candidates := make([]prompts.GameScenarioTerminalCondition, 0)
+	for _, transition := range gameScenario.Transitions {
+		if strings.TrimSpace(transition.ID) != target {
+			continue
+		}
+		for _, terminal := range transition.TerminalConditions {
+			candidates = append(candidates, terminal)
+		}
+		break
+	}
+	if len(candidates) == 0 {
+		return prompts.GameScenarioTerminalCondition{}, false
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].Priority == candidates[j].Priority {
+			return strings.TrimSpace(candidates[i].ID) < strings.TrimSpace(candidates[j].ID)
+		}
+		return candidates[i].Priority > candidates[j].Priority
+	})
+	return candidates[0], true
 }
 
 func (w *Worker) latestDecisionByStreamer(ctx context.Context, streamerID string) streamers.LLMDecision {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -1043,7 +1043,89 @@ func TestWorkerProcessStreamerKeepsCurrentScenarioPackageStepAcrossCycles(t *tes
 	}
 }
 
-func TestWorkerProcessStreamerStopsOnPostStepGameScenarioTerminalCondition(t *testing.T) {
+func TestWorkerProcessStreamerEmitsLiveEventOnGameScenarioTransition(t *testing.T) {
+	liveEvents := &fakeLiveEventStore{}
+	worker := NewWorker(
+		&fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Now().UTC()}},
+		fakeClassifier{results: map[string]StageClassification{
+			"faceit": {Label: "state_updated", Confidence: 0.9, UpdatedStateJSON: `{"mode":"faceit","ct_score":2,"t_score":3}`},
+		}},
+		fakePromptResolver{
+			gameScenario: prompts.GameScenario{
+				ID:            "game-scenario-1",
+				Name:          "faceit-terminal",
+				GameSlug:      "global",
+				InitialNodeID: "initial",
+				Nodes: []prompts.GameScenarioNode{
+					{ID: "initial", ScenarioPackageID: "scenario-root"},
+					{ID: "global", ScenarioPackageID: "scenario-root"},
+				},
+				Transitions: []prompts.GameScenarioTransition{
+					{
+						ID:         "faceit-entry",
+						FromNodeID: "initial",
+						ToNodeID:   "global",
+						Condition:  `mode == "faceit"`,
+						Priority:   1,
+						TerminalConditions: []prompts.GameScenarioTerminalCondition{
+							{
+								ID:              "score-limit",
+								Condition:       `ct_score >= 6 | t_score >= 6`,
+								GameTitle:       map[string]string{"ru": "Победитель карты"},
+								DefaultLanguage: "ru",
+								OutcomesCount:   2,
+								OutcomeTemplates: []prompts.GameScenarioOutcomeTemplate{
+									{ID: "ct", Title: map[string]string{"ru": "CT"}},
+									{ID: "t", Title: map[string]string{"ru": "T"}},
+								},
+								Priority: 1,
+							},
+						},
+					},
+				},
+				IsActive: true,
+			},
+			scenario: prompts.ScenarioPackage{
+				ID:               "scenario-root",
+				GameSlug:         "global",
+				LLMModelConfigID: "cfg-default",
+				Steps: []prompts.ScenarioStep{
+					{ID: "faceit", Name: "Faceit", PromptTemplate: "score", ResponseSchemaJSON: `{}`, Initial: true, Order: 1},
+				},
+			},
+			llmModelConfig: prompts.LLMModelConfig{ID: "cfg-default", Model: "gemini-2.5-flash"},
+		},
+		&InMemoryRunStore{},
+		&fakeDecisionStore{},
+		NewInMemoryLocker(),
+		WorkerConfig{MinConfidence: 0.5, LiveEvents: liveEvents},
+	)
+
+	decision, err := worker.ProcessStreamer(context.Background(), "streamer-1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	state := parseJSONMap(decision.UpdatedStateJSON)
+	meta, _ := state["_scenario"].(map[string]any)
+	transition, _ := meta["transition"].(map[string]any)
+	if transition["reason"] != "game_scenario_transition_matched" {
+		t.Fatalf("expected game-scenario transition trace, got %#v", transition)
+	}
+	if len(liveEvents.reqs) != 1 {
+		t.Fatalf("expected one live-event emit on transition match, got %d", len(liveEvents.reqs))
+	}
+	if liveEvents.reqs[0].TerminalID != "score-limit" {
+		t.Fatalf("expected terminal score-limit, got %#v", liveEvents.reqs[0])
+	}
+	if len(liveEvents.reqs[0].Options) != 2 {
+		t.Fatalf("expected 2 outcome options, got %#v", liveEvents.reqs[0].Options)
+	}
+	if decision.TransitionTerminal {
+		t.Fatalf("expected transitionTerminal=false before terminal condition matches")
+	}
+}
+
+func TestWorkerProcessStreamerMarksTerminalWithoutCreatingLiveEvent(t *testing.T) {
 	liveEvents := &fakeLiveEventStore{}
 	worker := NewWorker(
 		&fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Now().UTC()}},
@@ -1104,20 +1186,17 @@ func TestWorkerProcessStreamerStopsOnPostStepGameScenarioTerminalCondition(t *te
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
+	if !decision.TransitionTerminal {
+		t.Fatalf("expected transitionTerminal=true when terminal condition matches")
+	}
 	state := parseJSONMap(decision.UpdatedStateJSON)
 	meta, _ := state["_scenario"].(map[string]any)
 	transition, _ := meta["transition"].(map[string]any)
 	if transition["reason"] != "game_scenario_terminal_condition_matched" {
-		t.Fatalf("expected game-scenario terminal trace, got %#v", transition)
+		t.Fatalf("expected terminal trace, got %#v", transition)
 	}
-	if len(liveEvents.reqs) != 1 {
-		t.Fatalf("expected one live-event emit on terminal match, got %d", len(liveEvents.reqs))
-	}
-	if liveEvents.reqs[0].TerminalID != "score-limit" {
-		t.Fatalf("expected terminal score-limit, got %#v", liveEvents.reqs[0])
-	}
-	if len(liveEvents.reqs[0].Options) != 2 {
-		t.Fatalf("expected 2 outcome options, got %#v", liveEvents.reqs[0].Options)
+	if len(liveEvents.reqs) != 0 {
+		t.Fatalf("expected no live-event emit on terminal match, got %d", len(liveEvents.reqs))
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Ensure a live-event is emitted when a game scenario transition (not a terminal condition) occurs so front-end/UI can present transition-linked terminal templates as live options.
- Decouple emitting live-events for transitions from terminal-condition handling to avoid duplicate or missed emits and to allow marking transitions separately from terminal matches.

### Description

- Added `emitLiveEventFromScenarioTransition` to detect accepted transitions and emit a live-event using the selected terminal template for that transition. 
- Added `selectTransitionTerminalTemplate` to pick the highest-priority terminal template for a transition and imported `sort` to order candidates. 
- Modified `resolvePostStepScenarioTransition` to return `transitionId` and include it in the returned transition trace under `transitionId`. 
- Call `emitLiveEventFromScenarioTransition` after resolving post-step transitions in `processScenarioPackage`. 
- Changed `applyGameScenarioTerminalCondition` to stop emitting live-events there and instead mark the decision with `TransitionTerminal = true` while still enriching the scenario state with terminal trace info. 
- Updated and expanded tests to cover transition emission and terminal-only marking behavior and adjusted test fixtures accordingly.

### Testing

- Ran unit tests in `internal/media` including `TestWorkerProcessStreamerEmitsLiveEventOnGameScenarioTransition`, `TestWorkerProcessStreamerMarksTerminalWithoutCreatingLiveEvent`, `TestWorkerProcessStreamerKeepsCurrentScenarioPackageStepAcrossCycles`, and `TestResolveGameScenarioSlug`. 
- All modified and existing unit tests completed successfully (`go test ./...` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4fa11888832cb56689b98bb14c90)