### PR TITLE
Fix formatting in router sources

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -1701,10 +1701,10 @@ func NewHandler(
 					idx, exists := indexByStreamer[item.StreamerID]
 					if !exists {
 						entry := userEventHistoryStreamerItem{
-							DateTime:   item.CreatedAt,
-							StreamerID: item.StreamerID,
+							DateTime:         item.CreatedAt,
+							StreamerID:       item.StreamerID,
 							StreamerNickname: item.StreamerID,
-							Details:    []events.UserEventHistoryItem{},
+							Details:          []events.UserEventHistoryItem{},
 						}
 						if streamersService != nil {
 							if streamer, found := streamersService.GetByID(r.Context(), item.StreamerID); found {

--- a/internal/app/router_admin_test.go
+++ b/internal/app/router_admin_test.go
@@ -3,9 +3,9 @@ package app
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"


### PR DESCRIPTION
### Motivation
- Resolve the CI `Verify formatting` failure by formatting the affected router sources with `gofmt`; checklist: [x] formatting applied to `internal/app/router.go` and `internal/app/router_admin_test.go`, [ ] continue work toward `M2.1` in `docs/implementation_plan.md`, [ ] align runtime behavior with `docs/llm_stream_orchestration_plan.md`.

### Description
- Applied `gofmt` to `internal/app/router.go` and `internal/app/router_admin_test.go` to normalize spacing and alignment without changing program logic or public behavior.

### Testing
- Ran `gofmt -w internal/app/router.go internal/app/router_admin_test.go` and verified with `gofmt -l internal/app/router.go internal/app/router_admin_test.go` which produced no output, indicating formatting issues are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c4587204832c86ac1ad017c34e81)