### PR TITLE
Add user-scoped realtime channels and publish balance/bet updates

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -210,7 +210,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/admin/streamers/{streamerId}/llm-history?page=1&pageSize=20` – admin timeline endpoint with paginated LLM decision history (step name, LLM response, global state delta, event timestamps). Each LLM event now carries its own Bunny video fragment URL in `videoData`, plus the endpoint returns uploaded Bunny video metadata for the streamer.
 - `DELETE /api/admin/streamers/{streamerId}/llm-history` – admin cleanup endpoint that deletes persisted LLM decision history and removes tracked Bunny videos for the streamer.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
-- `GET /realtime?streamerId=<id>` – WebSocket upgrade endpoint (JWT required in `Authorization: Bearer <token>`), streams `EVENT_UPDATED` and `EVENT_VOTE_FEED_UPDATED` for the streamer scope.
+- `GET /realtime?streamerId=<id>` – WebSocket upgrade endpoint (JWT required in `Authorization: Bearer <token>`), streams streamer updates (`EVENT_UPDATED`, `EVENT_VOTE_FEED_UPDATED`) and user-scoped updates (`BALANCE_UPDATED`, `USER_BET_UPDATED`).
 - `GET /api/admin/games` – admin-only endpoint listing all configured games.
 - `POST /api/admin/games` – admin-only endpoint creating a game definition.
 - `PUT /api/admin/games/{gameId}` – admin-only endpoint updating a game definition.
@@ -238,7 +238,9 @@ Authorization: Bearer <jwt>
 4. Trigger vote via `POST /api/events/{eventId}/vote` with the same user token.
 5. Verify socket receives:
    - `EVENT_UPDATED` (totals by option),
-   - `EVENT_VOTE_FEED_UPDATED` (nickname + option + amount).
+   - `EVENT_VOTE_FEED_UPDATED` (nickname + option + amount),
+   - `BALANCE_UPDATED` (your new balance),
+   - `USER_BET_UPDATED` (your cumulative stake, coefficient, potential payout).
 
 When database connection fields are unset the server falls back to the in-memory
 repository for user profiles. This is useful for quick smoke tests but bypasses

--- a/docs/ws_messages.md
+++ b/docs/ws_messages.md
@@ -129,6 +129,20 @@ Payload schema:
 ```
 Delivered to user-specific subscriptions when ledger operations change balance.
 
+### USER_BET_UPDATED
+Payload schema:
+```json
+{
+  "eventId": "uuid",
+  "myBetTotalINT": 150,
+  "myOptionId": "ct",
+  "myCoefficient": 1.42,
+  "myPotentialWinINT": 213,
+  "updatedAt": "ISO-8601"
+}
+```
+Delivered to user-specific subscriptions right after successful vote processing.
+
 ### SYSTEM_NOTICE
 Payload schema:
 ```json

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -447,8 +447,11 @@ func NewHandler(
 				return
 			}
 			defer conn.Close() //nolint:errcheck
-			ch, unsubscribe := rtHub.SubscribeStreamer(streamerID, 64)
-			defer unsubscribe()
+			claims, _ := authService.ParseToken(parts[1])
+			streamerCh, unsubscribeStreamer := rtHub.SubscribeStreamer(streamerID, 64)
+			defer unsubscribeStreamer()
+			userCh, unsubscribeUser := rtHub.SubscribeUser(claims.Subject, 64)
+			defer unsubscribeUser()
 			_ = conn.SetReadDeadline(time.Now().Add(45 * time.Second))
 			conn.SetPongHandler(func(string) error {
 				return conn.SetReadDeadline(time.Now().Add(45 * time.Second))
@@ -465,7 +468,14 @@ func NewHandler(
 			defer pingTicker.Stop()
 			for {
 				select {
-				case env, ok := <-ch:
+				case env, ok := <-streamerCh:
+					if !ok {
+						return
+					}
+					if err := conn.WriteJSON(env); err != nil {
+						return
+					}
+				case env, ok := <-userCh:
 					if !ok {
 						return
 					}
@@ -1794,14 +1804,15 @@ func NewHandler(
 					writeError(w, http.StatusBadRequest, "invalid request body")
 					return
 				}
-				if _, _, err := walletService.Post(wallet.PostRequest{
+				_, balanceAfterVote, err := walletService.Post(wallet.PostRequest{
 					UserID:         claims.Subject,
 					Type:           wallet.EntryTypeDebit,
 					Amount:         req.AmountINT,
 					Reason:         "event_vote",
 					IdempotencyKey: idempotencyKey,
 					ActorID:        claims.Subject,
-				}); err != nil {
+				})
+				if err != nil {
 					switch {
 					case errors.Is(err, wallet.ErrInvalidAmount), errors.Is(err, wallet.ErrIdempotencyRequired):
 						writeError(w, http.StatusBadRequest, err.Error())
@@ -1861,6 +1872,32 @@ func NewHandler(
 							CreatedAt: realtime.NowRFC3339(),
 						}},
 						SnapshotAt: realtime.NowRFC3339(),
+					},
+				})
+				var myCoefficient float64
+				var myPotentialWinINT int64
+				for _, item := range eventsService.ListUserHistory(r.Context(), claims.Subject) {
+					if item.EventID == event.ID {
+						myCoefficient = item.Coefficient
+						myPotentialWinINT = item.PotentialWinINT
+						break
+					}
+				}
+				rtHub.PublishToUser(claims.Subject, realtime.Envelope{
+					Type: "BALANCE_UPDATED",
+					Payload: map[string]int64{
+						"balance": balanceAfterVote,
+					},
+				})
+				rtHub.PublishToUser(claims.Subject, realtime.Envelope{
+					Type: "USER_BET_UPDATED",
+					Payload: map[string]any{
+						"eventId":            event.ID,
+						"myBetTotalINT":      event.UserVote.TotalAmount,
+						"myOptionId":         event.UserVote.OptionID,
+						"myCoefficient":      myCoefficient,
+						"myPotentialWinINT":  myPotentialWinINT,
+						"updatedAt":          realtime.NowRFC3339(),
 					},
 				})
 				writeJSON(w, http.StatusOK, event)

--- a/internal/realtime/hub.go
+++ b/internal/realtime/hub.go
@@ -41,9 +41,15 @@ type ScenarioStepPayload struct {
 type Hub struct {
 	mu        sync.RWMutex
 	streamers map[string]map[chan Envelope]struct{}
+	users     map[string]map[chan Envelope]struct{}
 }
 
-func NewHub() *Hub { return &Hub{streamers: map[string]map[chan Envelope]struct{}{}} }
+func NewHub() *Hub {
+	return &Hub{
+		streamers: map[string]map[chan Envelope]struct{}{},
+		users:     map[string]map[chan Envelope]struct{}{},
+	}
+}
 
 func (h *Hub) SubscribeStreamer(streamerID string, buffer int) (<-chan Envelope, func()) {
 	if buffer <= 0 {
@@ -75,6 +81,45 @@ func (h *Hub) SubscribeStreamer(streamerID string, buffer int) (<-chan Envelope,
 func (h *Hub) PublishToStreamer(streamerID string, env Envelope) {
 	h.mu.RLock()
 	set := h.streamers[streamerID]
+	h.mu.RUnlock()
+	for ch := range set {
+		select {
+		case ch <- env:
+		default:
+		}
+	}
+}
+
+func (h *Hub) SubscribeUser(userID string, buffer int) (<-chan Envelope, func()) {
+	if buffer <= 0 {
+		buffer = 32
+	}
+	ch := make(chan Envelope, buffer)
+	h.mu.Lock()
+	if _, ok := h.users[userID]; !ok {
+		h.users[userID] = map[chan Envelope]struct{}{}
+	}
+	h.users[userID][ch] = struct{}{}
+	h.mu.Unlock()
+	unsub := func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if set, ok := h.users[userID]; ok {
+			if _, ok := set[ch]; ok {
+				delete(set, ch)
+				close(ch)
+			}
+			if len(set) == 0 {
+				delete(h.users, userID)
+			}
+		}
+	}
+	return ch, unsub
+}
+
+func (h *Hub) PublishToUser(userID string, env Envelope) {
+	h.mu.RLock()
+	set := h.users[userID]
 	h.mu.RUnlock()
 	for ch := range set {
 		select {

--- a/internal/realtime/hub_test.go
+++ b/internal/realtime/hub_test.go
@@ -1,0 +1,20 @@
+package realtime
+
+import "testing"
+
+func TestHubPublishesToUserSubscribers(t *testing.T) {
+	hub := NewHub()
+	ch, unsubscribe := hub.SubscribeUser("u1", 1)
+	defer unsubscribe()
+
+	hub.PublishToUser("u1", Envelope{Type: "BALANCE_UPDATED", Payload: map[string]int64{"balance": 90}})
+
+	select {
+	case env := <-ch:
+		if env.Type != "BALANCE_UPDATED" {
+			t.Fatalf("unexpected type: %s", env.Type)
+		}
+	default:
+		t.Fatal("expected user envelope")
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide user-specific realtime notifications so clients receive immediate balance and bet updates after voting. 
- Ensure the `/realtime` WebSocket can multiplex streamer-scoped and user-scoped updates for the same connection. 
- Document new realtime message types and add a basic unit test for user subscriptions.

### Description

- Extend `Hub` with a `users` registry and add `SubscribeUser` and `PublishToUser` methods to support user-scoped envelopes. 
- Update the `/realtime` handler in `internal/app/router.go` to parse token claims, subscribe to both streamer and user channels, and forward messages from both channels to the client. 
- Enhance the vote flow in `internal/app/router.go` to capture `balanceAfterVote` returned from `walletService.Post`, compute per-user bet info, and publish `BALANCE_UPDATED` and `USER_BET_UPDATED` envelopes to the user scope. 
- Update documentation files `docs/local_setup.md` and `docs/ws_messages.md` to include the new WebSocket message types and payload schemas, and add `internal/realtime/hub_test.go` to validate user publishing.

### Testing

- Ran the focused unit test `TestHubPublishesToUserSubscribers` via `go test ./internal/realtime -run TestHubPublishesToUserSubscribers` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c5e37df8832c933a962523636ae8)