### PR TITLE
wallet: hide game-related transactions from user currency history

### DIFF
--- a/internal/wallet/service.go
+++ b/internal/wallet/service.go
@@ -158,7 +158,13 @@ func (s *Service) Get(userID string) Wallet {
 		return Wallet{Balance: 0, History: []Entry{}}
 	}
 
-	history := append([]Entry(nil), acct.Entries...)
+	history := make([]Entry, 0, len(acct.Entries))
+	for _, entry := range acct.Entries {
+		if isGameRelatedReason(entry.Reason) {
+			continue
+		}
+		history = append(history, entry)
+	}
 	sort.Slice(history, func(i, j int) bool {
 		return history[i].CreatedAt.After(history[j].CreatedAt)
 	})
@@ -174,4 +180,9 @@ func (s *Service) ensureAccountLocked(userID string) *account {
 	acct = &account{ProcessedByIdemID: make(map[string]Entry)}
 	s.accounts[userID] = acct
 	return acct
+}
+
+func isGameRelatedReason(reason string) bool {
+	reason = strings.TrimSpace(reason)
+	return reason == "event_vote"
 }

--- a/internal/wallet/service_test.go
+++ b/internal/wallet/service_test.go
@@ -63,3 +63,30 @@ func TestServicePostAlwaysStoresGameCurrency(t *testing.T) {
 		t.Fatalf("expected %s currency, got %s", GameCurrency, entry.Currency)
 	}
 }
+
+func TestServiceGetSkipsGameRelatedEntriesInHistory(t *testing.T) {
+	svc := NewService()
+
+	if _, _, err := svc.Post(PostRequest{UserID: "u1", Type: EntryTypeCredit, Amount: 100, IdempotencyKey: "k1", Reason: "init"}); err != nil {
+		t.Fatalf("Post(init) error = %v", err)
+	}
+	if _, _, err := svc.Post(PostRequest{UserID: "u1", Type: EntryTypeDebit, Amount: 20, IdempotencyKey: "k2", Reason: "event_vote"}); err != nil {
+		t.Fatalf("Post(event vote) error = %v", err)
+	}
+	if _, _, err := svc.Post(PostRequest{UserID: "u1", Type: EntryTypeDebit, Amount: 10, IdempotencyKey: "k3", Reason: "withdraw"}); err != nil {
+		t.Fatalf("Post(withdraw) error = %v", err)
+	}
+
+	wallet := svc.Get("u1")
+	if wallet.Balance != 70 {
+		t.Fatalf("expected balance 70, got %d", wallet.Balance)
+	}
+	if len(wallet.History) != 2 {
+		t.Fatalf("expected 2 visible history entries, got %d", len(wallet.History))
+	}
+	for _, entry := range wallet.History {
+		if entry.Reason == "event_vote" {
+			t.Fatalf("event_vote entry must be hidden from history")
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- Users should not see wallet history entries that originate from game events (e.g. `reason == "event_vote"`) while the balance still reflects all operations.
- This change keeps the public wallet contract (balance and `/api/wallet` shape) intact but reduces noise in the user-visible history.
- Checklist: [x] Implemented filtering in `wallet.Service.Get`; [x] Added unit test to cover the behavior; [ ] Extend the set of game-related reason codes if new event reasons appear; [ ] Align remaining work with `docs/implementation_plan.md` milestone `M2.1` and `docs/llm_stream_orchestration_plan.md`.

### Description
- Filtered the wallet history returned by `wallet.Service.Get` to skip entries for which `isGameRelatedReason(entry.Reason)` is true in `internal/wallet/service.go`.
- Added a helper `isGameRelatedReason` that currently treats `"event_vote"` as a game-related reason.
- Added `TestServiceGetSkipsGameRelatedEntriesInHistory` in `internal/wallet/service_test.go` to verify game-related debits are hidden while non-game entries remain visible and balance is unchanged.
- No changes were made to balance computation or external API contracts; only the `History` slice returned to callers is filtered.

### Testing
- Ran `go test ./internal/wallet ./internal/app` and the test suite completed successfully.
- The new unit test `TestServiceGetSkipsGameRelatedEntriesInHistory` passes along with existing wallet tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c3617238832cb92923092d6c34bd)