### PR TITLE
Add nickname change cost setting and charge users on nickname update

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2274,14 +2274,20 @@ components:
       properties:
         votePlatformFeePercent:
           type: number
+        nicknameChangeCostINT:
+          type: integer
+          minimum: 0
     AdminGeneralSettingsUpdateRequest:
       type: object
-      required: [votePlatformFeePercent]
+      required: [votePlatformFeePercent, nicknameChangeCostINT]
       properties:
         votePlatformFeePercent:
           type: number
           minimum: 0
           maximum: 100
+        nicknameChangeCostINT:
+          type: integer
+          minimum: 0
     ReferralSummary:
       type: object
       properties:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -327,6 +327,7 @@ type withdrawRequest struct {
 
 type adminGeneralSettingsRequest struct {
 	VotePlatformFeePercent float64 `json:"votePlatformFeePercent"`
+	NicknameChangeCostINT  int64   `json:"nicknameChangeCostINT"`
 }
 
 type adminHistoryEvent struct {
@@ -665,6 +666,30 @@ func NewHandler(
 					}
 					return
 				}
+				if eventsService != nil && walletService != nil {
+					nicknameCost := eventsService.Settings().NicknameChangeCostINT
+					if nicknameCost > 0 {
+						_, _, debitErr := walletService.Post(wallet.PostRequest{
+							UserID:         claims.Subject,
+							Type:           wallet.EntryTypeDebit,
+							Amount:         nicknameCost,
+							Reason:         "nickname_change",
+							IdempotencyKey: "nickname_change:" + claims.Subject + ":" + profile.UpdatedAt.Format(time.RFC3339Nano),
+							ActorID:        claims.Subject,
+						})
+						if debitErr != nil {
+							switch {
+							case errors.Is(debitErr, wallet.ErrInsufficientFunds):
+								writeError(w, http.StatusConflict, debitErr.Error())
+							case errors.Is(debitErr, wallet.ErrInvalidAmount), errors.Is(debitErr, wallet.ErrIdempotencyRequired):
+								writeError(w, http.StatusBadRequest, debitErr.Error())
+							default:
+								writeError(w, http.StatusInternalServerError, "failed to charge nickname change")
+							}
+							return
+						}
+					}
+				}
 				writeJSON(w, http.StatusOK, profile)
 			default:
 				w.WriteHeader(http.StatusMethodNotAllowed)
@@ -972,9 +997,10 @@ func NewHandler(
 					}
 					updated, err := eventsService.UpdateSettings(events.Settings{
 						VotePlatformFeePercent: req.VotePlatformFeePercent,
+						NicknameChangeCostINT:  req.NicknameChangeCostINT,
 					})
 					if err != nil {
-						writeError(w, http.StatusBadRequest, "votePlatformFeePercent must be in range 0..100")
+						writeError(w, http.StatusBadRequest, "votePlatformFeePercent must be in range 0..100 and nicknameChangeCostINT must be >= 0")
 						return
 					}
 					writeJSON(w, http.StatusOK, updated)

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -35,10 +35,12 @@ type Service struct {
 	items              map[string]*liveEventState
 	historyByUser      map[string][]UserEventHistoryItem
 	votePlatformFeeBPS int64
+	nicknameChangeCost int64
 }
 
 type Settings struct {
 	VotePlatformFeePercent float64 `json:"votePlatformFeePercent"`
+	NicknameChangeCostINT  int64   `json:"nicknameChangeCostINT"`
 }
 
 func NewService(seed []LiveEvent) *Service {
@@ -117,6 +119,7 @@ func (s *Service) Settings() Settings {
 	defer s.mu.RUnlock()
 	return Settings{
 		VotePlatformFeePercent: float64(s.votePlatformFeeBPS) / 100.0,
+		NicknameChangeCostINT:  s.nicknameChangeCost,
 	}
 }
 
@@ -124,11 +127,18 @@ func (s *Service) UpdateSettings(settings Settings) (Settings, error) {
 	if settings.VotePlatformFeePercent < 0 || settings.VotePlatformFeePercent > 100 {
 		return Settings{}, ErrInvalidVote
 	}
+	if settings.NicknameChangeCostINT < 0 {
+		return Settings{}, ErrInvalidVote
+	}
 	feeBPS := int64(math.Round(settings.VotePlatformFeePercent * 100))
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.votePlatformFeeBPS = feeBPS
-	return Settings{VotePlatformFeePercent: float64(s.votePlatformFeeBPS) / 100.0}, nil
+	s.nicknameChangeCost = settings.NicknameChangeCostINT
+	return Settings{
+		VotePlatformFeePercent: float64(s.votePlatformFeeBPS) / 100.0,
+		NicknameChangeCostINT:  s.nicknameChangeCost,
+	}, nil
 }
 
 func (s *Service) ListLiveByStreamer(_ context.Context, streamerID string) []LiveEvent {

--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -88,6 +88,20 @@ func TestCalculateAccrualINT(t *testing.T) {
 	}
 }
 
+func TestUpdateSettingsStoresNicknameChangeCost(t *testing.T) {
+	svc := NewService(nil)
+	updated, err := svc.UpdateSettings(Settings{VotePlatformFeePercent: 5, NicknameChangeCostINT: 42})
+	if err != nil {
+		t.Fatalf("UpdateSettings() error = %v", err)
+	}
+	if updated.NicknameChangeCostINT != 42 {
+		t.Fatalf("expected nickname cost 42, got %d", updated.NicknameChangeCostINT)
+	}
+	if got := svc.Settings().NicknameChangeCostINT; got != 42 {
+		t.Fatalf("expected stored nickname cost 42, got %d", got)
+	}
+}
+
 func TestListUserHistoryReturnsLatestFirstWithoutDuplicatesForIdempotentVotes(t *testing.T) {
 	svc := NewService([]LiveEvent{
 		{


### PR DESCRIPTION
### Motivation
- Introduce a configurable cost for changing user nicknames so admins can charge users when they update their nickname.
- Persist the new setting in the events service and expose it via the admin settings API and OpenAPI schema.

### Description
- Add `NicknameChangeCostINT` to the events service `Settings` and store it on the `Service` struct, with validation that it is non-negative in `UpdateSettings`.
- Surface `nicknameChangeCostINT` in the OpenAPI schema (`docs/openapi.yaml`) for `AdminGeneralSettings` and make it required in `AdminGeneralSettingsUpdateRequest`.
- Extend the admin settings handler to accept and forward `nicknameChangeCostINT` when updating settings.
- When a user updates their nickname, charge the configured cost via `walletService.Post` if `NicknameChangeCostINT > 0`, using an idempotency key and mapping wallet errors to appropriate HTTP responses (`409` for insufficient funds, `400` for invalid amount/idempotency errors, `500` for other failures).

### Testing
- Added unit test `TestUpdateSettingsStoresNicknameChangeCost` in `internal/events/service_test.go` to verify the setting is persisted and returned by `Settings()`.
- Ran unit tests (`go test ./...`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c2eb9ab0832c9c6597836272b47a)