### PR TITLE
Group user event history by streamer with summary fields

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -354,6 +354,15 @@ type adminStreamerVideoManager interface {
 	DeleteStreamerVideos(ctx context.Context, streamerID string) (int, error)
 }
 
+type userEventHistoryStreamerItem struct {
+	DateTime         string                        `json:"dateTime"`
+	StreamerID       string                        `json:"streamerId"`
+	StreamerNickname string                        `json:"streamerNickname"`
+	StreamerIconURL  string                        `json:"streamerIconUrl,omitempty"`
+	NetAmountINT     int64                         `json:"netAmountINT"`
+	Details          []events.UserEventHistoryItem `json:"details"`
+}
+
 // NewHandler wires the base HTTP routes for the service.
 func NewHandler(
 	logger *zap.Logger,
@@ -1655,7 +1664,36 @@ func NewHandler(
 					writeError(w, http.StatusUnauthorized, "missing auth claims")
 					return
 				}
-				writeJSON(w, http.StatusOK, eventsService.ListUserHistory(r.Context(), claims.Subject))
+				items := eventsService.ListUserHistory(r.Context(), claims.Subject)
+				grouped := make([]userEventHistoryStreamerItem, 0, len(items))
+				indexByStreamer := make(map[string]int)
+				for _, item := range items {
+					idx, exists := indexByStreamer[item.StreamerID]
+					if !exists {
+						entry := userEventHistoryStreamerItem{
+							DateTime:   item.CreatedAt,
+							StreamerID: item.StreamerID,
+							StreamerNickname: item.StreamerID,
+							Details:    []events.UserEventHistoryItem{},
+						}
+						if streamersService != nil {
+							if streamer, found := streamersService.GetByID(r.Context(), item.StreamerID); found {
+								entry.StreamerNickname = streamer.TwitchNickname
+								entry.StreamerIconURL = streamer.MiniIconURL
+							}
+						}
+						grouped = append(grouped, entry)
+						idx = len(grouped) - 1
+						indexByStreamer[item.StreamerID] = idx
+					}
+					grouped[idx].Details = append(grouped[idx].Details, item)
+					if item.WinAmountINT != nil {
+						grouped[idx].NetAmountINT += *item.WinAmountINT - item.AmountINT
+					} else {
+						grouped[idx].NetAmountINT -= item.AmountINT
+					}
+				}
+				writeJSON(w, http.StatusOK, grouped)
 			})))
 
 			mux.Handle("/api/events/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/router_events_test.go
+++ b/internal/app/router_events_test.go
@@ -271,12 +271,17 @@ func TestEventsHistoryReturnsUserEventVotes(t *testing.T) {
 	}
 
 	var history []struct {
-		EventID      string  `json:"eventId"`
-		OptionID     string  `json:"optionId"`
-		AmountINT    int64   `json:"amountINT"`
-		Coefficient  float64 `json:"coefficient"`
-		ResultStatus string  `json:"resultStatus"`
-		PotentialWin int64   `json:"potentialWinINT"`
+		StreamerID       string `json:"streamerId"`
+		StreamerNickname string `json:"streamerNickname"`
+		NetAmountINT     int64  `json:"netAmountINT"`
+		Details          []struct {
+			EventID      string  `json:"eventId"`
+			OptionID     string  `json:"optionId"`
+			AmountINT    int64   `json:"amountINT"`
+			Coefficient  float64 `json:"coefficient"`
+			ResultStatus string  `json:"resultStatus"`
+			PotentialWin int64   `json:"potentialWinINT"`
+		} `json:"details"`
 	}
 	if err := json.Unmarshal(historyRes.Body.Bytes(), &history); err != nil {
 		t.Fatalf("unmarshal history response: %v", err)
@@ -284,13 +289,19 @@ func TestEventsHistoryReturnsUserEventVotes(t *testing.T) {
 	if len(history) != 1 {
 		t.Fatalf("expected history length 1, got %d", len(history))
 	}
-	if history[0].EventID != "event-1" || history[0].OptionID != "ct" || history[0].AmountINT != 10 {
+	if len(history[0].Details) != 1 {
+		t.Fatalf("expected one detail item, got %d", len(history[0].Details))
+	}
+	if history[0].StreamerID != "streamer-1" || history[0].StreamerNickname == "" || history[0].NetAmountINT != -10 {
+		t.Fatalf("unexpected grouped history item: %+v", history[0])
+	}
+	if history[0].Details[0].EventID != "event-1" || history[0].Details[0].OptionID != "ct" || history[0].Details[0].AmountINT != 10 {
 		t.Fatalf("unexpected history item: %+v", history[0])
 	}
-	if history[0].Coefficient <= 0 || history[0].PotentialWin <= 0 {
+	if history[0].Details[0].Coefficient <= 0 || history[0].Details[0].PotentialWin <= 0 {
 		t.Fatalf("expected positive coefficient and potential win, got %+v", history[0])
 	}
-	if history[0].ResultStatus != "pending" {
-		t.Fatalf("expected pending result status, got %s", history[0].ResultStatus)
+	if history[0].Details[0].ResultStatus != "pending" {
+		t.Fatalf("expected pending result status, got %s", history[0].Details[0].ResultStatus)
 	}
 }

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -185,6 +185,18 @@ func (s *Service) List(_ context.Context, query, status string, page int) []Stre
 	return result
 }
 
+func (s *Service) GetByID(_ context.Context, id string) (Streamer, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	needle := strings.TrimSpace(id)
+	for _, item := range s.items {
+		if item.ID == needle {
+			return item, true
+		}
+	}
+	return Streamer{}, false
+}
+
 func (s *Service) ResolveStreamlinkChannel(_ context.Context, streamerID string) (string, error) {
 	id := strings.TrimSpace(streamerID)
 	if id == "" {


### PR DESCRIPTION
### Motivation

- Provide a user-friendly timeline view where a user’s event history is grouped per streamer showing date, streamer nickname and icon, a net earned/lost summary, and nested detailed event entries (the UI requires a per-streamer card with aggregated value and the existing per-event details inside).

### Description

- Add `userEventHistoryStreamerItem` and change `GET /api/events/history` to return grouped records per streamer with `dateTime`, `streamerId`, `streamerNickname`, `streamerIconUrl`, `netAmountINT` and `details` containing existing `UserEventHistoryItem` entries.
- Add `GetByID` to `streamers.Service` to enrich groups with `TwitchNickname` and `MiniIconURL` when the streamer is known via `streamers.Service.GetByID`.
- Compute `netAmountINT` per streamer group by summing `winAmountINT - amountINT` when `WinAmountINT` is present and `-amountINT` otherwise, preserving existing pending-item behavior.
- Update router tests in `internal/app/router_events_test.go` to assert the new grouped response shape and the net amount calculation.

### Testing

- Ran `go test ./...` and the test suite completed successfully across packages including `internal/app`, `internal/events`, and `internal/streamers`.
- [x] Implement grouped backend response for `GET /api/events/history` and include nested details.
- [x] Add `streamers.Service.GetByID` and use it to enrich history entries with nickname/icon when available.
- [x] Update unit tests for the router to validate the new response shape and net aggregation.
- [ ] Update `docs/openapi.yaml` to reflect the changed response contract for `GET /api/events/history` and notify frontend integrators.
- [ ] Review and confirm `netAmountINT` aggregation semantics after event finalization flows populate all `WinAmountINT` values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4be68b664832cb1059a533fdad484)