### PR TITLE
Add weekly rewards: API, service logic, router handler and tests

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -425,6 +425,22 @@ paths:
         default:
           $ref: '#/components/responses/Error'
 
+
+  /api/rewards/weekly/claim:
+    post:
+      summary: Claim weekly reward
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Weekly reward claimed and wallet credited
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeeklyRewardClaimResponse'
+        default:
+          $ref: '#/components/responses/Error'
+
   /api/admin/games:
     get:
       summary: List games (admin)
@@ -2295,9 +2311,16 @@ components:
         nicknameChangeCostINT:
           type: integer
           minimum: 0
+        weeklyRewardByDayINT:
+          type: array
+          minItems: 7
+          maxItems: 7
+          items:
+            type: integer
+            minimum: 0
     AdminGeneralSettingsUpdateRequest:
       type: object
-      required: [votePlatformFeePercent, nicknameChangeCostINT]
+      required: [votePlatformFeePercent, nicknameChangeCostINT, weeklyRewardByDayINT]
       properties:
         votePlatformFeePercent:
           type: number
@@ -2306,6 +2329,13 @@ components:
         nicknameChangeCostINT:
           type: integer
           minimum: 0
+        weeklyRewardByDayINT:
+          type: array
+          minItems: 7
+          maxItems: 7
+          items:
+            type: integer
+            minimum: 0
     ReferralSummary:
       type: object
       properties:
@@ -2469,3 +2499,32 @@ components:
         checkedAt:
           type: string
           format: date-time
+
+    WeeklyRewardClaim:
+      type: object
+      properties:
+        claimedDay:
+          type: integer
+          minimum: 1
+          maximum: 7
+        rewardAmountINT:
+          type: integer
+          minimum: 0
+        claimedAt:
+          type: string
+          format: date-time
+        nextClaimAt:
+          type: string
+          format: date-time
+        streakDay:
+          type: integer
+          minimum: 1
+          maximum: 7
+
+    WeeklyRewardClaimResponse:
+      type: object
+      properties:
+        claim:
+          $ref: '#/components/schemas/WeeklyRewardClaim'
+        newBalance:
+          type: integer

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -326,8 +326,9 @@ type withdrawRequest struct {
 }
 
 type adminGeneralSettingsRequest struct {
-	VotePlatformFeePercent float64 `json:"votePlatformFeePercent"`
-	NicknameChangeCostINT  int64   `json:"nicknameChangeCostINT"`
+	VotePlatformFeePercent float64  `json:"votePlatformFeePercent"`
+	NicknameChangeCostINT  int64    `json:"nicknameChangeCostINT"`
+	WeeklyRewardByDayINT   [7]int64 `json:"weeklyRewardByDayINT"`
 }
 
 type adminHistoryEvent struct {
@@ -987,6 +988,44 @@ func NewHandler(
 				"newBalance": newBalance,
 			})
 		})))
+		mux.Handle("/api/rewards/weekly/claim", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			claims, ok := auth.ClaimsFromContext(r.Context())
+			if !ok {
+				writeError(w, http.StatusUnauthorized, "missing auth claims")
+				return
+			}
+			if eventsService == nil {
+				writeError(w, http.StatusNotFound, "rewards are not configured")
+				return
+			}
+			claim, err := eventsService.ClaimWeeklyReward(claims.Subject, time.Now().UTC())
+			if err != nil {
+				writeError(w, http.StatusConflict, "weekly reward is available once per 24 hours")
+				return
+			}
+			newBalance := walletService.Get(claims.Subject).Balance
+			if claim.RewardAmountINT > 0 {
+				_, newBalanceAfterReward, err := walletService.Post(wallet.PostRequest{
+					UserID:         claims.Subject,
+					Type:           wallet.EntryTypeCredit,
+					Amount:         claim.RewardAmountINT,
+					Reason:         "weekly_reward",
+					IdempotencyKey: claim.IdempotencyKey,
+					ActorID:        claims.Subject,
+				})
+				if err != nil {
+					eventsService.RollbackWeeklyRewardClaim(claims.Subject, claim.ClaimedAt)
+					writeError(w, http.StatusInternalServerError, "failed to credit weekly reward")
+					return
+				}
+				newBalance = newBalanceAfterReward
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"claim": claim, "newBalance": newBalance})
+		})))
 
 		if eventsService != nil {
 			mux.Handle("/api/admin/settings/general", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1012,6 +1051,7 @@ func NewHandler(
 					updated, err := eventsService.UpdateSettings(events.Settings{
 						VotePlatformFeePercent: req.VotePlatformFeePercent,
 						NicknameChangeCostINT:  req.NicknameChangeCostINT,
+						WeeklyRewardByDayINT:   req.WeeklyRewardByDayINT,
 					})
 					if err != nil {
 						writeError(w, http.StatusBadRequest, "votePlatformFeePercent must be in range 0..100 and nicknameChangeCostINT must be >= 0")

--- a/internal/app/router_events_test.go
+++ b/internal/app/router_events_test.go
@@ -305,3 +305,50 @@ func TestEventsHistoryReturnsUserEventVotes(t *testing.T) {
 		t.Fatalf("expected pending result status, got %s", history[0].Details[0].ResultStatus)
 	}
 }
+
+func TestWeeklyRewardClaimCreditsWalletAndRespects24h(t *testing.T) {
+	eventsService := events.NewService(nil)
+	_, err := eventsService.UpdateSettings(events.Settings{WeeklyRewardByDayINT: [7]int64{10, 20, 30, 40, 50, 60, 70}})
+	if err != nil {
+		t.Fatalf("UpdateSettings() error = %v", err)
+	}
+	userService := users.NewService(users.NewInMemoryRepository())
+	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), userService, nil, nil, nil, nil, eventsService, ClientConfigResponse{})
+	userToken := buildToken(t, "tg_1")
+
+	claimReq := httptest.NewRequest(http.MethodPost, "/api/rewards/weekly/claim", nil)
+	claimReq.Header.Set("Authorization", "Bearer "+userToken)
+	claimRes := httptest.NewRecorder()
+	handler.ServeHTTP(claimRes, claimReq)
+	if claimRes.Code != http.StatusOK {
+		t.Fatalf("claim status=%d body=%s", claimRes.Code, claimRes.Body.String())
+	}
+
+	replayReq := httptest.NewRequest(http.MethodPost, "/api/rewards/weekly/claim", nil)
+	replayReq.Header.Set("Authorization", "Bearer "+userToken)
+	replayRes := httptest.NewRecorder()
+	handler.ServeHTTP(replayRes, replayReq)
+	if replayRes.Code != http.StatusConflict {
+		t.Fatalf("replay claim status=%d body=%s", replayRes.Code, replayRes.Body.String())
+	}
+
+	walletReq := httptest.NewRequest(http.MethodGet, "/api/wallet", nil)
+	walletReq.Header.Set("Authorization", "Bearer "+userToken)
+	walletRes := httptest.NewRecorder()
+	handler.ServeHTTP(walletRes, walletReq)
+	if walletRes.Code != http.StatusOK {
+		t.Fatalf("wallet status=%d body=%s", walletRes.Code, walletRes.Body.String())
+	}
+	var walletPayload struct {
+		Balance int64 `json:"balance"`
+	}
+	if err := json.Unmarshal(walletRes.Body.Bytes(), &walletPayload); err != nil {
+		t.Fatalf("unmarshal wallet response: %v", err)
+	}
+	if walletPayload.Balance != 10 {
+		t.Fatalf("expected wallet balance 10, got %d", walletPayload.Balance)
+	}
+}

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -36,11 +37,28 @@ type Service struct {
 	historyByUser      map[string][]UserEventHistoryItem
 	votePlatformFeeBPS int64
 	nicknameChangeCost int64
+	weeklyRewardByDay  [7]int64
+	weeklyClaimsByUser map[string]weeklyClaimState
+}
+
+type weeklyClaimState struct {
+	LastClaimAt time.Time
+	StreakDay   int
 }
 
 type Settings struct {
-	VotePlatformFeePercent float64 `json:"votePlatformFeePercent"`
-	NicknameChangeCostINT  int64   `json:"nicknameChangeCostINT"`
+	VotePlatformFeePercent float64  `json:"votePlatformFeePercent"`
+	NicknameChangeCostINT  int64    `json:"nicknameChangeCostINT"`
+	WeeklyRewardByDayINT   [7]int64 `json:"weeklyRewardByDayINT"`
+}
+
+type WeeklyRewardClaim struct {
+	ClaimedDay      int    `json:"claimedDay"`
+	RewardAmountINT int64  `json:"rewardAmountINT"`
+	ClaimedAt       string `json:"claimedAt"`
+	NextClaimAt     string `json:"nextClaimAt"`
+	StreakDay       int    `json:"streakDay"`
+	IdempotencyKey  string `json:"idempotencyKey"`
 }
 
 func NewService(seed []LiveEvent) *Service {
@@ -57,8 +75,9 @@ func NewService(seed []LiveEvent) *Service {
 		}
 	}
 	return &Service{
-		items:         items,
-		historyByUser: map[string][]UserEventHistoryItem{},
+		items:              items,
+		historyByUser:      map[string][]UserEventHistoryItem{},
+		weeklyClaimsByUser: map[string]weeklyClaimState{},
 	}
 }
 
@@ -120,6 +139,7 @@ func (s *Service) Settings() Settings {
 	return Settings{
 		VotePlatformFeePercent: float64(s.votePlatformFeeBPS) / 100.0,
 		NicknameChangeCostINT:  s.nicknameChangeCost,
+		WeeklyRewardByDayINT:   s.weeklyRewardByDay,
 	}
 }
 
@@ -130,15 +150,75 @@ func (s *Service) UpdateSettings(settings Settings) (Settings, error) {
 	if settings.NicknameChangeCostINT < 0 {
 		return Settings{}, ErrInvalidVote
 	}
+	for _, amount := range settings.WeeklyRewardByDayINT {
+		if amount < 0 {
+			return Settings{}, ErrInvalidVote
+		}
+	}
 	feeBPS := int64(math.Round(settings.VotePlatformFeePercent * 100))
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.votePlatformFeeBPS = feeBPS
 	s.nicknameChangeCost = settings.NicknameChangeCostINT
+	s.weeklyRewardByDay = settings.WeeklyRewardByDayINT
 	return Settings{
 		VotePlatformFeePercent: float64(s.votePlatformFeeBPS) / 100.0,
 		NicknameChangeCostINT:  s.nicknameChangeCost,
+		WeeklyRewardByDayINT:   s.weeklyRewardByDay,
 	}, nil
+}
+
+func (s *Service) ClaimWeeklyReward(userID string, now time.Time) (WeeklyRewardClaim, error) {
+	uid := strings.TrimSpace(userID)
+	if uid == "" {
+		return WeeklyRewardClaim{}, ErrInvalidVote
+	}
+	now = now.UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.weeklyClaimsByUser[uid]
+	if !state.LastClaimAt.IsZero() && now.Before(state.LastClaimAt.Add(24*time.Hour)) {
+		return WeeklyRewardClaim{}, ErrInvalidVote
+	}
+	if state.LastClaimAt.IsZero() || now.After(state.LastClaimAt.Add(48*time.Hour)) {
+		state.StreakDay = 0
+	}
+	claimedDay := state.StreakDay + 1
+	if claimedDay > 7 {
+		claimedDay = 1
+	}
+	amount := s.weeklyRewardByDay[claimedDay-1]
+	claimedAt := now.Format(time.RFC3339Nano)
+	state.LastClaimAt = now
+	state.StreakDay = claimedDay
+	s.weeklyClaimsByUser[uid] = state
+	key := "weekly_reward:" + uid + ":" + strconv.Itoa(claimedDay) + ":" + claimedAt
+	return WeeklyRewardClaim{ClaimedDay: claimedDay, RewardAmountINT: amount, ClaimedAt: claimedAt, NextClaimAt: now.Add(24 * time.Hour).Format(time.RFC3339Nano), StreakDay: claimedDay, IdempotencyKey: key}, nil
+}
+
+func (s *Service) RollbackWeeklyRewardClaim(userID string, claimedAt string) {
+	uid := strings.TrimSpace(userID)
+	if uid == "" || strings.TrimSpace(claimedAt) == "" {
+		return
+	}
+	claimedTime, err := time.Parse(time.RFC3339Nano, claimedAt)
+	if err != nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.weeklyClaimsByUser[uid]
+	if !ok {
+		return
+	}
+	if !state.LastClaimAt.Equal(claimedTime) {
+		return
+	}
+	state.LastClaimAt = time.Time{}
+	if state.StreakDay > 0 {
+		state.StreakDay--
+	}
+	s.weeklyClaimsByUser[uid] = state
 }
 
 func (s *Service) ListLiveByStreamer(_ context.Context, streamerID string) []LiveEvent {


### PR DESCRIPTION
### Motivation
- Introduce a configurable weekly reward that users can claim once per 24 hours with a 7-day streak schedule. 
- Expose configuration for per-day reward amounts in the admin settings so operators can control weekly reward values. 
- Provide an authenticated endpoint to claim the daily weekly reward and credit the user's wallet atomically.

### Description
- Add a new POST endpoint `/api/rewards/weekly/claim` and OpenAPI schemas `WeeklyRewardClaim` and `WeeklyRewardClaimResponse`, and extend `AdminGeneralSettings`/`AdminGeneralSettingsUpdateRequest` with `weeklyRewardByDayINT` in `docs/openapi.yaml`. 
- Implement weekly reward state and logic in `internal/events/service.go` by adding `weeklyRewardByDay`, `weeklyClaimsByUser`, the `Settings.WeeklyRewardByDayINT` field, `ClaimWeeklyReward` and `RollbackWeeklyRewardClaim` methods, and validation in `UpdateSettings`. 
- Wire up claim handling in `internal/app/router.go` to call `eventsService.ClaimWeeklyReward`, credit the wallet via `walletService.Post` using the claim idempotency key, rollback claim on wallet failure, and include the new `WeeklyRewardByDayINT` field in the admin settings PUT handler. 
- Add `TestWeeklyRewardClaimCreditsWalletAndRespects24h` in `internal/app/router_events_test.go` to cover successful claiming, 24-hour replay protection, and wallet balance update.

### Testing
- Ran unit tests including the new `TestWeeklyRewardClaimCreditsWalletAndRespects24h` from `internal/app`, which exercise the claim endpoint and wallet credit flow, and they passed. 
- Ran package test suite with `go test ./...` to ensure service and router integration tests succeeded. 
- No automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5cd23198c832c8398abf38643bf89)