### PR TITLE
Add nickname field with generation, DB migration, and repository/service updates

### DIFF
--- a/internal/users/memory.go
+++ b/internal/users/memory.go
@@ -92,6 +92,7 @@ func profileMatches(profile Profile, query string) bool {
 	values := []string{
 		profile.ID,
 		profile.Username,
+		profile.Nickname,
 		profile.FirstName,
 		profile.LastName,
 		profile.LanguageCode,

--- a/internal/users/model.go
+++ b/internal/users/model.go
@@ -7,6 +7,7 @@ type Profile struct {
 	ID           string    `json:"id"`
 	TelegramID   int64     `json:"telegramId"`
 	Username     string    `json:"username"`
+	Nickname     string    `json:"nickname"`
 	FirstName    string    `json:"firstName"`
 	LastName     string    `json:"lastName"`
 	LanguageCode string    `json:"languageCode"`

--- a/internal/users/postgres.go
+++ b/internal/users/postgres.go
@@ -21,7 +21,7 @@ func NewPostgresRepository(db *sql.DB) *PostgresRepository {
 
 // GetByID returns a profile identified by internal user ID.
 func (r *PostgresRepository) GetByID(ctx context.Context, id string) (Profile, error) {
-	const query = `SELECT id, telegram_id, username, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at FROM users WHERE id = $1`
+	const query = `SELECT id, telegram_id, username, nickname, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at FROM users WHERE id = $1`
 
 	var profile Profile
 	var bannedAt sql.NullTime
@@ -30,6 +30,7 @@ func (r *PostgresRepository) GetByID(ctx context.Context, id string) (Profile, e
 		&profile.ID,
 		&profile.TelegramID,
 		&profile.Username,
+		&profile.Nickname,
 		&profile.FirstName,
 		&profile.LastName,
 		&profile.LanguageCode,
@@ -53,7 +54,7 @@ func (r *PostgresRepository) GetByID(ctx context.Context, id string) (Profile, e
 
 // GetByTelegramID returns a profile identified by the Telegram ID.
 func (r *PostgresRepository) GetByTelegramID(ctx context.Context, telegramID int64) (Profile, error) {
-	const query = `SELECT id, telegram_id, username, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at FROM users WHERE telegram_id = $1`
+	const query = `SELECT id, telegram_id, username, nickname, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at FROM users WHERE telegram_id = $1`
 
 	var profile Profile
 	var bannedAt sql.NullTime
@@ -62,6 +63,7 @@ func (r *PostgresRepository) GetByTelegramID(ctx context.Context, telegramID int
 		&profile.ID,
 		&profile.TelegramID,
 		&profile.Username,
+		&profile.Nickname,
 		&profile.FirstName,
 		&profile.LastName,
 		&profile.LanguageCode,
@@ -100,6 +102,7 @@ FROM users
 WHERE $1 = ''
    OR id ILIKE $2
    OR username ILIKE $2
+   OR nickname ILIKE $2
    OR first_name ILIKE $2
    OR last_name ILIKE $2
    OR language_code ILIKE $2
@@ -111,11 +114,12 @@ WHERE $1 = ''
 	}
 
 	const listQuery = `
-SELECT id, telegram_id, username, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at
+SELECT id, telegram_id, username, nickname, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at
 FROM users
 WHERE $1 = ''
    OR id ILIKE $2
    OR username ILIKE $2
+   OR nickname ILIKE $2
    OR first_name ILIKE $2
    OR last_name ILIKE $2
    OR language_code ILIKE $2
@@ -139,6 +143,7 @@ LIMIT $3 OFFSET $4`
 			&profile.ID,
 			&profile.TelegramID,
 			&profile.Username,
+			&profile.Nickname,
 			&profile.FirstName,
 			&profile.LastName,
 			&profile.LanguageCode,
@@ -165,14 +170,15 @@ LIMIT $3 OFFSET $4`
 // Create inserts a new profile. Existing records are left untouched.
 func (r *PostgresRepository) Create(ctx context.Context, profile Profile) error {
 	const query = `
-INSERT INTO users (id, telegram_id, username, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+INSERT INTO users (id, telegram_id, username, nickname, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 ON CONFLICT (telegram_id) DO NOTHING`
 
 	if _, err := r.db.ExecContext(ctx, query,
 		profile.ID,
 		profile.TelegramID,
 		profile.Username,
+		profile.Nickname,
 		profile.FirstName,
 		profile.LastName,
 		profile.LanguageCode,
@@ -195,21 +201,23 @@ func (r *PostgresRepository) Update(ctx context.Context, profile Profile) error 
 	const query = `
 		UPDATE users
 		SET username = $2,
-		    first_name = $3,
-		    last_name = $4,
-		    language_code = $5,
-		    referral_code = $6,
-		    is_banned = $7,
-		    ban_reason = $8,
-		    banned_at = $9,
-		    banned_until = $10,
-		    updated_at = $11
+		    nickname = $3,
+		    first_name = $4,
+		    last_name = $5,
+		    language_code = $6,
+		    referral_code = $7,
+		    is_banned = $8,
+		    ban_reason = $9,
+		    banned_at = $10,
+		    banned_until = $11,
+		    updated_at = $12
 		WHERE telegram_id = $1
 	`
 
 	result, err := r.db.ExecContext(ctx, query,
 		profile.TelegramID,
 		profile.Username,
+		profile.Nickname,
 		profile.FirstName,
 		profile.LastName,
 		profile.LanguageCode,

--- a/internal/users/postgres_test.go
+++ b/internal/users/postgres_test.go
@@ -21,10 +21,10 @@ func TestPostgresRepository_GetByTelegramID(t *testing.T) {
 	repo := NewPostgresRepository(db)
 	now := time.Now().UTC()
 
-	rows := sqlmock.NewRows([]string{"id", "telegram_id", "username", "first_name", "last_name", "language_code", "referral_code", "is_banned", "ban_reason", "banned_at", "banned_until", "created_at", "updated_at"}).
-		AddRow("tg_1", int64(1), "user", "First", "Last", "en", "ABC123", false, "", nil, nil, now, now)
+	rows := sqlmock.NewRows([]string{"id", "telegram_id", "username", "nickname", "first_name", "last_name", "language_code", "referral_code", "is_banned", "ban_reason", "banned_at", "banned_until", "created_at", "updated_at"}).
+		AddRow("tg_1", int64(1), "user", "BraveFox101", "First", "Last", "en", "ABC123", false, "", nil, nil, now, now)
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, telegram_id, username, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at FROM users WHERE telegram_id = $1")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, telegram_id, username, nickname, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at FROM users WHERE telegram_id = $1")).
 		WithArgs(int64(1)).
 		WillReturnRows(rows)
 
@@ -50,7 +50,7 @@ func TestPostgresRepository_GetByTelegramID_NotFound(t *testing.T) {
 
 	repo := NewPostgresRepository(db)
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, telegram_id, username, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at FROM users WHERE telegram_id = $1")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, telegram_id, username, nickname, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at FROM users WHERE telegram_id = $1")).
 		WithArgs(int64(99)).
 		WillReturnError(sql.ErrNoRows)
 
@@ -77,6 +77,7 @@ func TestPostgresRepository_Create(t *testing.T) {
 		ID:           "tg_1",
 		TelegramID:   1,
 		Username:     "user",
+		Nickname:     "BraveFox101",
 		FirstName:    "First",
 		LastName:     "Last",
 		LanguageCode: "en",
@@ -85,11 +86,12 @@ func TestPostgresRepository_Create(t *testing.T) {
 		UpdatedAt:    now,
 	}
 
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO users (id, telegram_id, username, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at)\nVALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)\nON CONFLICT (telegram_id) DO NOTHING")).
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO users (id, telegram_id, username, nickname, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at)\nVALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)\nON CONFLICT (telegram_id) DO NOTHING")).
 		WithArgs(
 			profile.ID,
 			profile.TelegramID,
 			profile.Username,
+			profile.Nickname,
 			profile.FirstName,
 			profile.LastName,
 			profile.LanguageCode,
@@ -125,6 +127,7 @@ func TestPostgresRepository_Update(t *testing.T) {
 		ID:           "tg_1",
 		TelegramID:   1,
 		Username:     "user",
+		Nickname:     "BraveFox101",
 		FirstName:    "First",
 		LastName:     "Last",
 		LanguageCode: "en",
@@ -133,10 +136,11 @@ func TestPostgresRepository_Update(t *testing.T) {
 		UpdatedAt:    now,
 	}
 
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE users\nSET username = $2,\n    first_name = $3,\n    last_name = $4,\n    language_code = $5,\n    referral_code = $6,\n    is_banned = $7,\n    ban_reason = $8,\n    banned_at = $9,\n    banned_until = $10,\n    updated_at = $11\nWHERE telegram_id = $1")).
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE users\nSET username = $2,\n    nickname = $3,\n    first_name = $4,\n    last_name = $5,\n    language_code = $6,\n    referral_code = $7,\n    is_banned = $8,\n    ban_reason = $9,\n    banned_at = $10,\n    banned_until = $11,\n    updated_at = $12\nWHERE telegram_id = $1")).
 		WithArgs(
 			profile.TelegramID,
 			profile.Username,
+			profile.Nickname,
 			profile.FirstName,
 			profile.LastName,
 			profile.LanguageCode,
@@ -169,8 +173,8 @@ func TestPostgresRepository_UpdateNotFound(t *testing.T) {
 	now := time.Now().UTC()
 	profile := Profile{TelegramID: 42, UpdatedAt: now}
 
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE users\nSET username = $2,\n    first_name = $3,\n    last_name = $4,\n    language_code = $5,\n    referral_code = $6,\n    is_banned = $7,\n    ban_reason = $8,\n    banned_at = $9,\n    banned_until = $10,\n    updated_at = $11\nWHERE telegram_id = $1")).
-		WithArgs(profile.TelegramID, "", "", "", "", "", false, "", nil, nil, profile.UpdatedAt).
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE users\nSET username = $2,\n    nickname = $3,\n    first_name = $4,\n    last_name = $5,\n    language_code = $6,\n    referral_code = $7,\n    is_banned = $8,\n    ban_reason = $9,\n    banned_at = $10,\n    banned_until = $11,\n    updated_at = $12\nWHERE telegram_id = $1")).
+		WithArgs(profile.TelegramID, "", "", "", "", "", "", false, "", nil, nil, profile.UpdatedAt).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	err = repo.Update(context.Background(), profile)

--- a/internal/users/service.go
+++ b/internal/users/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base32"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"strings"
@@ -50,6 +51,9 @@ func (s *Service) SyncTelegramProfile(ctx context.Context, profile TelegramProfi
 
 	updated := existing
 	updated.Username = profile.Username
+	if strings.TrimSpace(updated.Nickname) == "" {
+		updated.Nickname = generateNickname(profile.ID)
+	}
 	updated.FirstName = profile.FirstName
 	updated.LastName = profile.LastName
 	updated.LanguageCode = profile.LanguageCode
@@ -84,6 +88,9 @@ func (s *Service) UpdateByID(ctx context.Context, id string, profile TelegramPro
 	}
 	updated := existing
 	updated.Username = profile.Username
+	if strings.TrimSpace(updated.Nickname) == "" {
+		updated.Nickname = generateNickname(profile.ID)
+	}
 	updated.FirstName = profile.FirstName
 	updated.LastName = profile.LastName
 	updated.LanguageCode = profile.LanguageCode
@@ -141,6 +148,7 @@ func (s *Service) newProfile(profile TelegramProfile) Profile {
 		ID:           fmt.Sprintf("tg_%d", profile.ID),
 		TelegramID:   profile.ID,
 		Username:     profile.Username,
+		Nickname:     generateNickname(profile.ID),
 		FirstName:    profile.FirstName,
 		LastName:     profile.LastName,
 		LanguageCode: profile.LanguageCode,
@@ -148,6 +156,23 @@ func (s *Service) newProfile(profile TelegramProfile) Profile {
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
+}
+
+func generateNickname(telegramID int64) string {
+	adjectives := []string{"Brave", "Lucky", "Mighty", "Cozy", "Swift", "Sunny", "Epic", "Neon", "Chill", "Nimble"}
+	nouns := []string{"Fox", "Panda", "Otter", "Tiger", "Koala", "Falcon", "Penguin", "Bunny", "Raccoon", "Dolphin"}
+
+	hasher := sha256.New()
+	hasher.Write([]byte("funpot-nickname"))
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(telegramID))
+	hasher.Write(b)
+	sum := hasher.Sum(nil)
+
+	adj := adjectives[int(sum[0])%len(adjectives)]
+	noun := nouns[int(sum[1])%len(nouns)]
+	num := int(binary.BigEndian.Uint16(sum[2:4]))%900 + 100
+	return fmt.Sprintf("%s%s%d", adj, noun, num)
 }
 
 func generateReferralCode(telegramID int64) string {

--- a/migrations/0018_users_nickname.down.sql
+++ b/migrations/0018_users_nickname.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_users_nickname;
+ALTER TABLE users DROP COLUMN IF EXISTS nickname;

--- a/migrations/0018_users_nickname.up.sql
+++ b/migrations/0018_users_nickname.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS nickname TEXT NOT NULL DEFAULT '';
+UPDATE users SET nickname = username WHERE nickname = '';
+CREATE INDEX IF NOT EXISTS idx_users_nickname ON users (nickname);


### PR DESCRIPTION
### Motivation

- Introduce a persistent `nickname` for users to allow friendly autogenerated display names independent of `username`.
- Ensure nicknames are searchable and indexed in the database for list/query performance.
- Generate deterministic, human-friendly nicknames for users who don't provide one to avoid empty values.

### Description

- Added `Nickname string` to `Profile` and included it in in-memory matching by updating `profileMatches` to search `Nickname`.
- Extended Postgres queries and scans in `GetByID`, `GetByTelegramID`, `List`, `Create`, and `Update` to read/write the `nickname` column and the count/list SQL to include `nickname` in ILIKE search and results.
- Added SQL migrations `migrations/0018_users_nickname.up.sql` and `migrations/0018_users_nickname.down.sql` to add/drop the `nickname` column and create/drop `idx_users_nickname` index, and to backfill empty nicknames from `username`.
- Implemented deterministic `generateNickname(telegramID int64)` producing `AdjectiveNounNNN` using SHA-256 of a salt plus the telegram ID, and updated the service to set `Nickname` when creating new profiles and when syncing/updating if the nickname is blank.
- Updated unit tests in `internal/users/postgres_test.go` to include the `nickname` column in mocked rows and SQL expectations.

### Testing

- Ran unit tests for the users package with `go test ./internal/users` and the updated `TestPostgresRepository_*` tests passed.
- Ran the project test suite with `go test ./...` and tests completed successfully without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49c7a6aac832ca62e9181dabe4e2d)