### PR TITLE
Update OpenAPI for grouped user event history response

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -965,7 +965,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UserEventHistoryItem'
+                  $ref: '#/components/schemas/UserEventHistoryStreamerItem'
         default:
           $ref: '#/components/responses/Error'
   /api/wallet:
@@ -2226,6 +2226,24 @@ components:
         resultStatus:
           type: string
           enum: [pending, won, lost]
+    UserEventHistoryStreamerItem:
+      type: object
+      properties:
+        dateTime:
+          type: string
+          format: date-time
+        streamerId:
+          type: string
+        streamerNickname:
+          type: string
+        streamerIconUrl:
+          type: string
+        netAmountINT:
+          type: integer
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserEventHistoryItem'
     Wallet:
       type: object
       properties:


### PR DESCRIPTION
### Motivation
- Синхронизировать спецификацию OpenAPI с изменённым runtime-ответом `/api/events/history`, который теперь возвращает историю, сгруппированную по стримерам.

### Description
- Заменил в `docs/openapi.yaml` тип ответа `/api/events/history` с `UserEventHistoryItem[]` на `UserEventHistoryStreamerItem[]` и добавил схему `UserEventHistoryStreamerItem` с полями `dateTime`, `streamerId`, `streamerNickname`, `streamerIconUrl`, `netAmountINT` и `details` (ссылается на `UserEventHistoryItem`).

### Testing
- Запущены юнит-тесты `go test ./internal/app ./internal/events`, оба пакета прошли успешно.
- Checklist:
  - [x] Обновлён OpenAPI контракт для `/api/events/history`.
  - [x] Прогон юнит-тестов для затронутых пакетов выполнен успешно.
  - [ ] Выравнивание с `docs/implementation_plan.md` milestone M2.1.
  - [ ] Проверка соответствия `docs/llm_stream_orchestration_plan.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c330dfd0832cae93dea255690667)