### PR TITLE
Add streamer mini icon URL to submission flow and API payload

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1391,6 +1391,9 @@ components:
           type: string
         displayName:
           type: string
+        miniIconUrl:
+          type: string
+          format: uri
         online:
           type: boolean
         viewers:

--- a/internal/streamers/model.go
+++ b/internal/streamers/model.go
@@ -7,6 +7,7 @@ type Streamer struct {
 	Platform       string `json:"platform"`
 	TwitchNickname string `json:"twitchNickname"`
 	DisplayName    string `json:"displayName"`
+	MiniIconURL    string `json:"miniIconUrl,omitempty"`
 	Online         bool   `json:"online"`
 	Viewers        int    `json:"viewers"`
 	AddedBy        string `json:"addedBy"`

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -33,6 +33,10 @@ type TwitchAudienceValidator interface {
 	GetLiveAudience(ctx context.Context, username string) (online bool, viewers int, err error)
 }
 
+type TwitchProfileValidator interface {
+	GetProfileImageURL(ctx context.Context, username string) (string, error)
+}
+
 type noopTwitchValidator struct{}
 
 func (v noopTwitchValidator) ValidateUsername(_ context.Context, username string) (string, error) {
@@ -234,6 +238,7 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 
 	online := false
 	viewers := 0
+	miniIconURL := ""
 	if audienceValidator, ok := s.validator.(TwitchAudienceValidator); ok {
 		online, viewers, err = audienceValidator.GetLiveAudience(ctx, nickname)
 		if err != nil {
@@ -253,6 +258,14 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 			return Submission{}, fmt.Errorf("%w: got=%d required=%d", ErrInsufficientLive, viewers, s.minLiveViewers)
 		}
 	}
+	if profileValidator, ok := s.validator.(TwitchProfileValidator); ok {
+		profileImageURL, profileErr := profileValidator.GetProfileImageURL(ctx, nickname)
+		if profileErr != nil {
+			logger.Warn("streamer profile image fetch failed", zap.String("twitchNickname", nickname), zap.Error(profileErr))
+		} else {
+			miniIconURL = strings.TrimSpace(profileImageURL)
+		}
+	}
 
 	now := s.nowFn().UnixNano()
 	id := fmt.Sprintf("str_%d", now)
@@ -261,6 +274,7 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 		Platform:       "twitch",
 		TwitchNickname: strings.ToLower(nickname),
 		DisplayName:    displayName,
+		MiniIconURL:    miniIconURL,
 		Online:         online,
 		Viewers:        viewers,
 		AddedBy:        addedBy,

--- a/internal/streamers/service_test.go
+++ b/internal/streamers/service_test.go
@@ -9,6 +9,7 @@ import (
 
 type validatorStub struct {
 	displayName string
+	miniIconURL string
 	err         error
 }
 
@@ -17,6 +18,13 @@ func (v validatorStub) ValidateUsername(_ context.Context, _ string) (string, er
 		return "", v.err
 	}
 	return v.displayName, nil
+}
+
+func (v validatorStub) GetProfileImageURL(_ context.Context, _ string) (string, error) {
+	if v.err != nil {
+		return "", v.err
+	}
+	return v.miniIconURL, nil
 }
 
 type audienceValidatorStub struct {
@@ -42,7 +50,7 @@ func TestServiceSubmitValidationAndListing(t *testing.T) {
 	}{
 		{name: "empty username", username: "", expectedError: ErrInvalidUsername},
 		{name: "validator failure", username: "bad@user", validator: validatorStub{err: errors.New("not found")}, expectedError: ErrTwitchUnavailable},
-		{name: "success", username: "Best_Streamer", validator: validatorStub{displayName: "Best Streamer"}},
+		{name: "success", username: "Best_Streamer", validator: validatorStub{displayName: "Best Streamer", miniIconURL: "https://cdn.twitch.tv/icon.png"}},
 	}
 
 	for _, tt := range tests {
@@ -68,6 +76,9 @@ func TestServiceSubmitValidationAndListing(t *testing.T) {
 			}
 			if items[0].TwitchNickname != "best_streamer" {
 				t.Fatalf("unexpected twitch nickname: %s", items[0].TwitchNickname)
+			}
+			if items[0].MiniIconURL == "" {
+				t.Fatalf("expected mini icon URL to be stored")
 			}
 		})
 	}

--- a/internal/streamers/twitch_validator.go
+++ b/internal/streamers/twitch_validator.go
@@ -70,9 +70,18 @@ func (v *TwitchAPIValidator) GetLiveAudience(ctx context.Context, username strin
 	return true, stream.ViewerCount, nil
 }
 
+func (v *TwitchAPIValidator) GetProfileImageURL(ctx context.Context, username string) (string, error) {
+	user, err := v.fetchUser(ctx, username)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(user.ProfileImageURL), nil
+}
+
 type twitchUser struct {
-	ID          string `json:"id"`
-	DisplayName string `json:"display_name"`
+	ID              string `json:"id"`
+	DisplayName     string `json:"display_name"`
+	ProfileImageURL string `json:"profile_image_url"`
 }
 
 type twitchStream struct {


### PR DESCRIPTION
### Motivation
- Provide the frontend with a streamer mini-icon (avatar thumbnail) when a streamer is added so UI can display avatars alongside existing streamer fields.
- Fetch the icon URL from Twitch during streamer submission on a best-effort basis without making submission fatal if the fetch fails.
- Checklist aligned with implementation plan: [x] update onboarding (`POST /api/streamers`) to include mini icon; [ ] add HTTP-level API integration/e2e test to assert `miniIconUrl` in router responses; [ ] review any follow-ups for scenario-graph v2 (no runtime state changes in this PR).

### Description
- Added `MiniIconURL string `json:"miniIconUrl,omitempty"`` to the `Streamer` model so API payloads include `miniIconUrl`.
- Introduced `TwitchProfileValidator` interface and invoked `GetProfileImageURL` in `Submit` to populate `MiniIconURL` as a best-effort operation with warn-logging on failure.
- Extended `TwitchAPIValidator` to parse `profile_image_url` from Helix `/users` and added `GetProfileImageURL` accessor.
- Updated `docs/openapi.yaml` to document the new `miniIconUrl` field and added/updated service-level tests to assert persistence of the mini icon URL.

### Testing
- Ran `go test ./...` and the full test suite passed successfully (all automated tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49d1f752c832cb32585999b05f57f)