### PR TITLE
Add per-outcome conditions and priorities for game scenario terminal outcomes

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1878,14 +1878,12 @@ components:
             $ref: '#/components/schemas/GameScenarioTerminalCondition'
     GameScenarioTerminalCondition:
       type: object
-      required: [id, condition, gameTitle, defaultLanguage, outcomesCount, outcomeTemplates]
+      required: [id, gameTitle, defaultLanguage, outcomeTemplates]
       additionalProperties: false
       properties:
         id:
           type: string
           minLength: 1
-        condition:
-          type: string
         gameTitle:
           type: object
           minProperties: 1
@@ -1894,12 +1892,10 @@ components:
         defaultLanguage:
           type: string
           description: Primary locale key used to validate required localized title fields.
-        outcomesCount:
-          type: integer
-          minimum: 1
         outcomeTemplates:
           type: array
           minItems: 1
+          description: Outcome templates with per-button matching conditions. Terminal is considered matched when at least one outcome condition is true.
           items:
             $ref: '#/components/schemas/GameScenarioOutcomeTemplate'
         priority:
@@ -1907,7 +1903,7 @@ components:
           minimum: 1
     GameScenarioOutcomeTemplate:
       type: object
-      required: [id, title]
+      required: [id, title, condition]
       additionalProperties: false
       properties:
         id:
@@ -1918,6 +1914,13 @@ components:
           minProperties: 1
           additionalProperties:
             type: string
+        condition:
+          type: string
+          description: Data-driven expression evaluated against aggregated state to determine if this option is the winning outcome.
+        priority:
+          type: integer
+          minimum: 0
+          description: Tie-breaker when multiple outcome conditions are true; higher value wins.
     GameScenarioCreateRequest:
       type: object
       required: [name, gameSlug, initialNodeId, nodes]

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -134,16 +134,16 @@ func gameScenarioRequestToCreateRequest(req gameScenarioCreateRequest, actorID s
 			outcomeTemplates := make([]prompts.GameScenarioOutcomeTemplate, 0, len(item.OutcomeTemplates))
 			for _, outcome := range item.OutcomeTemplates {
 				outcomeTemplates = append(outcomeTemplates, prompts.GameScenarioOutcomeTemplate{
-					ID:    outcome.ID,
-					Title: outcome.Title,
+					ID:        outcome.ID,
+					Title:     outcome.Title,
+					Condition: outcome.Condition,
+					Priority:  outcome.Priority,
 				})
 			}
 			terminalConditions = append(terminalConditions, prompts.GameScenarioTerminalCondition{
 				ID:               item.ID,
-				Condition:        item.Condition,
 				GameTitle:        item.GameTitle,
 				DefaultLanguage:  item.DefaultLanguage,
-				OutcomesCount:    item.OutcomesCount,
 				OutcomeTemplates: outcomeTemplates,
 				Priority:         item.Priority,
 			})
@@ -249,17 +249,17 @@ type gameScenarioTransitionRequest struct {
 
 type gameScenarioTerminalConditionRequest struct {
 	ID               string                                     `json:"id"`
-	Condition        string                                     `json:"condition"`
 	GameTitle        map[string]string                          `json:"gameTitle"`
 	DefaultLanguage  string                                     `json:"defaultLanguage"`
-	OutcomesCount    int                                        `json:"outcomesCount"`
 	OutcomeTemplates []gameScenarioTerminalOutcomeTemplateInput `json:"outcomeTemplates"`
 	Priority         int                                        `json:"priority"`
 }
 
 type gameScenarioTerminalOutcomeTemplateInput struct {
-	ID    string            `json:"id"`
-	Title map[string]string `json:"title"`
+	ID        string            `json:"id"`
+	Title     map[string]string `json:"title"`
+	Condition string            `json:"condition"`
+	Priority  int               `json:"priority"`
 }
 
 type gameScenarioCreateRequest struct {

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -272,13 +272,11 @@ func TestAdminLLMGameScenarioRoutes(t *testing.T) {
 				"terminalConditions": []map[string]any{
 					{
 						"id":              "tm-1",
-						"condition":       `winner == "ct" && side == "ct"`,
 						"gameTitle":       map[string]string{"ru": "Победа CT", "en": "CT win"},
 						"defaultLanguage": "ru",
-						"outcomesCount":   2,
 						"outcomeTemplates": []map[string]any{
-							{"id": "ct", "title": map[string]string{"ru": "CT", "en": "CT"}},
-							{"id": "t", "title": map[string]string{"ru": "T", "en": "T"}},
+							{"id": "ct", "title": map[string]string{"ru": "CT", "en": "CT"}, "condition": `winner == "ct" && side == "ct"`, "priority": 100},
+							{"id": "t", "title": map[string]string{"ru": "T", "en": "T"}, "condition": `winner == "t" && side == "t"`, "priority": 90},
 						},
 						"priority": 100,
 					},

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -1043,6 +1043,14 @@ func (w *Worker) applyGameScenarioTerminalCondition(ctx context.Context, executi
 	if w.logger != nil {
 		w.logger.Debug("game-scenario terminal condition matched", zap.String("streamerID", decision.StreamerID), zap.String("gameScenarioID", gameScenarioID), zap.String("transitionID", strings.TrimSpace(transitionID)), zap.String("terminalID", strings.TrimSpace(terminal.ID)), zap.String("stage", decision.Stage))
 	}
+	winningOutcome, winningMatched, err := terminal.ResolveWinningOutcome(currentState)
+	if err != nil {
+		return streamers.LLMDecision{}, false, err
+	}
+	winningOutcomeID := ""
+	if winningMatched {
+		winningOutcomeID = strings.TrimSpace(winningOutcome.ID)
+	}
 	decision.TransitionTerminal = true
 	decision.UpdatedStateJSON = enrichScenarioState(currentState, execution.PreviousState, gameScenarioID, scenarioStatePackageID(currentState), decision.Stage, map[string]any{
 		"status":               "terminal_condition_matched",
@@ -1053,6 +1061,7 @@ func (w *Worker) applyGameScenarioTerminalCondition(ctx context.Context, executi
 		"reason":               "game_scenario_terminal_condition_matched",
 		"terminalId":           strings.TrimSpace(terminal.ID),
 		"terminalTransitionId": strings.TrimSpace(terminal.TransitionID),
+		"winningOutcomeId":     winningOutcomeID,
 	})
 	return decision, false, nil
 }

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -1070,13 +1070,11 @@ func TestWorkerProcessStreamerEmitsLiveEventOnGameScenarioTransition(t *testing.
 						TerminalConditions: []prompts.GameScenarioTerminalCondition{
 							{
 								ID:              "score-limit",
-								Condition:       `ct_score >= 6 | t_score >= 6`,
 								GameTitle:       map[string]string{"ru": "Победитель карты"},
 								DefaultLanguage: "ru",
-								OutcomesCount:   2,
 								OutcomeTemplates: []prompts.GameScenarioOutcomeTemplate{
-									{ID: "ct", Title: map[string]string{"ru": "CT"}},
-									{ID: "t", Title: map[string]string{"ru": "T"}},
+									{ID: "ct", Title: map[string]string{"ru": "CT"}, Condition: `ct_score >= 6`, Priority: 100},
+									{ID: "t", Title: map[string]string{"ru": "T"}, Condition: `t_score >= 6`, Priority: 100},
 								},
 								Priority: 1,
 							},
@@ -1151,13 +1149,11 @@ func TestWorkerProcessStreamerMarksTerminalWithoutCreatingLiveEvent(t *testing.T
 						TerminalConditions: []prompts.GameScenarioTerminalCondition{
 							{
 								ID:              "score-limit",
-								Condition:       `ct_score >= 6 | t_score >= 6`,
 								GameTitle:       map[string]string{"ru": "Победитель карты"},
 								DefaultLanguage: "ru",
-								OutcomesCount:   2,
 								OutcomeTemplates: []prompts.GameScenarioOutcomeTemplate{
-									{ID: "ct", Title: map[string]string{"ru": "CT"}},
-									{ID: "t", Title: map[string]string{"ru": "T"}},
+									{ID: "ct", Title: map[string]string{"ru": "CT"}, Condition: `ct_score >= 6`, Priority: 100},
+									{ID: "t", Title: map[string]string{"ru": "T"}, Condition: `t_score >= 6`, Priority: 100},
 								},
 								Priority: 1,
 							},

--- a/internal/prompts/game_scenario.go
+++ b/internal/prompts/game_scenario.go
@@ -33,17 +33,17 @@ type GameScenarioTransition struct {
 type GameScenarioTerminalCondition struct {
 	ID               string                        `json:"id"`
 	TransitionID     string                        `json:"transitionId,omitempty"`
-	Condition        string                        `json:"condition"`
 	GameTitle        map[string]string             `json:"gameTitle,omitempty"`
 	DefaultLanguage  string                        `json:"defaultLanguage,omitempty"`
-	OutcomesCount    int                           `json:"outcomesCount"`
 	OutcomeTemplates []GameScenarioOutcomeTemplate `json:"outcomeTemplates,omitempty"`
 	Priority         int                           `json:"priority"`
 }
 
 type GameScenarioOutcomeTemplate struct {
-	ID    string            `json:"id"`
-	Title map[string]string `json:"title,omitempty"`
+	ID        string            `json:"id"`
+	Title     map[string]string `json:"title,omitempty"`
+	Condition string            `json:"condition"`
+	Priority  int               `json:"priority"`
 }
 
 type GameScenario struct {
@@ -128,17 +128,8 @@ func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScena
 			if strings.TrimSpace(tc.ID) == "" {
 				return fmt.Errorf("%w: transition %s terminal id is required", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
 			}
-			if strings.TrimSpace(tc.Condition) == "" {
-				return fmt.Errorf("%w: transition %s terminal condition is required", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
-			}
-			if err := validateScenarioCondition(tc.Condition); err != nil {
-				return fmt.Errorf("%w: transition %s terminal condition: %v", ErrInvalidGameScenario, strings.TrimSpace(tr.ID), err)
-			}
-			if tc.OutcomesCount <= 0 {
-				return fmt.Errorf("%w: transition %s terminal outcomesCount must be positive", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
-			}
-			if len(tc.OutcomeTemplates) != tc.OutcomesCount {
-				return fmt.Errorf("%w: transition %s terminal outcomesCount must match outcomeTemplates", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
+			if len(tc.OutcomeTemplates) == 0 {
+				return fmt.Errorf("%w: transition %s terminal outcomeTemplates are required", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
 			}
 			if strings.TrimSpace(tc.DefaultLanguage) == "" {
 				return fmt.Errorf("%w: transition %s terminal defaultLanguage is required", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
@@ -149,6 +140,12 @@ func (s *Service) validateGameScenarioRequest(ctx context.Context, req GameScena
 			for _, outcome := range tc.OutcomeTemplates {
 				if strings.TrimSpace(outcome.ID) == "" {
 					return fmt.Errorf("%w: transition %s terminal outcome id is required", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
+				}
+				if strings.TrimSpace(outcome.Condition) == "" {
+					return fmt.Errorf("%w: transition %s terminal outcome condition is required", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
+				}
+				if err := validateScenarioCondition(outcome.Condition); err != nil {
+					return fmt.Errorf("%w: transition %s terminal outcome condition: %v", ErrInvalidGameScenario, strings.TrimSpace(tr.ID), err)
 				}
 				if strings.TrimSpace(outcome.Title[tc.DefaultLanguage]) == "" {
 					return fmt.Errorf("%w: transition %s terminal outcome title for default language is required", ErrInvalidGameScenario, strings.TrimSpace(tr.ID))
@@ -469,7 +466,7 @@ func evaluateOrderedTerminals(items []GameScenarioTerminalCondition, state map[s
 		return items[i].Priority > items[j].Priority
 	})
 	for _, terminal := range items {
-		ok, err := evaluateCondition(terminal.Condition, state)
+		_, ok, err := terminal.ResolveWinningOutcomeWithState(state)
 		if err != nil {
 			return GameScenarioTerminalCondition{}, false, err
 		}
@@ -478,6 +475,30 @@ func evaluateOrderedTerminals(items []GameScenarioTerminalCondition, state map[s
 		}
 	}
 	return GameScenarioTerminalCondition{}, false, nil
+}
+
+func (t GameScenarioTerminalCondition) ResolveWinningOutcome(stateJSON string) (GameScenarioOutcomeTemplate, bool, error) {
+	return t.ResolveWinningOutcomeWithState(parseJSONMap(stateJSON))
+}
+
+func (t GameScenarioTerminalCondition) ResolveWinningOutcomeWithState(state map[string]any) (GameScenarioOutcomeTemplate, bool, error) {
+	options := append([]GameScenarioOutcomeTemplate(nil), t.OutcomeTemplates...)
+	sort.SliceStable(options, func(i, j int) bool {
+		if options[i].Priority == options[j].Priority {
+			return strings.TrimSpace(options[i].ID) < strings.TrimSpace(options[j].ID)
+		}
+		return options[i].Priority > options[j].Priority
+	})
+	for _, option := range options {
+		ok, err := evaluateCondition(option.Condition, state)
+		if err != nil {
+			return GameScenarioOutcomeTemplate{}, false, err
+		}
+		if ok {
+			return option, true, nil
+		}
+	}
+	return GameScenarioOutcomeTemplate{}, false, nil
 }
 
 func (s *Service) hasActiveGameScenarioLocked() bool {

--- a/internal/prompts/game_scenario_test.go
+++ b/internal/prompts/game_scenario_test.go
@@ -53,13 +53,11 @@ func TestGameScenarioCRUD(t *testing.T) {
 			TerminalConditions: []GameScenarioTerminalCondition{
 				{
 					ID:              "tm-1",
-					Condition:       `winner == "ct"`,
 					GameTitle:       map[string]string{"ru": "Победа CT", "en": "CT win"},
 					DefaultLanguage: "ru",
-					OutcomesCount:   2,
 					OutcomeTemplates: []GameScenarioOutcomeTemplate{
-						{ID: "ct", Title: map[string]string{"ru": "CT", "en": "CT"}},
-						{ID: "t", Title: map[string]string{"ru": "T", "en": "T"}},
+						{ID: "ct", Title: map[string]string{"ru": "CT", "en": "CT"}, Condition: `winner == "ct"`, Priority: 100},
+						{ID: "t", Title: map[string]string{"ru": "T", "en": "T"}, Condition: `winner == "t"`, Priority: 90},
 					},
 					Priority: 100,
 				},
@@ -182,7 +180,7 @@ func TestGameScenarioCreateRejectsTerminalWithoutOutcomes(t *testing.T) {
 			Condition:  `winner == "ct"`,
 			Priority:   1,
 			TerminalConditions: []GameScenarioTerminalCondition{
-				{Condition: `winner == "ct"`, DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomesCount: 0, Priority: 1},
+				{ID: "tm-1", DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, Priority: 1},
 			},
 		}},
 		ActorID: "admin-1",
@@ -223,7 +221,7 @@ func TestGameScenarioCreateRejectsTerminalWithoutID(t *testing.T) {
 			Condition:  `winner == "ct"`,
 			Priority:   1,
 			TerminalConditions: []GameScenarioTerminalCondition{
-				{Condition: `winner == "ct"`, DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomesCount: 1, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt-1", Title: map[string]string{"ru": "Опция"}}}, Priority: 1},
+				{DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt-1", Title: map[string]string{"ru": "Опция"}, Condition: `winner == "ct"`}}, Priority: 1},
 			},
 		}},
 		ActorID: "admin-1",
@@ -305,7 +303,7 @@ func TestGameScenarioResolveTerminalConditionFallsBackToGlobalScope(t *testing.T
 				Condition:  `winner == "ct"`,
 				Priority:   100,
 				TerminalConditions: []GameScenarioTerminalCondition{
-					{ID: "edge-win", Condition: `winner == "ct"`, DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomesCount: 1, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt", Title: map[string]string{"ru": "Опция"}}}, Priority: 100},
+					{ID: "edge-win", DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt", Title: map[string]string{"ru": "Опция"}, Condition: `winner == "ct"`}}, Priority: 100},
 				},
 			},
 		},
@@ -339,8 +337,8 @@ func TestGameScenarioResolveTerminalConditionPrefersTransitionScope(t *testing.T
 				Condition:  `winner == "ct"`,
 				Priority:   100,
 				TerminalConditions: []GameScenarioTerminalCondition{
-					{ID: "edge-win-high", Condition: `winner == "ct"`, DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomesCount: 1, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt", Title: map[string]string{"ru": "Опция"}}}, Priority: 200},
-					{ID: "edge-win-low", Condition: `winner == "ct"`, DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomesCount: 1, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt", Title: map[string]string{"ru": "Опция"}}}, Priority: 10},
+					{ID: "edge-win-high", DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt", Title: map[string]string{"ru": "Опция"}, Condition: `winner == "ct"`}}, Priority: 200},
+					{ID: "edge-win-low", DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt", Title: map[string]string{"ru": "Опция"}, Condition: `winner == "ct"`}}, Priority: 10},
 				},
 			},
 		},
@@ -371,7 +369,7 @@ func TestGameScenarioResolveTerminalConditionPrefersMatchedTransitionBeforeGloba
 				Condition:  `winner == "ct"`,
 				Priority:   100,
 				TerminalConditions: []GameScenarioTerminalCondition{
-					{ID: "edge-win-local", Condition: `winner == "ct"`, DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomesCount: 1, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt", Title: map[string]string{"ru": "Опция"}}}, Priority: 10},
+					{ID: "edge-win-local", DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt", Title: map[string]string{"ru": "Опция"}, Condition: `winner == "ct"`}}, Priority: 10},
 				},
 			},
 			{
@@ -381,7 +379,7 @@ func TestGameScenarioResolveTerminalConditionPrefersMatchedTransitionBeforeGloba
 				Condition:  `winner == "ct"`,
 				Priority:   90,
 				TerminalConditions: []GameScenarioTerminalCondition{
-					{ID: "edge-win-global", Condition: `winner == "ct"`, DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomesCount: 1, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt", Title: map[string]string{"ru": "Опция"}}}, Priority: 999},
+					{ID: "edge-win-global", DefaultLanguage: "ru", GameTitle: map[string]string{"ru": "Игра"}, OutcomeTemplates: []GameScenarioOutcomeTemplate{{ID: "opt", Title: map[string]string{"ru": "Опция"}, Condition: `winner == "ct"`}}, Priority: 999},
 				},
 			},
 		},


### PR DESCRIPTION
### Motivation
- Improve terminal-condition handling by moving decision logic from a single terminal-level expression to per-outcome expressions so the runtime can pick a winning outcome based on data-driven conditions and tie-breaker priorities.
- Simplify terminal schema by removing `condition` and `outcomesCount` at the terminal level and make outcome templates authoritative for matching.
- Surface the chosen outcome in runtime decisions so downstream systems can act on the winning outcome ID.

### Description
- Data model and API: updated OpenAPI schema (`docs/openapi.yaml`) to remove `GameScenarioTerminalCondition.condition` and `outcomesCount`, and to require `GameScenarioOutcomeTemplate.condition` and `priority` while making `GameScenarioTerminalCondition.outcomeTemplates` required.
- Router and request models: mapped incoming JSON to the new fields in `internal/app/router.go` and updated request structs to include `Condition` and `Priority` on outcome templates and removed terminal-level `Condition`/`OutcomesCount` fields.
- Game scenario service: changed validation in `internal/prompts/game_scenario.go` to require non-empty `outcomeTemplates`, validate each outcome's `condition` via `validateScenarioCondition`, and removed terminal-level condition/outcomesCount checks.
- Terminal evaluation: replaced terminal-level condition evaluation with per-outcome evaluation by adding `ResolveWinningOutcome` / `ResolveWinningOutcomeWithState` methods and updating `evaluateOrderedTerminals` to use outcome evaluation and outcome priorities as tie-breakers.
- Worker/runtime: updated `internal/media/worker.go` to resolve the winning outcome at runtime and write `winningOutcomeId` into the enriched scenario state (`decision.TransitionTerminal = true` path).
- Tests: updated multiple tests (`internal/prompts/game_scenario_test.go`, `internal/media/worker_test.go`, `internal/app/router_admin_llm_test.go`) to use per-outcome `condition` and `priority` fields and adjusted expectations accordingly.

### Testing
- Ran unit tests for prompts and worker logic including `TestGameScenarioCRUD`, terminal validation tests, and worker scenario terminal tests; all updated tests passed locally.
- Ran admin router tests covering game scenario create/get flows; tests that exercise the new outcome fields passed.
- No new integration tests were added beyond the updated unit tests, and no automated tests failed.```}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5aacf624832c8b44520c462dabcb)