### PR TITLE
Relax Streamlink timeout enforcement, change duration formatting, and disable continuous default; update tests

### DIFF
--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -41,7 +41,7 @@ var streamlinkEndedMarkers = []string{
 }
 
 const defaultPreferredStreamQuality = "1080p60,1080p,720p60,720p,936p60,936p,648p60,648p,480p,best"
-const minimumStreamlinkCaptureTimeout = 30 * time.Second
+const defaultStreamlinkCaptureTimeout = 30 * time.Second
 const streamlinkCaptureShutdownGracePeriod = 5 * time.Second
 const continuousSegmentStabilityWindow = 1500 * time.Millisecond
 
@@ -104,8 +104,8 @@ func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver Streamlin
 		cfg.FFmpegBinary = "ffmpeg"
 	}
 	cfg.Quality = normalizeStreamlinkQuality(cfg.Quality)
-	if cfg.CaptureTimeout <= 0 || cfg.CaptureTimeout < minimumStreamlinkCaptureTimeout {
-		cfg.CaptureTimeout = minimumStreamlinkCaptureTimeout
+	if cfg.CaptureTimeout <= 0 {
+		cfg.CaptureTimeout = defaultStreamlinkCaptureTimeout
 	}
 	if strings.TrimSpace(cfg.OutputDir) == "" {
 		cfg.OutputDir = "tmp/stream_chunks"
@@ -113,10 +113,8 @@ func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver Streamlin
 	if strings.TrimSpace(cfg.URLTemplate) == "" {
 		cfg.URLTemplate = "https://twitch.tv/%s"
 	}
-	continuous := false
 	if runner == nil {
 		runner = execStreamlinkRunner{}
-		continuous = true
 	}
 	return &StreamlinkCaptureAdapter{
 		logger:     zap.NewNop(),
@@ -125,7 +123,7 @@ func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver Streamlin
 		runner:     runner,
 		normalizer: NewFFmpegChunkNormalizer(cfg.FFmpegBinary, runner),
 		nowFn:      time.Now,
-		continuous: continuous,
+		continuous: false,
 		sessions:   make(map[string]*continuousCaptureSession),
 	}
 }
@@ -148,9 +146,6 @@ func (a *StreamlinkCaptureAdapter) Capture(ctx context.Context, streamerID strin
 func (a *StreamlinkCaptureAdapter) CaptureWithDuration(ctx context.Context, streamerID string, duration time.Duration) (ChunkRef, error) {
 	if duration <= 0 {
 		duration = a.cfg.CaptureTimeout
-	}
-	if duration < minimumStreamlinkCaptureTimeout {
-		duration = minimumStreamlinkCaptureTimeout
 	}
 	if a.continuous {
 		return a.captureContinuous(ctx, streamerID, duration)
@@ -476,7 +471,7 @@ func (a *StreamlinkCaptureAdapter) setSessionError(streamerID string, err error)
 func formatStreamlinkDurationArg(value time.Duration) string {
 	seconds := int(value.Round(time.Second) / time.Second)
 	if seconds <= 0 {
-		seconds = int(minimumStreamlinkCaptureTimeout / time.Second)
+		seconds = 1
 	}
 	return strconv.Itoa(seconds)
 }

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -3,7 +3,6 @@ package media
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -103,7 +102,7 @@ func TestStreamlinkCaptureAdapterCaptureSuccess(t *testing.T) {
 	if !strings.Contains(joined, "https://twitch.tv/shroud") {
 		t.Fatalf("expected resolved channel in args, got %q", joined)
 	}
-	if !strings.Contains(joined, fmt.Sprintf("--stream-segmented-duration %d", int(minimumStreamlinkCaptureTimeout/time.Second))) {
+	if !strings.Contains(joined, "--stream-segmented-duration 2") {
 		t.Fatalf("expected --stream-segmented-duration argument, got %q", joined)
 	}
 
@@ -169,10 +168,10 @@ func TestStreamlinkCaptureAdapterFallsBackToHLSDurationWhenStreamSegmentedUnsupp
 	}
 	first := strings.Join(runner.argsHistory[0], " ")
 	second := strings.Join(runner.argsHistory[1], " ")
-	if !strings.Contains(first, fmt.Sprintf("--stream-segmented-duration %d", int(minimumStreamlinkCaptureTimeout/time.Second))) {
+	if !strings.Contains(first, "--stream-segmented-duration 30") {
 		t.Fatalf("first streamlink invocation = %q, want --stream-segmented-duration", first)
 	}
-	if !strings.Contains(second, fmt.Sprintf("--hls-duration %d", int(minimumStreamlinkCaptureTimeout/time.Second))) {
+	if !strings.Contains(second, "--hls-duration 30") {
 		t.Fatalf("second streamlink invocation = %q, want --hls-duration", second)
 	}
 }
@@ -186,23 +185,23 @@ func TestStreamlinkCaptureAdapterAcceptsTimeoutWhenChunkCaptured(t *testing.T) {
 	}
 }
 
-func TestNewStreamlinkCaptureAdapterEnforcesMinimumCaptureTimeout(t *testing.T) {
+func TestNewStreamlinkCaptureAdapterKeepsConfiguredCaptureTimeout(t *testing.T) {
 	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
 		CaptureTimeout: 5 * time.Second,
 		OutputDir:      t.TempDir(),
 	}, nil, &fakeCommandRunner{})
 
-	if adapter.cfg.CaptureTimeout != minimumStreamlinkCaptureTimeout {
-		t.Fatalf("CaptureTimeout = %s, want %s", adapter.cfg.CaptureTimeout, minimumStreamlinkCaptureTimeout)
+	if adapter.cfg.CaptureTimeout != 5*time.Second {
+		t.Fatalf("CaptureTimeout = %s, want 5s", adapter.cfg.CaptureTimeout)
 	}
 }
 
-func TestNewStreamlinkCaptureAdapterEnablesContinuousModeForDefaultRunner(t *testing.T) {
+func TestNewStreamlinkCaptureAdapterDisablesContinuousModeForDefaultRunner(t *testing.T) {
 	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
 		OutputDir: t.TempDir(),
 	}, nil, nil)
-	if !adapter.continuous {
-		t.Fatalf("expected continuous mode for default runner")
+	if adapter.continuous {
+		t.Fatalf("expected non-continuous mode for default runner")
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Remove a hard minimum capture timeout and make the default timeout behavior explicit so callers can set shorter timeouts when desired.
- Ensure formatted duration for Streamlink arguments can represent very small durations correctly.
- Stop enabling continuous capture mode implicitly for the default runner to make mode explicit.

### Description

- Renamed `minimumStreamlinkCaptureTimeout` to `defaultStreamlinkCaptureTimeout` and use it only as the default when no timeout is configured, removing enforced minimums in `NewStreamlinkCaptureAdapter` and `CaptureWithDuration`.
- Changed `formatStreamlinkDurationArg` to return `1` second for non-positive inputs instead of forcing the previous minimum value.
- Disabled implicit continuous mode by always setting `continuous` to `false` when constructing `StreamlinkCaptureAdapter` so the adapter no longer switches modes based on whether a custom runner was provided.
- Updated unit tests in `internal/media/adapters_test.go` to reflect the new timeout handling, duration formatting, and continuous-mode behavior, and removed an unused import.

### Testing

- Ran `go test ./internal/media` and related package tests after updates and the test suite completed successfully.
- Updated and executed tests include `TestStreamlinkCaptureAdapterCaptureSuccess`, `TestStreamlinkCaptureAdapterFallsBackToHLSDurationWhenStreamSegmentedUnsupported`, `TestStreamlinkCaptureAdapterAcceptsTimeoutWhenChunkCaptured`, `TestNewStreamlinkCaptureAdapterKeepsConfiguredCaptureTimeout`, and continuous-mode expectation tests, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8d9f586c832c95c8945d6d55e9fe)