### PR TITLE
Add endpoint for users to update their own nickname

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -117,6 +117,25 @@ paths:
                 $ref: '#/components/schemas/UserProfile'
         default:
           $ref: '#/components/responses/Error'
+    put:
+      summary: Update current user profile nickname
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeNicknameUpdateRequest'
+      responses:
+        '200':
+          description: Updated user profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+        default:
+          $ref: '#/components/responses/Error'
   /api/config:
     get:
       summary: Get configuration and feature flags
@@ -1302,6 +1321,8 @@ components:
           type: integer
         username:
           type: string
+        nickname:
+          type: string
         firstName:
           type: string
         lastName:
@@ -1329,6 +1350,12 @@ components:
         isAdmin:
           type: boolean
           description: Indicates whether the authenticated user has admin privileges.
+    MeNicknameUpdateRequest:
+      type: object
+      required: [nickname]
+      properties:
+        nickname:
+          type: string
     AdminUserUpsertRequest:
       type: object
       properties:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -288,6 +288,10 @@ type meResponse struct {
 	IsAdmin bool `json:"isAdmin"`
 }
 
+type meNicknameUpdateRequest struct {
+	Nickname string `json:"nickname"`
+}
+
 type eventVoteRequest struct {
 	StreamerID string `json:"streamerId"`
 	OptionID   string `json:"optionId"`
@@ -610,26 +614,52 @@ func NewHandler(
 		})))
 
 		mux.Handle("/api/me", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != http.MethodGet {
-				w.WriteHeader(http.StatusMethodNotAllowed)
-				return
-			}
 			claims, ok := auth.ClaimsFromContext(r.Context())
 			if !ok {
 				writeError(w, http.StatusUnauthorized, "missing auth claims")
 				return
 			}
-			profile, err := userService.GetByTelegramID(r.Context(), claims.TelegramID)
-			if err != nil {
-				if errors.Is(err, users.ErrNotFound) {
-					writeError(w, http.StatusNotFound, "user not found")
+			switch r.Method {
+			case http.MethodGet:
+				profile, err := userService.GetByTelegramID(r.Context(), claims.TelegramID)
+				if err != nil {
+					if errors.Is(err, users.ErrNotFound) {
+						writeError(w, http.StatusNotFound, "user not found")
+						return
+					}
+					writeError(w, http.StatusInternalServerError, "failed to load profile")
 					return
 				}
-				writeError(w, http.StatusInternalServerError, "failed to load profile")
-				return
+				isAdmin := adminService != nil && adminService.IsAdmin(claims.Subject)
+				writeJSON(w, http.StatusOK, meResponse{Profile: profile, IsAdmin: isAdmin})
+			case http.MethodPut:
+				defer r.Body.Close() //nolint:errcheck
+				body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+				if err != nil {
+					writeError(w, http.StatusBadRequest, "failed to read request body")
+					return
+				}
+				var req meNicknameUpdateRequest
+				if err := decodeJSONStrict(body, &req); err != nil {
+					writeError(w, http.StatusBadRequest, "invalid request body")
+					return
+				}
+				profile, err := userService.UpdateNicknameByID(r.Context(), claims.Subject, req.Nickname)
+				if err != nil {
+					switch {
+					case errors.Is(err, users.ErrNotFound):
+						writeError(w, http.StatusNotFound, "user not found")
+					case errors.Is(err, users.ErrInvalidNickname):
+						writeError(w, http.StatusBadRequest, err.Error())
+					default:
+						writeError(w, http.StatusInternalServerError, "failed to update nickname")
+					}
+					return
+				}
+				writeJSON(w, http.StatusOK, profile)
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
 			}
-			isAdmin := adminService != nil && adminService.IsAdmin(claims.Subject)
-			writeJSON(w, http.StatusOK, meResponse{Profile: profile, IsAdmin: isAdmin})
 		})))
 
 		mux.Handle("/api/admin/users", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/router_admin_test.go
+++ b/internal/app/router_admin_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -83,5 +84,32 @@ func TestAdminMeEndpointRemovedFallsBackToRoot(t *testing.T) {
 	handler.ServeHTTP(res, req)
 	if res.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d", res.Code)
+	}
+}
+
+func TestMeUpdateNickname(t *testing.T) {
+	userService := users.NewService(users.NewInMemoryRepository())
+	created, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "user"})
+	if err != nil {
+		t.Fatalf("userService.SyncTelegramProfile() error = %v", err)
+	}
+
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), userService, nil, nil, nil, nil, nil, ClientConfigResponse{})
+
+	req := httptest.NewRequest(http.MethodPut, "/api/me", strings.NewReader(`{"nickname":"CaptainFox"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, created.ID))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+
+	var payload users.Profile
+	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if payload.Nickname != "CaptainFox" {
+		t.Fatalf("expected nickname to be updated, got %q", payload.Nickname)
 	}
 }

--- a/internal/users/service.go
+++ b/internal/users/service.go
@@ -13,6 +13,7 @@ import (
 
 var ErrAlreadyExists = errors.New("user already exists")
 var ErrBanUntilBeforeNow = errors.New("banUntil must be in the future")
+var ErrInvalidNickname = errors.New("nickname is required")
 
 // Service orchestrates business logic around user profiles.
 type Service struct {
@@ -100,6 +101,24 @@ func (s *Service) UpdateByID(ctx context.Context, id string, profile TelegramPro
 		return Profile{}, err
 	}
 	return updated, nil
+}
+
+// UpdateNicknameByID updates only nickname for a user profile by internal user id.
+func (s *Service) UpdateNicknameByID(ctx context.Context, id, nickname string) (Profile, error) {
+	existing, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return Profile{}, err
+	}
+	trimmed := strings.TrimSpace(nickname)
+	if trimmed == "" {
+		return Profile{}, ErrInvalidNickname
+	}
+	existing.Nickname = trimmed
+	existing.UpdatedAt = s.now().UTC()
+	if err := s.repo.Update(ctx, existing); err != nil {
+		return Profile{}, err
+	}
+	return existing, nil
 }
 
 // BanByID blocks a user either temporarily (banUntil > zero) or permanently (zero).

--- a/internal/users/service_nickname_test.go
+++ b/internal/users/service_nickname_test.go
@@ -1,0 +1,38 @@
+package users
+
+import (
+	"context"
+	"testing"
+)
+
+func TestService_UpdateNicknameByID(t *testing.T) {
+	repo := NewInMemoryRepository()
+	svc := NewService(repo)
+
+	created, err := svc.SyncTelegramProfile(context.Background(), TelegramProfile{ID: 100})
+	if err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
+
+	updated, err := svc.UpdateNicknameByID(context.Background(), created.ID, "  NewNick  ")
+	if err != nil {
+		t.Fatalf("UpdateNicknameByID() error = %v", err)
+	}
+	if updated.Nickname != "NewNick" {
+		t.Fatalf("expected nickname to be trimmed and updated, got %q", updated.Nickname)
+	}
+}
+
+func TestService_UpdateNicknameByID_EmptyNickname(t *testing.T) {
+	repo := NewInMemoryRepository()
+	svc := NewService(repo)
+
+	created, err := svc.SyncTelegramProfile(context.Background(), TelegramProfile{ID: 200})
+	if err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
+
+	if _, err := svc.UpdateNicknameByID(context.Background(), created.ID, "   "); err != ErrInvalidNickname {
+		t.Fatalf("expected ErrInvalidNickname, got %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide users the ability to change the auto-generated nickname and display the custom nickname in their profile payload.
- Centralize nickname update logic in the users domain with validation to avoid scattered ad-hoc updates.
- Keep API contract and documentation consistent by exposing the change in OpenAPI and tests.
- Checklist (aligned with implementation tracking): [x] API + service change implemented, [x] OpenAPI updated, [x] unit and HTTP tests added and run, [ ] follow-up milestones in `docs/implementation_plan.md` and `docs/llm_stream_orchestration_plan.md` remain.

### Description
- Added `UpdateNicknameByID(ctx, id, nickname string)` to `internal/users/service.go` with validation returning `ErrInvalidNickname` for empty values and trimming input before saving.
- Extended `/api/me` route in `internal/app/router.go` to accept `PUT` requests with `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4bec0fa3c832ca9f276c93786dbc8)