### PR TITLE
Add authenticated user event history API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -915,6 +915,22 @@ paths:
                 $ref: '#/components/schemas/LiveEvent'
         default:
           $ref: '#/components/responses/Error'
+  /api/events/history:
+    get:
+      summary: Get authenticated user event vote history
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: User event history
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserEventHistoryItem'
+        default:
+          $ref: '#/components/responses/Error'
   /api/wallet:
     get:
       summary: Get wallet balance and history
@@ -2122,6 +2138,51 @@ components:
         amountINT:
           type: integer
           minimum: 1
+    UserEventHistoryItem:
+      type: object
+      properties:
+        eventId:
+          type: string
+        streamerId:
+          type: string
+        scenarioId:
+          type: string
+        transitionId:
+          type: string
+        terminalId:
+          type: string
+        title:
+          type: object
+          additionalProperties:
+            type: string
+        defaultLanguage:
+          type: string
+        optionId:
+          type: string
+        amountINT:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        totalContributed:
+          type: integer
+        platformFeeINT:
+          type: integer
+        distributableINT:
+          type: integer
+        optionPoolINT:
+          type: integer
+        coefficient:
+          type: number
+          format: double
+        potentialWinINT:
+          type: integer
+        winAmountINT:
+          type: integer
+          nullable: true
+        resultStatus:
+          type: string
+          enum: [pending, won, lost]
     Wallet:
       type: object
       properties:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -1587,6 +1587,18 @@ func NewHandler(
 				}
 				writeJSON(w, http.StatusOK, eventsService.ListLiveByStreamer(r.Context(), streamerID))
 			})))
+			mux.Handle("/api/events/history", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				writeJSON(w, http.StatusOK, eventsService.ListUserHistory(r.Context(), claims.Subject))
+			})))
 
 			mux.Handle("/api/events/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {

--- a/internal/app/router_events_test.go
+++ b/internal/app/router_events_test.go
@@ -199,3 +199,98 @@ func TestAdminGeneralSettingsAffectVotePlatformFee(t *testing.T) {
 		t.Fatalf("unexpected pool values: %+v", payload)
 	}
 }
+
+func TestEventsHistoryReturnsUserEventVotes(t *testing.T) {
+	eventsService := events.NewService([]events.LiveEvent{
+		{
+			ID:              "event-1",
+			TemplateID:      "streamer-1:terminal-1",
+			StreamerID:      "streamer-1",
+			ScenarioID:      "scenario-1",
+			TerminalID:      "terminal-1",
+			Title:           map[string]string{"ru": "Победитель карты"},
+			DefaultLanguage: "ru",
+			Options: []events.Option{
+				{ID: "ct", Title: map[string]string{"ru": "CT"}},
+				{ID: "t", Title: map[string]string{"ru": "T"}},
+			},
+			ClosesAt:  time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+			CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			Status:    "open",
+			Totals: map[string]int64{
+				"ct": 0,
+				"t":  0,
+			},
+		},
+	})
+	userService := users.NewService(users.NewInMemoryRepository())
+	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		userService,
+		nil,
+		nil,
+		nil,
+		nil,
+		eventsService,
+		ClientConfigResponse{},
+	)
+	adminToken := buildToken(t, "admin-1")
+	userToken := buildToken(t, "tg_1")
+
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
+	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
+	adjustReq.Header.Set("Idempotency-Key", "adj-seed")
+	adjustRes := httptest.NewRecorder()
+	handler.ServeHTTP(adjustRes, adjustReq)
+	if adjustRes.Code != http.StatusOK {
+		t.Fatalf("seed wallet status=%d body=%s", adjustRes.Code, adjustRes.Body.String())
+	}
+
+	voteReq := httptest.NewRequest(http.MethodPost, "/api/events/event-1/vote", bytes.NewReader([]byte(`{"streamerId":"streamer-1","optionId":"ct","amountINT":10}`)))
+	voteReq.Header.Set("Authorization", "Bearer "+userToken)
+	voteReq.Header.Set("Idempotency-Key", "vote-1")
+	voteRes := httptest.NewRecorder()
+	handler.ServeHTTP(voteRes, voteReq)
+	if voteRes.Code != http.StatusOK {
+		t.Fatalf("vote status=%d body=%s", voteRes.Code, voteRes.Body.String())
+	}
+
+	historyReq := httptest.NewRequest(http.MethodGet, "/api/events/history", nil)
+	historyReq.Header.Set("Authorization", "Bearer "+userToken)
+	historyRes := httptest.NewRecorder()
+	handler.ServeHTTP(historyRes, historyReq)
+	if historyRes.Code != http.StatusOK {
+		t.Fatalf("history status=%d body=%s", historyRes.Code, historyRes.Body.String())
+	}
+
+	var history []struct {
+		EventID      string  `json:"eventId"`
+		OptionID     string  `json:"optionId"`
+		AmountINT    int64   `json:"amountINT"`
+		Coefficient  float64 `json:"coefficient"`
+		ResultStatus string  `json:"resultStatus"`
+		PotentialWin int64   `json:"potentialWinINT"`
+	}
+	if err := json.Unmarshal(historyRes.Body.Bytes(), &history); err != nil {
+		t.Fatalf("unmarshal history response: %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("expected history length 1, got %d", len(history))
+	}
+	if history[0].EventID != "event-1" || history[0].OptionID != "ct" || history[0].AmountINT != 10 {
+		t.Fatalf("unexpected history item: %+v", history[0])
+	}
+	if history[0].Coefficient <= 0 || history[0].PotentialWin <= 0 {
+		t.Fatalf("expected positive coefficient and potential win, got %+v", history[0])
+	}
+	if history[0].ResultStatus != "pending" {
+		t.Fatalf("expected pending result status, got %s", history[0].ResultStatus)
+	}
+}

--- a/internal/events/model.go
+++ b/internal/events/model.go
@@ -12,25 +12,46 @@ type UserVote struct {
 	TotalAmount int64  `json:"totalAmount"`
 }
 
+type UserEventHistoryItem struct {
+	EventID          string            `json:"eventId"`
+	StreamerID       string            `json:"streamerId"`
+	ScenarioID       string            `json:"scenarioId"`
+	TransitionID     string            `json:"transitionId,omitempty"`
+	TerminalID       string            `json:"terminalId"`
+	Title            map[string]string `json:"title"`
+	DefaultLanguage  string            `json:"defaultLanguage"`
+	OptionID         string            `json:"optionId"`
+	AmountINT        int64             `json:"amountINT"`
+	CreatedAt        string            `json:"createdAt"`
+	TotalContributed int64             `json:"totalContributed"`
+	PlatformFeeINT   int64             `json:"platformFeeINT"`
+	DistributableINT int64             `json:"distributableINT"`
+	OptionPoolINT    int64             `json:"optionPoolINT"`
+	Coefficient      float64           `json:"coefficient"`
+	PotentialWinINT  int64             `json:"potentialWinINT"`
+	WinAmountINT     *int64            `json:"winAmountINT,omitempty"`
+	ResultStatus     string            `json:"resultStatus"`
+}
+
 type LiveEvent struct {
-	ID              string            `json:"id"`
-	TemplateID      string            `json:"templateId"`
-	GameID          *string           `json:"gameId"`
-	StreamerID      string            `json:"-"`
-	ScenarioID      string            `json:"scenarioId"`
-	TransitionID    string            `json:"transitionId,omitempty"`
-	TerminalID      string            `json:"terminalId"`
-	Title           map[string]string `json:"title"`
-	DefaultLanguage string            `json:"defaultLanguage"`
-	Options         []Option          `json:"options"`
-	ClosesAt        string            `json:"closesAt"`
-	CreatedAt       string            `json:"createdAt"`
-	Status          string            `json:"status"`
-	Totals          map[string]int64  `json:"totals"`
-	TotalContributed int64            `json:"totalContributed"`
-	PlatformFeeINT   int64            `json:"platformFeeINT"`
-	DistributableINT int64            `json:"distributableINT"`
-	UserVote        *UserVote         `json:"userVote,omitempty"`
+	ID               string            `json:"id"`
+	TemplateID       string            `json:"templateId"`
+	GameID           *string           `json:"gameId"`
+	StreamerID       string            `json:"-"`
+	ScenarioID       string            `json:"scenarioId"`
+	TransitionID     string            `json:"transitionId,omitempty"`
+	TerminalID       string            `json:"terminalId"`
+	Title            map[string]string `json:"title"`
+	DefaultLanguage  string            `json:"defaultLanguage"`
+	Options          []Option          `json:"options"`
+	ClosesAt         string            `json:"closesAt"`
+	CreatedAt        string            `json:"createdAt"`
+	Status           string            `json:"status"`
+	Totals           map[string]int64  `json:"totals"`
+	TotalContributed int64             `json:"totalContributed"`
+	PlatformFeeINT   int64             `json:"platformFeeINT"`
+	DistributableINT int64             `json:"distributableINT"`
+	UserVote         *UserVote         `json:"userVote,omitempty"`
 }
 
 type CreateLiveEventRequest struct {

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -31,8 +31,9 @@ type liveEventState struct {
 }
 
 type Service struct {
-	mu                  sync.RWMutex
-	items               map[string]*liveEventState
+	mu                 sync.RWMutex
+	items              map[string]*liveEventState
+	historyByUser      map[string][]UserEventHistoryItem
 	votePlatformFeeBPS int64
 }
 
@@ -53,7 +54,10 @@ func NewService(seed []LiveEvent) *Service {
 			userVotes:      map[string]voteRecord{},
 		}
 	}
-	return &Service{items: items}
+	return &Service{
+		items:         items,
+		historyByUser: map[string][]UserEventHistoryItem{},
+	}
 }
 
 func (s *Service) CreateLiveEvent(_ context.Context, req CreateLiveEventRequest) (LiveEvent, error) {
@@ -190,9 +194,69 @@ func (s *Service) Vote(_ context.Context, req VoteRequest) (LiveEvent, error) {
 	userVote.Amount += req.Amount
 	item.userVotes[strings.TrimSpace(req.UserID)] = userVote
 	item.processedVotes[strings.TrimSpace(req.IdempotencyKey)] = voteRecord{OptionID: optionID, Amount: req.Amount}
+	optionPool := item.event.Totals[optionID]
+	coefficient := calculateCoefficient(item.event.DistributableINT, optionPool)
+	potentialWin := CalculateAccrualINT(
+		item.event.TotalContributed,
+		item.event.PlatformFeeINT,
+		optionPool,
+		req.Amount,
+	)
+	userID := strings.TrimSpace(req.UserID)
+	historyItem := UserEventHistoryItem{
+		EventID:          item.event.ID,
+		StreamerID:       item.event.StreamerID,
+		ScenarioID:       item.event.ScenarioID,
+		TransitionID:     item.event.TransitionID,
+		TerminalID:       item.event.TerminalID,
+		Title:            cloneStringsMap(item.event.Title),
+		DefaultLanguage:  item.event.DefaultLanguage,
+		OptionID:         optionID,
+		AmountINT:        req.Amount,
+		CreatedAt:        now.Format(time.RFC3339Nano),
+		TotalContributed: item.event.TotalContributed,
+		PlatformFeeINT:   item.event.PlatformFeeINT,
+		DistributableINT: item.event.DistributableINT,
+		OptionPoolINT:    optionPool,
+		Coefficient:      coefficient,
+		PotentialWinINT:  potentialWin,
+		ResultStatus:     "pending",
+	}
+	s.historyByUser[userID] = append(s.historyByUser[userID], historyItem)
 	event := item.event
 	event.UserVote = &UserVote{OptionID: userVote.OptionID, TotalAmount: userVote.Amount}
 	return event, nil
+}
+
+func (s *Service) ListUserHistory(_ context.Context, userID string) []UserEventHistoryItem {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := s.historyByUser[strings.TrimSpace(userID)]
+	result := make([]UserEventHistoryItem, 0, len(items))
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		item.Title = cloneStringsMap(item.Title)
+		result = append(result, item)
+	}
+	return result
+}
+
+func calculateCoefficient(distributableINT, optionPoolINT int64) float64 {
+	if distributableINT <= 0 || optionPoolINT <= 0 {
+		return 0
+	}
+	return float64(distributableINT) / float64(optionPoolINT)
+}
+
+func cloneStringsMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
 }
 
 func calculateFee(amount int64, feeBPS int64) int64 {

--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -87,3 +87,71 @@ func TestCalculateAccrualINT(t *testing.T) {
 		t.Fatalf("expected accrual 180, got %d", got)
 	}
 }
+
+func TestListUserHistoryReturnsLatestFirstWithoutDuplicatesForIdempotentVotes(t *testing.T) {
+	svc := NewService([]LiveEvent{
+		{
+			ID:         "evt-1",
+			StreamerID: "s-1",
+			ScenarioID: "scenario-1",
+			TerminalID: "terminal-1",
+			Title:      map[string]string{"ru": "Победитель карты"},
+			ClosesAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+			Totals: map[string]int64{
+				"a": 0,
+				"b": 0,
+			},
+			Options: []Option{
+				{ID: "a", Title: map[string]string{"ru": "A"}},
+				{ID: "b", Title: map[string]string{"ru": "B"}},
+			},
+		},
+	})
+	if _, err := svc.Vote(context.Background(), VoteRequest{
+		EventID:        "evt-1",
+		StreamerID:     "s-1",
+		UserID:         "u-1",
+		OptionID:       "a",
+		Amount:         100,
+		IdempotencyKey: "vote-1",
+	}); err != nil {
+		t.Fatalf("Vote() error = %v", err)
+	}
+	if _, err := svc.Vote(context.Background(), VoteRequest{
+		EventID:        "evt-1",
+		StreamerID:     "s-1",
+		UserID:         "u-1",
+		OptionID:       "a",
+		Amount:         100,
+		IdempotencyKey: "vote-1",
+	}); err != nil {
+		t.Fatalf("Vote() idempotency replay error = %v", err)
+	}
+	if _, err := svc.Vote(context.Background(), VoteRequest{
+		EventID:        "evt-1",
+		StreamerID:     "s-1",
+		UserID:         "u-1",
+		OptionID:       "b",
+		Amount:         50,
+		IdempotencyKey: "vote-2",
+	}); err != nil {
+		t.Fatalf("Vote() second vote error = %v", err)
+	}
+
+	history := svc.ListUserHistory(context.Background(), "u-1")
+	if len(history) != 2 {
+		t.Fatalf("expected history length 2, got %d", len(history))
+	}
+	if history[0].OptionID != "b" || history[0].AmountINT != 50 {
+		t.Fatalf("expected latest history item for option b amount 50, got %+v", history[0])
+	}
+	if history[1].OptionID != "a" || history[1].AmountINT != 100 {
+		t.Fatalf("expected oldest history item for option a amount 100, got %+v", history[1])
+	}
+	if history[0].Coefficient <= 0 || history[1].Coefficient <= 0 {
+		t.Fatalf("expected positive coefficients, got latest=%f oldest=%f", history[0].Coefficient, history[1].Coefficient)
+	}
+	if history[0].PotentialWinINT <= 0 || history[1].PotentialWinINT <= 0 {
+		t.Fatalf("expected positive potential wins, got latest=%d oldest=%d", history[0].PotentialWinINT, history[1].PotentialWinINT)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide users with a personal history of their event bets (when placed, which option, amount, pool snapshots, odds/coefficient and potential win) so they can track past bets and pending results.

### Description
- Added `UserEventHistoryItem` model and in-memory per-user history storage `historyByUser` in `internal/events` and record history entries on successful `Vote` calls while preserving idempotency behavior.  
- Computed and stored pool snapshots, coefficient and potential win on vote (`calculateCoefficient`, `CalculateAccrualINT`) and cloned title maps to avoid shared mutation.  
- Exposed authenticated HTTP endpoint `GET /api/events/history` in `internal/app/router.go` that returns the caller's history newest-first.  
- Updated OpenAPI (`docs/openapi.yaml`) with the new path and `UserEventHistoryItem` schema and added unit/integration tests for service and router behavior.

### Testing
- Ran formatting and targeted tests: `gofmt -w` was applied to modified files and `go test ./internal/events ./internal/app` succeeded.  
- A full `go test ./...` run timed out in this environment (attempted with a 90s timeout).  
- Added and executed tests: `internal/events/service_test.go` (history ordering, idempotency, coefficient/potential win checks) and `internal/app/router_events_test.go` (HTTP endpoint integration), both passed.  

Checklist (status reporting aligned with repository guidelines):
- [x] Implemented per-user event history storage and recording on vote.  
- [x] Added authenticated endpoint `GET /api/events/history` and OpenAPI documentation.  
- [x] Added unit and router-level tests for the new functionality.  
- [ ] Full verification against `docs/implementation_plan.md` milestone M2.1 is pending.  
- [ ] Full orchestration alignment with `docs/llm_stream_orchestration_plan.md` (state transitions / settlement of results) is pending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c902e9d4832cb9fe168f0a7adc33)