### PR TITLE
Add platform vote fee, admin general settings, and accrual formula for event voting

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -375,6 +375,40 @@ paths:
         default:
           $ref: '#/components/responses/Error'
 
+  /api/admin/settings/general:
+    get:
+      summary: Get general platform settings (admin)
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current general settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminGeneralSettings'
+        default:
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update general platform settings (admin)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminGeneralSettingsUpdateRequest'
+      responses:
+        '200':
+          description: Updated general settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminGeneralSettings'
+        default:
+          $ref: '#/components/responses/Error'
+
   /api/admin/games:
     get:
       summary: List games (admin)
@@ -2066,6 +2100,12 @@ components:
           type: object
           additionalProperties:
             type: integer
+        totalContributed:
+          type: integer
+        platformFeeINT:
+          type: integer
+        distributableINT:
+          type: integer
         userVote:
           $ref: '#/components/schemas/UserVote'
     EventOption:
@@ -2158,6 +2198,19 @@ components:
           $ref: '#/components/schemas/WalletEntry'
         newBalance:
           type: integer
+    AdminGeneralSettings:
+      type: object
+      properties:
+        votePlatformFeePercent:
+          type: number
+    AdminGeneralSettingsUpdateRequest:
+      type: object
+      required: [votePlatformFeePercent]
+      properties:
+        votePlatformFeePercent:
+          type: number
+          minimum: 0
+          maximum: 100
     ReferralSummary:
       type: object
       properties:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -326,6 +326,10 @@ type adminWalletAdjustRequest struct {
 	Currency string `json:"currency,omitempty"`
 }
 
+type adminGeneralSettingsRequest struct {
+	VotePlatformFeePercent float64 `json:"votePlatformFeePercent"`
+}
+
 type adminHistoryEvent struct {
 	EventTime        string  `json:"eventTime"`
 	StepName         string  `json:"stepName"`
@@ -872,6 +876,41 @@ func NewHandler(
 				"newBalance": newBalance,
 			})
 		})))
+
+		if eventsService != nil {
+			mux.Handle("/api/admin/settings/general", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				switch r.Method {
+				case http.MethodGet:
+					writeJSON(w, http.StatusOK, eventsService.Settings())
+				case http.MethodPut:
+					defer r.Body.Close() //nolint:errcheck
+					body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "failed to read request body")
+						return
+					}
+					var req adminGeneralSettingsRequest
+					if err := decodeJSONStrict(body, &req); err != nil {
+						writeError(w, http.StatusBadRequest, "invalid request body")
+						return
+					}
+					updated, err := eventsService.UpdateSettings(events.Settings{
+						VotePlatformFeePercent: req.VotePlatformFeePercent,
+					})
+					if err != nil {
+						writeError(w, http.StatusBadRequest, "votePlatformFeePercent must be in range 0..100")
+						return
+					}
+					writeJSON(w, http.StatusOK, updated)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			})))
+		}
 
 		if streamersService != nil {
 			mux.Handle("/api/streamers", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/router_events_test.go
+++ b/internal/app/router_events_test.go
@@ -109,3 +109,84 @@ func TestEventsVoteDebitsWalletAndIsIdempotent(t *testing.T) {
 		t.Fatalf("expected wallet balance 90 after idempotent vote replay, got %d", walletPayload.Balance)
 	}
 }
+
+func TestAdminGeneralSettingsAffectVotePlatformFee(t *testing.T) {
+	eventsService := events.NewService([]events.LiveEvent{
+		{
+			ID:              "event-1",
+			TemplateID:      "streamer-1:terminal-1",
+			StreamerID:      "streamer-1",
+			ScenarioID:      "scenario-1",
+			TerminalID:      "terminal-1",
+			Title:           map[string]string{"ru": "Победитель карты"},
+			DefaultLanguage: "ru",
+			Options: []events.Option{
+				{ID: "ct", Title: map[string]string{"ru": "CT"}},
+			},
+			ClosesAt:  time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+			CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			Status:    "open",
+			Totals: map[string]int64{
+				"ct": 0,
+			},
+		},
+	})
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		users.NewService(users.NewInMemoryRepository()),
+		nil,
+		nil,
+		nil,
+		nil,
+		eventsService,
+		ClientConfigResponse{},
+	)
+	adminToken := buildToken(t, "admin-1")
+	userToken := buildToken(t, "user-1")
+
+	settingsReq := httptest.NewRequest(http.MethodPut, "/api/admin/settings/general", bytes.NewReader([]byte(`{"votePlatformFeePercent":15}`)))
+	settingsReq.Header.Set("Authorization", "Bearer "+adminToken)
+	settingsRes := httptest.NewRecorder()
+	handler.ServeHTTP(settingsRes, settingsReq)
+	if settingsRes.Code != http.StatusOK {
+		t.Fatalf("settings status=%d body=%s", settingsRes.Code, settingsRes.Body.String())
+	}
+
+	adjustReq := httptest.NewRequest(http.MethodPost, "/api/admin/wallet/adjust", bytes.NewReader([]byte(`{"userId":"user-1","deltaINT":100,"reason":"seed"}`)))
+	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
+	adjustReq.Header.Set("Idempotency-Key", "adj-seed")
+	adjustRes := httptest.NewRecorder()
+	handler.ServeHTTP(adjustRes, adjustReq)
+	if adjustRes.Code != http.StatusOK {
+		t.Fatalf("seed wallet status=%d body=%s", adjustRes.Code, adjustRes.Body.String())
+	}
+
+	voteReq := httptest.NewRequest(http.MethodPost, "/api/events/event-1/vote", bytes.NewReader([]byte(`{"streamerId":"streamer-1","optionId":"ct","amountINT":100}`)))
+	voteReq.Header.Set("Authorization", "Bearer "+userToken)
+	voteReq.Header.Set("Idempotency-Key", "vote-1")
+	voteRes := httptest.NewRecorder()
+	handler.ServeHTTP(voteRes, voteReq)
+	if voteRes.Code != http.StatusOK {
+		t.Fatalf("vote status=%d body=%s", voteRes.Code, voteRes.Body.String())
+	}
+
+	var payload struct {
+		Totals           map[string]int64 `json:"totals"`
+		TotalContributed int64            `json:"totalContributed"`
+		PlatformFeeINT   int64            `json:"platformFeeINT"`
+		DistributableINT int64            `json:"distributableINT"`
+	}
+	if err := json.Unmarshal(voteRes.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal vote response: %v", err)
+	}
+	if payload.Totals["ct"] != 85 {
+		t.Fatalf("expected net total 85, got %d", payload.Totals["ct"])
+	}
+	if payload.TotalContributed != 100 || payload.PlatformFeeINT != 15 || payload.DistributableINT != 85 {
+		t.Fatalf("unexpected pool values: %+v", payload)
+	}
+}

--- a/internal/events/model.go
+++ b/internal/events/model.go
@@ -27,6 +27,9 @@ type LiveEvent struct {
 	CreatedAt       string            `json:"createdAt"`
 	Status          string            `json:"status"`
 	Totals          map[string]int64  `json:"totals"`
+	TotalContributed int64            `json:"totalContributed"`
+	PlatformFeeINT   int64            `json:"platformFeeINT"`
+	DistributableINT int64            `json:"distributableINT"`
 	UserVote        *UserVote         `json:"userVote,omitempty"`
 }
 

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"errors"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -30,8 +31,13 @@ type liveEventState struct {
 }
 
 type Service struct {
-	mu    sync.RWMutex
-	items map[string]*liveEventState
+	mu                  sync.RWMutex
+	items               map[string]*liveEventState
+	votePlatformFeeBPS int64
+}
+
+type Settings struct {
+	VotePlatformFeePercent float64 `json:"votePlatformFeePercent"`
 }
 
 func NewService(seed []LiveEvent) *Service {
@@ -102,6 +108,25 @@ func (s *Service) CreateLiveEvent(_ context.Context, req CreateLiveEventRequest)
 	return event, nil
 }
 
+func (s *Service) Settings() Settings {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return Settings{
+		VotePlatformFeePercent: float64(s.votePlatformFeeBPS) / 100.0,
+	}
+}
+
+func (s *Service) UpdateSettings(settings Settings) (Settings, error) {
+	if settings.VotePlatformFeePercent < 0 || settings.VotePlatformFeePercent > 100 {
+		return Settings{}, ErrInvalidVote
+	}
+	feeBPS := int64(math.Round(settings.VotePlatformFeePercent * 100))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.votePlatformFeeBPS = feeBPS
+	return Settings{VotePlatformFeePercent: float64(s.votePlatformFeeBPS) / 100.0}, nil
+}
+
 func (s *Service) ListLiveByStreamer(_ context.Context, streamerID string) []LiveEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -149,7 +174,12 @@ func (s *Service) Vote(_ context.Context, req VoteRequest) (LiveEvent, error) {
 	if _, ok := item.event.Totals[optionID]; !ok {
 		return LiveEvent{}, ErrInvalidVote
 	}
-	item.event.Totals[optionID] += req.Amount
+	fee := calculateFee(req.Amount, s.votePlatformFeeBPS)
+	netAmount := req.Amount - fee
+	item.event.Totals[optionID] += netAmount
+	item.event.TotalContributed += req.Amount
+	item.event.PlatformFeeINT += fee
+	item.event.DistributableINT = item.event.TotalContributed - item.event.PlatformFeeINT
 	userVote := item.userVotes[strings.TrimSpace(req.UserID)]
 	if userVote.OptionID == "" {
 		userVote.OptionID = optionID
@@ -163,6 +193,29 @@ func (s *Service) Vote(_ context.Context, req VoteRequest) (LiveEvent, error) {
 	event := item.event
 	event.UserVote = &UserVote{OptionID: userVote.OptionID, TotalAmount: userVote.Amount}
 	return event, nil
+}
+
+func calculateFee(amount int64, feeBPS int64) int64 {
+	if amount <= 0 || feeBPS <= 0 {
+		return 0
+	}
+	if feeBPS >= 10000 {
+		return amount
+	}
+	return (amount * feeBPS) / 10000
+}
+
+// CalculateAccrualINT calculates user's accrual from the distributable event pool.
+// Formula: (totalContributed - platformFee) * userContribution / totalContributionForWinningOption.
+func CalculateAccrualINT(totalContributed, platformFeeINT, totalContributionForWinningOption, userContribution int64) int64 {
+	if totalContributed <= 0 || userContribution <= 0 || totalContributionForWinningOption <= 0 {
+		return 0
+	}
+	distributable := totalContributed - platformFeeINT
+	if distributable <= 0 {
+		return 0
+	}
+	return (distributable * userContribution) / totalContributionForWinningOption
 }
 
 func isOpen(event LiveEvent, now time.Time) bool {

--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -41,3 +41,49 @@ func TestCreateLiveEventAvoidsDuplicateActiveByTemplate(t *testing.T) {
 		t.Fatalf("expected duplicate active event error")
 	}
 }
+
+func TestVoteAppliesPlatformFeeToDistributablePool(t *testing.T) {
+	svc := NewService([]LiveEvent{
+		{
+			ID:         "evt-1",
+			StreamerID: "s-1",
+			ClosesAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+			Totals:     map[string]int64{"a": 0},
+			Options:    []Option{{ID: "a", Title: map[string]string{"ru": "A"}}},
+		},
+	})
+	if _, err := svc.UpdateSettings(Settings{VotePlatformFeePercent: 10}); err != nil {
+		t.Fatalf("UpdateSettings() error = %v", err)
+	}
+
+	event, err := svc.Vote(context.Background(), VoteRequest{
+		EventID:        "evt-1",
+		StreamerID:     "s-1",
+		UserID:         "u-1",
+		OptionID:       "a",
+		Amount:         100,
+		IdempotencyKey: "vote-1",
+	})
+	if err != nil {
+		t.Fatalf("Vote() error = %v", err)
+	}
+	if event.Totals["a"] != 90 {
+		t.Fatalf("expected net option total 90, got %d", event.Totals["a"])
+	}
+	if event.TotalContributed != 100 {
+		t.Fatalf("expected total contributed 100, got %d", event.TotalContributed)
+	}
+	if event.PlatformFeeINT != 10 {
+		t.Fatalf("expected platform fee 10, got %d", event.PlatformFeeINT)
+	}
+	if event.DistributableINT != 90 {
+		t.Fatalf("expected distributable 90, got %d", event.DistributableINT)
+	}
+}
+
+func TestCalculateAccrualINT(t *testing.T) {
+	got := CalculateAccrualINT(1000, 100, 450, 90)
+	if got != 180 {
+		t.Fatalf("expected accrual 180, got %d", got)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic formula and runtime bookkeeping so mini-game live events can distribute a prize pool derived from player votes while the platform takes a configurable commission.  
- Expose a simple admin control to set the platform percent taken from each vote so operators can tune economy behavior without redeploy.  
- Keep tracking of gross vs net contributions so downstream settlement (winner payout) can be implemented reliably.  
- Checklist aligned with implementation plan: [x] core event-side fee application and pool accounting implemented (M2.1), [x] admin endpoint to manage fee percent added, [ ] persist settings to DB, [ ] integrate settlement flow for final winner payouts (llm_stream_orchestration scope). 

### Description
- Added pool accounting fields to `events.LiveEvent`: `totalContributed`, `platformFeeINT`, and `distributableINT` in `internal/events/model.go`.  
- Implemented fee support and accrual helper in `internal/events/service.go`: added `Settings` type, `Settings()` and `UpdateSettings()` methods, fee calculation via `calculateFee()`, and accrual formula `CalculateAccrualINT(totalContributed, platformFeeINT, totalContributionForWinningOption, userContribution)`.  
- Adjusted vote processing in `Service.Vote` so each vote: records gross `totalContributed`, deducts platform fee (applies percent configured in settings) and adds net to option `Totals`, updates `platformFeeINT` and `distributableINT`.  
- Added admin routes in router: `GET /api/admin/settings/general` and `PUT /api/admin/settings/general` with admin role check and payload `votePlatformFeePercent` in `internal/app/router.go`.  
- Updated API spec `docs/openapi.yaml` to document the new admin endpoints and added the new `LiveEvent` fields and request/response schemas.  
- Added tests: unit tests in `internal/events/service_test.go` (`TestVoteAppliesPlatformFeeToDistributablePool`, `TestCalculateAccrualINT`) and router-level test in `internal/app/router_events_test.go` (`TestAdminGeneralSettingsAffectVotePlatformFee`). 

### Testing
- Ran `go test ./...` and the test suite completed successfully.  
- New unit tests added in `internal/events/service_test.go` passed and validate fee application and accrual math.  
- New router test in `internal/app/router_events_test.go` passed and validates admin `PUT /api/admin/settings/general` affects vote accounting.  
- Note: settings are stored in-memory in the service; persistent DB storage and settlement flow tests remain as follow-ups (not implemented in this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0be2ff798832c86c2408fc250329b)