### PR TITLE
Fix migration 0019 when wallet_ledger exists without idempotency_key

### DIFF
--- a/migrations/0019_wallet_ledger_and_accounts.up.sql
+++ b/migrations/0019_wallet_ledger_and_accounts.up.sql
@@ -19,6 +19,16 @@ CREATE TABLE IF NOT EXISTS wallet_ledger (
     CONSTRAINT fk_wallet_ledger_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
+ALTER TABLE IF EXISTS wallet_ledger
+    ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+
+UPDATE wallet_ledger
+SET idempotency_key = id::text
+WHERE idempotency_key IS NULL;
+
+ALTER TABLE wallet_ledger
+    ALTER COLUMN idempotency_key SET NOT NULL;
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_wallet_ledger_idempotency_key
     ON wallet_ledger (idempotency_key);
 


### PR DESCRIPTION
### Motivation
- The migration failed on environments where `wallet_ledger` already existed without the `idempotency_key` column because `CREATE TABLE IF NOT EXISTS` skipped creation and the subsequent `CREATE UNIQUE INDEX ... (idempotency_key)` errored with `column "idempotency_key" does not exist`, leaving the DB at a dirty version.

### Description
- Update `migrations/0019_wallet_ledger_and_accounts.up.sql` to add a resilient path when the table preexists by adding `ALTER TABLE IF EXISTS wallet_ledger ADD COLUMN IF NOT EXISTS idempotency_key TEXT`.
- Backfill missing values with `UPDATE wallet_ledger SET idempotency_key = id::text WHERE idempotency_key IS NULL` and then enforce `NOT NULL` with `ALTER TABLE ... ALTER COLUMN ... SET NOT NULL` before creating the unique index.
- Preserve original table/index creation logic and maintain `CREATE UNIQUE INDEX IF NOT EXISTS uq_wallet_ledger_idempotency_key` and the `idx_wallet_ledger_user_created_at` index.

### Testing
- Verified repository files with `rg --files | rg -i 'migr|wallet|schema'` and inspected the migration contents with `nl -ba migrations/0019_wallet_ledger_and_accounts.up.sql`, both successful.
- Applied the patch to `migrations/0019_wallet_ledger_and_accounts.up.sql` and validated the file contains the added `ALTER TABLE / UPDATE / ALTER COLUMN` sequence, which succeeded.
- Automated checks performed: file search and migration file inspection passed; no DB `migrate up` was executed in this run, so recommend running `migrate -path ./migrations -database "$FUNPOT_DATABASE_URL" up` in a staging environment to validate runtime behavior.

Checklist (aligned with `docs/implementation_plan.md` M2.1 and `docs/llm_stream_orchestration_plan.md`):
- [x] Fix the startup blocker caused by migration 19 failing on partially-existing `wallet_ledger` schemas.
- [ ] End-to-end validation of M2.1 runtime scenarios and full integration testing in staging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ce39bb64832c930ca9112236326b)