### PR TITLE
Update UserProfile schema in OpenAPI spec (rename fields, add timestamps, remove deprecated fields)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1249,34 +1249,20 @@ components:
     UserProfile:
       type: object
       properties:
-        userId:
+        id:
           type: string
-          format: uuid
-        tgUserId:
+        telegramId:
           type: integer
-        nickname:
+        username:
           type: string
-        language:
+        firstName:
           type: string
-        roles:
-          type: array
-          items:
-            type: string
-        balances:
-          type: object
-          properties:
-            internal:
-              type: integer
-        referral:
-          type: object
-          properties:
-            code:
-              type: string
-            url:
-              type: string
-        flags:
-          type: object
-          additionalProperties: true
+        lastName:
+          type: string
+        languageCode:
+          type: string
+        referralCode:
+          type: string
         isBanned:
           type: boolean
         banReason:
@@ -1285,6 +1271,12 @@ components:
           type: string
           format: date-time
         bannedUntil:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
           type: string
           format: date-time
         isAdmin:


### PR DESCRIPTION
### Motivation

- Align the OpenAPI `UserProfile` schema with updated server-side user model and naming conventions in `docs/openapi.yaml`.
- Remove deprecated or internal fields and expose clearer user identity and metadata fields.

### Description

- Renamed and restructured properties on the `UserProfile` schema in `docs/openapi.yaml`, including `userId` -> `id` and `tgUserId` -> `telegramId`.
- Replaced older name fields with `username`, `firstName`, `lastName`, and `languageCode` and added `referralCode` as a flat string field.
- Removed nested/complex properties `roles`, `balances`, `referral`, and `flags` from the public schema.
- Added `createdAt` and `updatedAt` timestamp properties and retained ban/admin related flags like `isBanned`, `banReason`, and `isAdmin`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b7f97e9c832cb519b36913d90505)