### PR TITLE
Add wallet service with Postgres-backed ledger/accounts and wire into server/handler

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/funpot/funpot-go-core/internal/prompts"
 	"github.com/funpot/funpot-go-core/internal/streamers"
 	"github.com/funpot/funpot-go-core/internal/users"
+	"github.com/funpot/funpot-go-core/internal/wallet"
 	"github.com/funpot/funpot-go-core/pkg/cache"
 	dbpkg "github.com/funpot/funpot-go-core/pkg/database"
 	"github.com/funpot/funpot-go-core/pkg/telemetry"
@@ -103,6 +104,10 @@ func main() {
 	}
 
 	userService := users.NewService(userRepo)
+	walletService := wallet.NewService()
+	if db != nil {
+		walletService = wallet.NewPostgresService(db)
+	}
 	adminService := admin.NewService(cfg.Admin.UserIDs)
 	streamerValidator := streamers.TwitchValidator(streamers.NewTwitchAPIValidator(
 		cfg.Twitch.ClientID,
@@ -219,6 +224,7 @@ func main() {
 		chunkPublisher,
 		eventsService,
 		app.ConfigResponseFromConfig(cfg),
+		walletService,
 	)
 
 	application, err := app.New(cfg, logger, handler)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -382,6 +382,7 @@ func NewHandler(
 	streamerVideoManager any,
 	eventsService *events.Service,
 	clientConfig ClientConfigResponse,
+	walletServices ...*wallet.Service,
 ) http.Handler {
 	const rateLimitAutoBanDuration = 15 * time.Minute
 
@@ -418,6 +419,9 @@ func NewHandler(
 
 	if authService != nil {
 		walletService := wallet.NewService()
+		if len(walletServices) > 0 && walletServices[0] != nil {
+			walletService = walletServices[0]
+		}
 		mux.HandleFunc("/realtime", func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodGet {
 				w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/wallet/service.go
+++ b/internal/wallet/service.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"context"
+	"database/sql"
 	"errors"
 	"sort"
 	"strings"
@@ -70,6 +72,7 @@ type Service struct {
 	mu       sync.RWMutex
 	now      func() time.Time
 	accounts map[string]*account
+	db       *sql.DB
 }
 
 func NewService() *Service {
@@ -77,6 +80,12 @@ func NewService() *Service {
 		now:      time.Now,
 		accounts: make(map[string]*account),
 	}
+}
+
+func NewPostgresService(db *sql.DB) *Service {
+	svc := NewService()
+	svc.db = db
+	return svc
 }
 
 func (s *Service) Post(req PostRequest) (Entry, int64, error) {
@@ -93,6 +102,10 @@ func (s *Service) Post(req PostRequest) (Entry, int64, error) {
 	if req.Type != EntryTypeCredit && req.Type != EntryTypeDebit {
 		return Entry{}, 0, errors.New("wallet entry type is invalid")
 	}
+	if s.db != nil {
+		return s.postToDB(req, userID)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -129,6 +142,62 @@ func (s *Service) Post(req PostRequest) (Entry, int64, error) {
 	return entry, acct.Balance, nil
 }
 
+func (s *Service) postToDB(req PostRequest, userID string) (Entry, int64, error) {
+	ctx := context.Background()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Entry{}, 0, err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var existing Entry
+	var existingBalance int64
+	row := tx.QueryRowContext(ctx, `
+SELECT id, user_id, type, amount_int, currency, reason, idempotency_key, created_at
+FROM wallet_ledger WHERE idempotency_key = $1
+`, strings.TrimSpace(req.IdempotencyKey))
+	if scanErr := row.Scan(&existing.ID, &existing.UserID, &existing.Type, &existing.Amount, &existing.Currency, &existing.Reason, &existing.IdempotencyKey, &existing.CreatedAt); scanErr == nil {
+		if err = tx.QueryRowContext(ctx, `SELECT balance_int FROM wallet_accounts WHERE user_id = $1`, userID).Scan(&existingBalance); err != nil {
+			return Entry{}, 0, err
+		}
+		if err = tx.Commit(); err != nil {
+			return Entry{}, 0, err
+		}
+		return existing, existingBalance, nil
+	} else if !errors.Is(scanErr, sql.ErrNoRows) {
+		return Entry{}, 0, scanErr
+	}
+
+	if _, err = tx.ExecContext(ctx, `INSERT INTO wallet_accounts (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING`, userID); err != nil {
+		return Entry{}, 0, err
+	}
+
+	var balance int64
+	if err = tx.QueryRowContext(ctx, `SELECT balance_int FROM wallet_accounts WHERE user_id = $1 FOR UPDATE`, userID).Scan(&balance); err != nil {
+		return Entry{}, 0, err
+	}
+	if req.Type == EntryTypeDebit && balance < req.Amount {
+		return Entry{}, balance, ErrInsufficientFunds
+	}
+
+	entry := Entry{ID: uuid.NewString(), UserID: userID, Type: req.Type, Amount: req.Amount, Currency: GameCurrency, Reason: strings.TrimSpace(req.Reason), IdempotencyKey: strings.TrimSpace(req.IdempotencyKey), ActorID: strings.TrimSpace(req.ActorID), CreatedAt: s.now().UTC()}
+	if _, err = tx.ExecContext(ctx, `INSERT INTO wallet_ledger (id, user_id, type, amount_int, currency, reason, idempotency_key, created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`, entry.ID, entry.UserID, entry.Type, entry.Amount, entry.Currency, entry.Reason, entry.IdempotencyKey, entry.CreatedAt); err != nil {
+		return Entry{}, 0, err
+	}
+	if entry.Type == EntryTypeCredit {
+		balance += entry.Amount
+	} else {
+		balance -= entry.Amount
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE wallet_accounts SET balance_int=$2, updated_at=NOW(), version=version+1 WHERE user_id=$1`, userID, balance); err != nil {
+		return Entry{}, 0, err
+	}
+	if err = tx.Commit(); err != nil {
+		return Entry{}, 0, err
+	}
+	return entry, balance, nil
+}
+
 func (s *Service) Adjust(req AdjustRequest) (Entry, int64, error) {
 	if req.Delta == 0 {
 		return Entry{}, 0, ErrInvalidDelta
@@ -150,6 +219,9 @@ func (s *Service) Adjust(req AdjustRequest) (Entry, int64, error) {
 }
 
 func (s *Service) Get(userID string) Wallet {
+	if s.db != nil {
+		return s.getFromDB(userID)
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -164,6 +236,29 @@ func (s *Service) Get(userID string) Wallet {
 	})
 
 	return Wallet{Balance: acct.Balance, History: history}
+}
+
+func (s *Service) getFromDB(userID string) Wallet {
+	lookup := strings.TrimSpace(userID)
+	if lookup == "" {
+		return Wallet{Balance: 0, History: []Entry{}}
+	}
+	ctx := context.Background()
+	balance := int64(0)
+	_ = s.db.QueryRowContext(ctx, `SELECT balance_int FROM wallet_accounts WHERE user_id = $1`, lookup).Scan(&balance)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, user_id, type, amount_int, currency, reason, idempotency_key, created_at FROM wallet_ledger WHERE user_id = $1 ORDER BY created_at DESC`, lookup)
+	if err != nil {
+		return Wallet{Balance: balance, History: []Entry{}}
+	}
+	defer rows.Close() //nolint:errcheck
+	history := make([]Entry, 0)
+	for rows.Next() {
+		var e Entry
+		if scanErr := rows.Scan(&e.ID, &e.UserID, &e.Type, &e.Amount, &e.Currency, &e.Reason, &e.IdempotencyKey, &e.CreatedAt); scanErr == nil {
+			history = append(history, e)
+		}
+	}
+	return Wallet{Balance: balance, History: history}
 }
 
 func (s *Service) ensureAccountLocked(userID string) *account {

--- a/migrations/0018_wallet_ledger_and_accounts.down.sql
+++ b/migrations/0018_wallet_ledger_and_accounts.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_wallet_ledger_user_created_at;
+DROP INDEX IF EXISTS uq_wallet_ledger_idempotency_key;
+DROP TABLE IF EXISTS wallet_ledger;
+DROP TABLE IF EXISTS wallet_accounts;

--- a/migrations/0018_wallet_ledger_and_accounts.up.sql
+++ b/migrations/0018_wallet_ledger_and_accounts.up.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS wallet_accounts (
+    user_id TEXT PRIMARY KEY,
+    balance_int BIGINT NOT NULL DEFAULT 0 CHECK (balance_int >= 0),
+    currency TEXT NOT NULL DEFAULT 'FPC' CHECK (currency = 'FPC'),
+    version BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS wallet_ledger (
+    id UUID PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('credit', 'debit')),
+    amount_int BIGINT NOT NULL CHECK (amount_int > 0),
+    currency TEXT NOT NULL DEFAULT 'FPC' CHECK (currency = 'FPC'),
+    reason TEXT NOT NULL,
+    ref_id TEXT,
+    idempotency_key TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_wallet_ledger_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_wallet_ledger_idempotency_key
+    ON wallet_ledger (idempotency_key);
+
+CREATE INDEX IF NOT EXISTS idx_wallet_ledger_user_created_at
+    ON wallet_ledger (user_id, created_at DESC);


### PR DESCRIPTION
### Motivation
- Introduce a wallet system to track user balances and ledger entries with both in-memory and Postgres-backed implementations.
- Persist wallet state and enforce idempotency and concurrency-safe balance updates in the database.
- Expose wallet functionality to the HTTP handler and realtime endpoints so other parts of the application can access user wallets.

### Description
- Added `internal/wallet` service with in-memory behavior and a Postgres-backed implementation via `NewPostgresService`, including `Post`, `Adjust`, and `Get` logic and DB helpers `postToDB` and `getFromDB` that perform transactional inserts/selects and idempotency checks.
- Added SQL migrations `migrations/0018_wallet_ledger_and_accounts.up.sql` and `.down.sql` to create `wallet_accounts` and `wallet_ledger` tables and related indexes and constraints.
- Wired the wallet service into `cmd/server/main.go` so the Postgres-backed service is used when a DB connection exists, and passed the service into the application handler.
- Updated `internal/app/router.go` `NewHandler` signature to accept optional `wallet.Service` and selected the provided DB-backed wallet service (or a new in-memory fallback) for use by the realtime endpoint.

### Testing
- Ran `go test ./...` across the repository and the test suite completed successfully.
- Ran `go vet` against the project and it reported no issues.
- Ran `go build ./cmd/server` to verify the server binary compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c2f4e610832cb44e41fa3d72917b)