### PR TITLE
fix: format internal/app/router.go with gofmt

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -1892,12 +1892,12 @@ func NewHandler(
 				rtHub.PublishToUser(claims.Subject, realtime.Envelope{
 					Type: "USER_BET_UPDATED",
 					Payload: map[string]any{
-						"eventId":            event.ID,
-						"myBetTotalINT":      event.UserVote.TotalAmount,
-						"myOptionId":         event.UserVote.OptionID,
-						"myCoefficient":      myCoefficient,
-						"myPotentialWinINT":  myPotentialWinINT,
-						"updatedAt":          realtime.NowRFC3339(),
+						"eventId":           event.ID,
+						"myBetTotalINT":     event.UserVote.TotalAmount,
+						"myOptionId":        event.UserVote.OptionID,
+						"myCoefficient":     myCoefficient,
+						"myPotentialWinINT": myPotentialWinINT,
+						"updatedAt":         realtime.NowRFC3339(),
 					},
 				})
 				writeJSON(w, http.StatusOK, event)


### PR DESCRIPTION
### Motivation
- Fix CI `Verify formatting` failure by normalizing Go formatting in `internal/app/router.go`; checklist: [x] M2.1 alignment (format-only), [x] `docs/llm_stream_orchestration_plan.md` unaffected, [ ] additional scenario-graph v2 work not required.

### Description
- Applied `gofmt -w internal/app/router.go` to adjust whitespace/alignment inside a `Payload` map literal under a realtime envelope; this is a formatting-only change with no behavioral impact.

### Testing
- Verified with `gofmt -l internal/app/router.go` (clean) and ran `go test ./...` which completed successfully for all tested packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5caad7a88832c86cfc282c27920cb)