### PR TITLE
fix: format internal/events files to restore formatting check

### DIFF
--- a/internal/events/model.go
+++ b/internal/events/model.go
@@ -13,24 +13,24 @@ type UserVote struct {
 }
 
 type LiveEvent struct {
-	ID              string            `json:"id"`
-	TemplateID      string            `json:"templateId"`
-	GameID          *string           `json:"gameId"`
-	StreamerID      string            `json:"-"`
-	ScenarioID      string            `json:"scenarioId"`
-	TransitionID    string            `json:"transitionId,omitempty"`
-	TerminalID      string            `json:"terminalId"`
-	Title           map[string]string `json:"title"`
-	DefaultLanguage string            `json:"defaultLanguage"`
-	Options         []Option          `json:"options"`
-	ClosesAt        string            `json:"closesAt"`
-	CreatedAt       string            `json:"createdAt"`
-	Status          string            `json:"status"`
-	Totals          map[string]int64  `json:"totals"`
-	TotalContributed int64            `json:"totalContributed"`
-	PlatformFeeINT   int64            `json:"platformFeeINT"`
-	DistributableINT int64            `json:"distributableINT"`
-	UserVote        *UserVote         `json:"userVote,omitempty"`
+	ID               string            `json:"id"`
+	TemplateID       string            `json:"templateId"`
+	GameID           *string           `json:"gameId"`
+	StreamerID       string            `json:"-"`
+	ScenarioID       string            `json:"scenarioId"`
+	TransitionID     string            `json:"transitionId,omitempty"`
+	TerminalID       string            `json:"terminalId"`
+	Title            map[string]string `json:"title"`
+	DefaultLanguage  string            `json:"defaultLanguage"`
+	Options          []Option          `json:"options"`
+	ClosesAt         string            `json:"closesAt"`
+	CreatedAt        string            `json:"createdAt"`
+	Status           string            `json:"status"`
+	Totals           map[string]int64  `json:"totals"`
+	TotalContributed int64             `json:"totalContributed"`
+	PlatformFeeINT   int64             `json:"platformFeeINT"`
+	DistributableINT int64             `json:"distributableINT"`
+	UserVote         *UserVote         `json:"userVote,omitempty"`
 }
 
 type CreateLiveEventRequest struct {

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -31,8 +31,8 @@ type liveEventState struct {
 }
 
 type Service struct {
-	mu                  sync.RWMutex
-	items               map[string]*liveEventState
+	mu                 sync.RWMutex
+	items              map[string]*liveEventState
 	votePlatformFeeBPS int64
 }
 


### PR DESCRIPTION
### Motivation
- Restore CI formatting verification after the build failed due to unformatted files by applying `gofmt`; this is a formatting-only change with no behavioral impact.
- Checklist (aligned with implementation plan):
  - [x] M2.1 alignment: restore formatting gate so pipeline can proceed.
  - [ ] M2.1 feature scope: no business-logic changes implemented in this PR.
  - [x] `docs/llm_stream_orchestration_plan.md` alignment: no conflicts introduced by formatting-only changes.
  - [ ] Immediate backend scope: scenario-graph v2 runtime work not included in this change.

### Description
- Ran `gofmt -w` on `internal/events/model.go` and `internal/events/service.go` and committed whitespace/formatting-only edits so files conform to repository formatting checks.

### Testing
- Executed `gofmt -l internal/events/model.go internal/events/service.go` which produced no output, confirming files are formatted correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c9723f5c832c8c20e441c0126e64)