### PR TITLE
Apply admin wallet adjustments via `PUT /api/admin/users/{userId}` with idempotency

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -306,6 +306,12 @@ paths:
           required: true
           schema:
             type: string
+        - in: header
+          name: Idempotency-Key
+          required: false
+          description: Required when `balanceDeltaINT` is provided in request body.
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -345,33 +351,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserProfile'
-        default:
-          $ref: '#/components/responses/Error'
-
-  /api/admin/wallet/adjust:
-    post:
-      summary: Adjust user wallet balance (admin)
-      security:
-        - bearerAuth: []
-      parameters:
-        - in: header
-          name: Idempotency-Key
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AdminWalletAdjustRequest'
-      responses:
-        '200':
-          description: Wallet adjustment applied (or idempotent replay)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdminWalletAdjustResponse'
         default:
           $ref: '#/components/responses/Error'
 
@@ -1330,6 +1309,14 @@ components:
           type: string
         languageCode:
           type: string
+        balanceDeltaINT:
+          type: integer
+          description: Signed amount in internal currency units. Positive = credit, negative = debit.
+        balanceReason:
+          type: string
+          description: Required when `balanceDeltaINT` is provided.
+        currency:
+          type: string
     AdminUsersResponse:
       type: object
       properties:
@@ -2175,27 +2162,6 @@ components:
         status:
           type: string
           enum: [pending, processing, done, rejected]
-        newBalance:
-          type: integer
-    AdminWalletAdjustRequest:
-      type: object
-      required: [userId, deltaINT, reason]
-      properties:
-        userId:
-          type: string
-        deltaINT:
-          type: integer
-          description: Signed amount in internal currency units. Positive = credit, negative = debit.
-        reason:
-          type: string
-        currency:
-          type: string
-    AdminWalletAdjustResponse:
-      type: object
-      required: [entry, newBalance]
-      properties:
-        entry:
-          $ref: '#/components/schemas/WalletEntry'
         newBalance:
           type: integer
     AdminGeneralSettings:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -302,11 +302,14 @@ type adminUsersResponse struct {
 }
 
 type adminUserUpsertRequest struct {
-	TelegramID   int64  `json:"telegramId"`
-	Username     string `json:"username"`
-	FirstName    string `json:"firstName"`
-	LastName     string `json:"lastName"`
-	LanguageCode string `json:"languageCode"`
+	TelegramID    int64  `json:"telegramId"`
+	Username      string `json:"username"`
+	FirstName     string `json:"firstName"`
+	LastName      string `json:"lastName"`
+	LanguageCode  string `json:"languageCode"`
+	BalanceDelta  *int64 `json:"balanceDeltaINT,omitempty"`
+	BalanceReason string `json:"balanceReason,omitempty"`
+	Currency      string `json:"currency,omitempty"`
 }
 
 type adminUserBanRequest struct {
@@ -317,13 +320,6 @@ type adminUserBanRequest struct {
 
 type withdrawRequest struct {
 	AmountINT int64 `json:"amountINT"`
-}
-
-type adminWalletAdjustRequest struct {
-	UserID   string `json:"userId"`
-	DeltaINT int64  `json:"deltaINT"`
-	Reason   string `json:"reason"`
-	Currency string `json:"currency,omitempty"`
 }
 
 type adminGeneralSettingsRequest struct {
@@ -738,6 +734,44 @@ func NewHandler(
 					writeError(w, http.StatusInternalServerError, "failed to update user")
 					return
 				}
+				if req.BalanceDelta != nil {
+					idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+					if idempotencyKey == "" {
+						writeError(w, http.StatusBadRequest, wallet.ErrIdempotencyRequired.Error())
+						return
+					}
+					if strings.TrimSpace(req.BalanceReason) == "" {
+						writeError(w, http.StatusBadRequest, "balanceReason is required when balanceDeltaINT is provided")
+						return
+					}
+					claims, ok := auth.ClaimsFromContext(r.Context())
+					if !ok {
+						writeError(w, http.StatusUnauthorized, "missing auth claims")
+						return
+					}
+					if _, _, err := walletService.Adjust(wallet.AdjustRequest{
+						UserID:         userID,
+						Delta:          *req.BalanceDelta,
+						Reason:         req.BalanceReason,
+						Currency:       req.Currency,
+						IdempotencyKey: idempotencyKey,
+						ActorID:        claims.Subject,
+					}); err != nil {
+						switch {
+						case errors.Is(err, wallet.ErrInvalidAmount),
+							errors.Is(err, wallet.ErrInvalidDelta),
+							errors.Is(err, wallet.ErrUserIDRequired),
+							errors.Is(err, wallet.ErrIdempotencyRequired):
+							writeError(w, http.StatusBadRequest, err.Error())
+						case errors.Is(err, wallet.ErrInsufficientFunds):
+							writeError(w, http.StatusConflict, err.Error())
+						default:
+							logger.Error("failed to apply admin user wallet adjustment", zap.String("userID", userID), zap.Error(err))
+							writeError(w, http.StatusInternalServerError, "failed to adjust wallet")
+						}
+						return
+					}
+				}
 				writeJSON(w, http.StatusOK, profile)
 			default:
 				w.WriteHeader(http.StatusMethodNotAllowed)
@@ -814,65 +848,6 @@ func NewHandler(
 			}
 			writeJSON(w, http.StatusOK, map[string]any{
 				"status":     "done",
-				"newBalance": newBalance,
-			})
-		})))
-
-		mux.Handle("/api/admin/wallet/adjust", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !requireAdmin(w, r, adminService) {
-				writeError(w, http.StatusForbidden, "admin role is required")
-				return
-			}
-			if r.Method != http.MethodPost {
-				w.WriteHeader(http.StatusMethodNotAllowed)
-				return
-			}
-			claims, ok := auth.ClaimsFromContext(r.Context())
-			if !ok {
-				writeError(w, http.StatusUnauthorized, "missing auth claims")
-				return
-			}
-			idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
-			if idempotencyKey == "" {
-				writeError(w, http.StatusBadRequest, wallet.ErrIdempotencyRequired.Error())
-				return
-			}
-			defer r.Body.Close() //nolint:errcheck
-			body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
-			if err != nil {
-				writeError(w, http.StatusBadRequest, "failed to read request body")
-				return
-			}
-			var req adminWalletAdjustRequest
-			if err := decodeJSONStrict(body, &req); err != nil {
-				writeError(w, http.StatusBadRequest, "invalid request body")
-				return
-			}
-			entry, newBalance, err := walletService.Adjust(wallet.AdjustRequest{
-				UserID:         req.UserID,
-				Delta:          req.DeltaINT,
-				Reason:         req.Reason,
-				Currency:       req.Currency,
-				IdempotencyKey: idempotencyKey,
-				ActorID:        claims.Subject,
-			})
-			if err != nil {
-				switch {
-				case errors.Is(err, wallet.ErrInvalidAmount),
-					errors.Is(err, wallet.ErrInvalidDelta),
-					errors.Is(err, wallet.ErrUserIDRequired),
-					errors.Is(err, wallet.ErrIdempotencyRequired):
-					writeError(w, http.StatusBadRequest, err.Error())
-				case errors.Is(err, wallet.ErrInsufficientFunds):
-					writeError(w, http.StatusConflict, err.Error())
-				default:
-					logger.Error("failed to apply admin wallet adjustment", zap.String("userID", req.UserID), zap.String("actorID", claims.Subject), zap.Error(err))
-					writeError(w, http.StatusInternalServerError, "failed to adjust wallet")
-				}
-				return
-			}
-			writeJSON(w, http.StatusOK, map[string]any{
-				"entry":      entry,
 				"newBalance": newBalance,
 			})
 		})))

--- a/internal/app/router_admin_users_test.go
+++ b/internal/app/router_admin_users_test.go
@@ -59,6 +59,15 @@ func TestAdminUsersCRUD(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", updateRes.Code, updateRes.Body.String())
 	}
 
+	balanceReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID, strings.NewReader(`{"balanceDeltaINT":50,"balanceReason":"manual grant"}`))
+	balanceReq.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
+	balanceReq.Header.Set("Idempotency-Key", "bal-1")
+	balanceRes := httptest.NewRecorder()
+	handler.ServeHTTP(balanceRes, balanceReq)
+	if balanceRes.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", balanceRes.Code, balanceRes.Body.String())
+	}
+
 	banReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID+"/ban", strings.NewReader(`{"isBanned":true,"reason":"manual"}`))
 	banReq.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
 	banRes := httptest.NewRecorder()

--- a/internal/app/router_events_test.go
+++ b/internal/app/router_events_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -38,13 +39,17 @@ func TestEventsVoteDebitsWalletAndIsIdempotent(t *testing.T) {
 			},
 		},
 	})
+	userService := users.NewService(users.NewInMemoryRepository())
+	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
 	handler := NewHandler(
 		zap.NewNop(),
 		func() bool { return true },
 		nil,
 		buildAuthService(t),
 		admin.NewService([]string{"admin-1"}),
-		users.NewService(users.NewInMemoryRepository()),
+		userService,
 		nil,
 		nil,
 		nil,
@@ -53,9 +58,9 @@ func TestEventsVoteDebitsWalletAndIsIdempotent(t *testing.T) {
 		ClientConfigResponse{},
 	)
 	adminToken := buildToken(t, "admin-1")
-	userToken := buildToken(t, "user-1")
+	userToken := buildToken(t, "tg_1")
 
-	adjustReq := httptest.NewRequest(http.MethodPost, "/api/admin/wallet/adjust", bytes.NewReader([]byte(`{"userId":"user-1","deltaINT":100,"reason":"seed"}`)))
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
 	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
 	adjustReq.Header.Set("Idempotency-Key", "adj-seed")
 	adjustRes := httptest.NewRecorder()
@@ -131,13 +136,17 @@ func TestAdminGeneralSettingsAffectVotePlatformFee(t *testing.T) {
 			},
 		},
 	})
+	userService := users.NewService(users.NewInMemoryRepository())
+	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
 	handler := NewHandler(
 		zap.NewNop(),
 		func() bool { return true },
 		nil,
 		buildAuthService(t),
 		admin.NewService([]string{"admin-1"}),
-		users.NewService(users.NewInMemoryRepository()),
+		userService,
 		nil,
 		nil,
 		nil,
@@ -146,7 +155,7 @@ func TestAdminGeneralSettingsAffectVotePlatformFee(t *testing.T) {
 		ClientConfigResponse{},
 	)
 	adminToken := buildToken(t, "admin-1")
-	userToken := buildToken(t, "user-1")
+	userToken := buildToken(t, "tg_1")
 
 	settingsReq := httptest.NewRequest(http.MethodPut, "/api/admin/settings/general", bytes.NewReader([]byte(`{"votePlatformFeePercent":15}`)))
 	settingsReq.Header.Set("Authorization", "Bearer "+adminToken)
@@ -156,7 +165,7 @@ func TestAdminGeneralSettingsAffectVotePlatformFee(t *testing.T) {
 		t.Fatalf("settings status=%d body=%s", settingsRes.Code, settingsRes.Body.String())
 	}
 
-	adjustReq := httptest.NewRequest(http.MethodPost, "/api/admin/wallet/adjust", bytes.NewReader([]byte(`{"userId":"user-1","deltaINT":100,"reason":"seed"}`)))
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
 	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
 	adjustReq.Header.Set("Idempotency-Key", "adj-seed")
 	adjustRes := httptest.NewRecorder()

--- a/internal/app/router_wallet_test.go
+++ b/internal/app/router_wallet_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,14 +14,18 @@ import (
 	"github.com/funpot/funpot-go-core/internal/users"
 )
 
-func TestWalletAdminAdjustAndWithdrawIdempotency(t *testing.T) {
+func TestWalletAdminUserUpdateBalanceAndWithdrawIdempotency(t *testing.T) {
+	userService := users.NewService(users.NewInMemoryRepository())
+	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
 	handler := NewHandler(
 		zap.NewNop(),
 		func() bool { return true },
 		nil,
 		buildAuthService(t),
 		admin.NewService([]string{"admin-1"}),
-		users.NewService(users.NewInMemoryRepository()),
+		userService,
 		nil,
 		nil,
 		nil,
@@ -29,10 +34,10 @@ func TestWalletAdminAdjustAndWithdrawIdempotency(t *testing.T) {
 		ClientConfigResponse{},
 	)
 	adminToken := buildToken(t, "admin-1")
-	userToken := buildToken(t, "user-1")
+	userToken := buildToken(t, "tg_1")
 
-	adjustBody := []byte(`{"userId":"user-1","deltaINT":100,"reason":"manual grant"}`)
-	adjustReq := httptest.NewRequest(http.MethodPost, "/api/admin/wallet/adjust", bytes.NewReader(adjustBody))
+	adjustBody := []byte(`{"balanceDeltaINT":100,"balanceReason":"manual grant"}`)
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader(adjustBody))
 	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
 	adjustReq.Header.Set("Idempotency-Key", "adj-1")
 	adjustRes := httptest.NewRecorder()
@@ -41,7 +46,7 @@ func TestWalletAdminAdjustAndWithdrawIdempotency(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", adjustRes.Code, adjustRes.Body.String())
 	}
 
-	replayReq := httptest.NewRequest(http.MethodPost, "/api/admin/wallet/adjust", bytes.NewReader(adjustBody))
+	replayReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader(adjustBody))
 	replayReq.Header.Set("Authorization", "Bearer "+adminToken)
 	replayReq.Header.Set("Idempotency-Key", "adj-1")
 	replayRes := httptest.NewRecorder()
@@ -108,14 +113,18 @@ func TestWalletAdminAdjustAndWithdrawIdempotency(t *testing.T) {
 	}
 }
 
-func TestAdminWalletAdjustRequiresAdmin(t *testing.T) {
+func TestAdminUserBalanceAdjustRequiresAdmin(t *testing.T) {
+	userService := users.NewService(users.NewInMemoryRepository())
+	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
 	handler := NewHandler(
 		zap.NewNop(),
 		func() bool { return true },
 		nil,
 		buildAuthService(t),
 		admin.NewService([]string{"admin-1"}),
-		users.NewService(users.NewInMemoryRepository()),
+		userService,
 		nil,
 		nil,
 		nil,
@@ -124,8 +133,8 @@ func TestAdminWalletAdjustRequiresAdmin(t *testing.T) {
 		ClientConfigResponse{},
 	)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/admin/wallet/adjust", bytes.NewReader([]byte(`{"userId":"user-1","deltaINT":10,"reason":"test"}`)))
-	req.Header.Set("Authorization", "Bearer "+buildToken(t, "user-1"))
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader([]byte(`{"balanceDeltaINT":10,"balanceReason":"test"}`)))
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "tg_1"))
 	req.Header.Set("Idempotency-Key", "adj-1")
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)


### PR DESCRIPTION
### Motivation
- Consolidate admin user updates and wallet adjustments into the user upsert flow so balance changes are applied when updating a user record.
- Remove the separate admin wallet adjustment endpoint and associated schemas to simplify the API surface and enforce idempotency via an `Idempotency-Key` on user updates.

### Description
- Added optional fields `balanceDeltaINT`, `balanceReason`, and `currency` to the `AdminUserUpsertRequest` and added an `Idempotency-Key` header parameter to the `PUT /api/admin/users/{userId}` OpenAPI spec, and removed the `/api/admin/wallet/adjust` path and `AdminWalletAdjustRequest/Response` schemas. 
- Extended the server `adminUserUpsertRequest` type with `BalanceDelta`, `BalanceReason`, and `Currency` and implemented logic in the user update handler to call `walletService.Adjust` when `balanceDeltaINT` is provided. 
- Enforced that `Idempotency-Key` header and `balanceReason` are required when `balanceDeltaINT` is present, validated auth claims, and mapped wallet errors to appropriate HTTP responses. 
- Removed the legacy `/api/admin/wallet/adjust` handler and updated tests to exercise the new flow and tokens to use the telegram-based user IDs.

### Testing
- Updated and ran the unit tests that exercise admin user operations, wallet flows and events, including `router_admin_users_test.go`, `router_wallet_test.go`, and `router_events_test.go`. 
- Executed `go test ./...` for the application package and all modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c1191264832ca41a1af4edcea506)