### PR TITLE
Enforce single in-game currency (FPC) across wallet, API and DB

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -4,7 +4,7 @@
 - **users** `(id uuid PK, tg_user_id bigint unique, nickname text, language text, roles text[], created_at timestamptz)`
 - **referrals** `(user_id uuid PK FK users, code text unique, inviter_user_id uuid FK users, percent numeric(5,2), created_at timestamptz)`
 - **wallet_accounts** `(user_id uuid PK FK users, balance_int bigint, updated_at timestamptz)`
-- **wallet_ledger** `(id uuid PK, user_id uuid FK users, type text CHECK (type IN ('credit','debit')), amount_int bigint CHECK (amount_int>0), currency text DEFAULT 'INT', reason text CHECK (reason IN ('stars_topup','vote_cost','reward','withdraw','referral_bonus')), ref_id text, idempotency_key text, created_at timestamptz)` with indexes on `(user_id, created_at)`, `(idempotency_key)`.
+- **wallet_ledger** `(id uuid PK, user_id uuid FK users, type text CHECK (type IN ('credit','debit')), amount_int bigint CHECK (amount_int>0), currency text NOT NULL DEFAULT 'FPC' CHECK (currency = 'FPC'), reason text CHECK (reason IN ('stars_topup','vote_cost','reward','withdraw','referral_bonus')), ref_id text, idempotency_key text, created_at timestamptz)` with indexes on `(user_id, created_at)`, `(idempotency_key)`.
 - **payments** `(id uuid PK, user_id uuid FK users, provider text CHECK (provider='telegram_stars'), invoice_id text unique, amount_int bigint, status text CHECK (status IN ('pending','paid','failed')), payload jsonb, created_at timestamptz, updated_at timestamptz)`
 - **streamers** `(id uuid PK, platform text CHECK (platform='twitch'), username text unique, display_name text, online boolean, viewers int, status text CHECK (status IN ('ok','pending','rejected','banned')), added_by uuid FK users, created_at timestamptz, updated_at timestamptz)`
 - **games** `(id uuid PK, streamer_id uuid FK streamers, title text, rules_json jsonb, status text CHECK (status IN ('draft','active','closed','paused')), start_at timestamptz, end_at timestamptz)`
@@ -28,4 +28,3 @@
 ## Partitioning Strategy (Future)
 - Partition `wallet_ledger` by month once record counts exceed 10M.
 - Partition `votes` by `(streamer_id HASH)` or `(created_at RANGE)` depending on access patterns.
-

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -886,7 +886,7 @@ paths:
           $ref: '#/components/responses/Error'
   /api/events/{eventId}/vote:
     post:
-      summary: Cast a vote for live event outcome
+      summary: Cast a vote for live event outcome using in-game currency (FPC)
       security:
         - bearerAuth: []
       parameters:
@@ -1327,12 +1327,10 @@ components:
           type: string
         balanceDeltaINT:
           type: integer
-          description: Signed amount in internal currency units. Positive = credit, negative = debit.
+          description: Signed amount in in-game currency units (FPC). Positive = credit, negative = debit.
         balanceReason:
           type: string
           description: Required when `balanceDeltaINT` is provided.
-        currency:
-          type: string
     AdminUsersResponse:
       type: object
       properties:
@@ -2138,6 +2136,7 @@ components:
         amountINT:
           type: integer
           minimum: 1
+          description: Amount of in-game currency (FPC) selected by the user for this vote.
     UserEventHistoryItem:
       type: object
       properties:
@@ -2205,6 +2204,7 @@ components:
           type: integer
         currency:
           type: string
+          enum: [FPC]
         reason:
           type: string
         createdAt:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -309,7 +309,6 @@ type adminUserUpsertRequest struct {
 	LanguageCode  string `json:"languageCode"`
 	BalanceDelta  *int64 `json:"balanceDeltaINT,omitempty"`
 	BalanceReason string `json:"balanceReason,omitempty"`
-	Currency      string `json:"currency,omitempty"`
 }
 
 type adminUserBanRequest struct {
@@ -753,7 +752,7 @@ func NewHandler(
 						UserID:         userID,
 						Delta:          *req.BalanceDelta,
 						Reason:         req.BalanceReason,
-						Currency:       req.Currency,
+						Currency:       wallet.GameCurrency,
 						IdempotencyKey: idempotencyKey,
 						ActorID:        claims.Subject,
 					}); err != nil {
@@ -1642,7 +1641,7 @@ func NewHandler(
 					UserID:         claims.Subject,
 					Type:           wallet.EntryTypeDebit,
 					Amount:         req.AmountINT,
-					Currency:       "FPC",
+					Currency:       wallet.GameCurrency,
 					Reason:         "event_vote",
 					IdempotencyKey: idempotencyKey,
 					ActorID:        claims.Subject,

--- a/internal/app/router_events_test.go
+++ b/internal/app/router_events_test.go
@@ -115,6 +115,67 @@ func TestEventsVoteDebitsWalletAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestEventsVoteRejectsCurrencyFieldInPayload(t *testing.T) {
+	eventsService := events.NewService([]events.LiveEvent{
+		{
+			ID:              "event-1",
+			TemplateID:      "streamer-1:terminal-1",
+			StreamerID:      "streamer-1",
+			ScenarioID:      "scenario-1",
+			TerminalID:      "terminal-1",
+			Title:           map[string]string{"ru": "Победитель карты"},
+			DefaultLanguage: "ru",
+			Options: []events.Option{
+				{ID: "ct", Title: map[string]string{"ru": "CT"}},
+			},
+			ClosesAt:  time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+			CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			Status:    "open",
+			Totals: map[string]int64{
+				"ct": 0,
+			},
+		},
+	})
+	userService := users.NewService(users.NewInMemoryRepository())
+	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		userService,
+		nil,
+		nil,
+		nil,
+		nil,
+		eventsService,
+		ClientConfigResponse{},
+	)
+	adminToken := buildToken(t, "admin-1")
+	userToken := buildToken(t, "tg_1")
+
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
+	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
+	adjustReq.Header.Set("Idempotency-Key", "adj-seed")
+	adjustRes := httptest.NewRecorder()
+	handler.ServeHTTP(adjustRes, adjustReq)
+	if adjustRes.Code != http.StatusOK {
+		t.Fatalf("seed wallet status=%d body=%s", adjustRes.Code, adjustRes.Body.String())
+	}
+
+	voteReq := httptest.NewRequest(http.MethodPost, "/api/events/event-1/vote", bytes.NewReader([]byte(`{"streamerId":"streamer-1","optionId":"ct","amountINT":10,"currency":"USD"}`)))
+	voteReq.Header.Set("Authorization", "Bearer "+userToken)
+	voteReq.Header.Set("Idempotency-Key", "vote-1")
+	voteRes := httptest.NewRecorder()
+	handler.ServeHTTP(voteRes, voteReq)
+	if voteRes.Code != http.StatusBadRequest {
+		t.Fatalf("vote status=%d body=%s", voteRes.Code, voteRes.Body.String())
+	}
+}
+
 func TestAdminGeneralSettingsAffectVotePlatformFee(t *testing.T) {
 	eventsService := events.NewService([]events.LiveEvent{
 		{

--- a/internal/app/router_wallet_test.go
+++ b/internal/app/router_wallet_test.go
@@ -142,3 +142,33 @@ func TestAdminUserBalanceAdjustRequiresAdmin(t *testing.T) {
 		t.Fatalf("expected 403, got %d", res.Code)
 	}
 }
+
+func TestAdminUserBalanceAdjustRejectsCurrencyOverride(t *testing.T) {
+	userService := users.NewService(users.NewInMemoryRepository())
+	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		userService,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		ClientConfigResponse{},
+	)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader([]byte(`{"balanceDeltaINT":10,"balanceReason":"test","currency":"USD"}`)))
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
+	req.Header.Set("Idempotency-Key", "adj-1")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", res.Code)
+	}
+}

--- a/internal/wallet/service.go
+++ b/internal/wallet/service.go
@@ -14,6 +14,7 @@ var (
 	ErrUserIDRequired      = errors.New("user id is required")
 	ErrInvalidAmount       = errors.New("amount must be a positive integer")
 	ErrInvalidDelta        = errors.New("delta must not be zero")
+	ErrInvalidCurrency     = errors.New("currency must be FPC")
 	ErrIdempotencyRequired = errors.New("idempotency key is required")
 	ErrInsufficientFunds   = errors.New("insufficient funds")
 )
@@ -23,6 +24,7 @@ type EntryType string
 const (
 	EntryTypeCredit EntryType = "credit"
 	EntryTypeDebit  EntryType = "debit"
+	GameCurrency    string    = "FPC"
 )
 
 type Entry struct {
@@ -94,6 +96,10 @@ func (s *Service) Post(req PostRequest) (Entry, int64, error) {
 	if req.Type != EntryTypeCredit && req.Type != EntryTypeDebit {
 		return Entry{}, 0, errors.New("wallet entry type is invalid")
 	}
+	currency, err := normalizeCurrency(req.Currency)
+	if err != nil {
+		return Entry{}, 0, err
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -113,7 +119,7 @@ func (s *Service) Post(req PostRequest) (Entry, int64, error) {
 		UserID:         userID,
 		Type:           req.Type,
 		Amount:         req.Amount,
-		Currency:       normalizeCurrency(req.Currency),
+		Currency:       currency,
 		Reason:         strings.TrimSpace(req.Reason),
 		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
 		ActorID:        strings.TrimSpace(req.ActorID),
@@ -179,10 +185,13 @@ func (s *Service) ensureAccountLocked(userID string) *account {
 	return acct
 }
 
-func normalizeCurrency(currency string) string {
+func normalizeCurrency(currency string) (string, error) {
 	trimmed := strings.TrimSpace(currency)
 	if trimmed == "" {
-		return "FPC"
+		return GameCurrency, nil
 	}
-	return strings.ToUpper(trimmed)
+	if strings.ToUpper(trimmed) != GameCurrency {
+		return "", ErrInvalidCurrency
+	}
+	return GameCurrency, nil
 }

--- a/internal/wallet/service_test.go
+++ b/internal/wallet/service_test.go
@@ -46,3 +46,18 @@ func TestServiceAdjustDebitAndCredit(t *testing.T) {
 		t.Fatalf("expected 2 entries, got %d", len(wallet.History))
 	}
 }
+
+func TestServicePostRejectsNonGameCurrency(t *testing.T) {
+	svc := NewService()
+	_, _, err := svc.Post(PostRequest{
+		UserID:         "u1",
+		Type:           EntryTypeCredit,
+		Amount:         100,
+		Currency:       "USD",
+		IdempotencyKey: "k1",
+		Reason:         "init",
+	})
+	if err != ErrInvalidCurrency {
+		t.Fatalf("expected ErrInvalidCurrency, got %v", err)
+	}
+}

--- a/migrations/0016_live_event_votes_currency_fpc_only.down.sql
+++ b/migrations/0016_live_event_votes_currency_fpc_only.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE live_event_votes
+    DROP CONSTRAINT IF EXISTS live_event_votes_currency_fpc_check;
+
+ALTER TABLE live_event_votes
+    DROP COLUMN IF EXISTS currency;

--- a/migrations/0016_live_event_votes_currency_fpc_only.up.sql
+++ b/migrations/0016_live_event_votes_currency_fpc_only.up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE live_event_votes
+    ADD COLUMN IF NOT EXISTS currency TEXT NOT NULL DEFAULT 'FPC';
+
+UPDATE live_event_votes
+SET currency = 'FPC'
+WHERE currency IS DISTINCT FROM 'FPC';
+
+ALTER TABLE live_event_votes
+    DROP CONSTRAINT IF EXISTS live_event_votes_currency_fpc_check;
+
+ALTER TABLE live_event_votes
+    ADD CONSTRAINT live_event_votes_currency_fpc_check
+    CHECK (currency = 'FPC');


### PR DESCRIPTION
### Motivation
- Standardize the system on a single in-game currency `FPC` and prevent arbitrary currency overrides from client payloads or admin requests.
- Make internal wallet logic, API contracts and DB schema consistent about the allowed currency to avoid accounting mismatches.

### Description
- Wallet service: add `GameCurrency` constant (`"FPC"`), new `ErrInvalidCurrency`, and validate/normalize currency in `Post` and `Adjust` flows via `normalizeCurrency` which now returns an error for non-`FPC` values.
- Router/API: remove free-form `currency` field from `adminUserUpsertRequest`, and use `wallet.GameCurrency` when creating wallet adjustments and vote debit entries; update vote handler and admin adjust handler to reject currency overrides implicitly by using the fixed currency.
- OpenAPI and docs: update `openapi.yaml` and `docs/erd.md` to document `FPC` as the only supported currency and clarify request/field descriptions referencing in-game currency units; restrict `WalletEntry.currency` enum to `[FPC]` and annotate request fields accordingly.
- DB migrations: add migration to set `live_event_votes.currency` column default to `'FPC'` and add a CHECK constraint to ensure the column equals `'FPC'`, plus a down migration to remove it.
- Tests: add unit tests to assert rejection of non-`FPC` currency in wallet service and to ensure handlers reject payloads attempting to override currency (`TestServicePostRejectsNonGameCurrency`, `TestAdminUserBalanceAdjustRejectsCurrencyOverride`, and `TestEventsVoteRejectsCurrencyFieldInPayload`).

### Testing
- Ran wallet unit tests including `TestServicePostRejectsNonGameCurrency` and existing wallet/adjust/idempotency tests; all passed.
- Ran router tests including `TestAdminUserBalanceAdjustRejectsCurrencyOverride` and `TestEventsVoteRejectsCurrencyFieldInPayload`; they passed and validated handlers reject currency overrides.
- No database migration failures observed when applying the new `0016_live_event_votes_currency_fpc_only` migration in a test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d02f2664832cb12d4bf5637769c5)