### PR TITLE
Avoid overwriting user profile on admin balance adjustments

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -857,21 +857,33 @@ func NewHandler(
 					writeError(w, http.StatusBadRequest, "invalid request body")
 					return
 				}
-				profile, err := userService.UpdateByID(r.Context(), userID, users.TelegramProfile{
-					ID:           req.TelegramID,
-					Username:     req.Username,
-					FirstName:    req.FirstName,
-					LastName:     req.LastName,
-					LanguageCode: req.LanguageCode,
-				})
+				profile, err := userService.GetByID(r.Context(), userID)
 				if err != nil {
 					if errors.Is(err, users.ErrNotFound) {
 						writeError(w, http.StatusNotFound, err.Error())
 						return
 					}
-					logger.Error("failed to update user", zap.String("userID", userID), zap.Error(err))
-					writeError(w, http.StatusInternalServerError, "failed to update user")
+					logger.Error("failed to fetch user", zap.String("userID", userID), zap.Error(err))
+					writeError(w, http.StatusInternalServerError, "failed to fetch user")
 					return
+				}
+				if req.TelegramID != 0 || strings.TrimSpace(req.Username) != "" || strings.TrimSpace(req.FirstName) != "" || strings.TrimSpace(req.LastName) != "" || strings.TrimSpace(req.LanguageCode) != "" {
+					profile, err = userService.UpdateByID(r.Context(), userID, users.TelegramProfile{
+						ID:           req.TelegramID,
+						Username:     req.Username,
+						FirstName:    req.FirstName,
+						LastName:     req.LastName,
+						LanguageCode: req.LanguageCode,
+					})
+					if err != nil {
+						if errors.Is(err, users.ErrNotFound) {
+							writeError(w, http.StatusNotFound, err.Error())
+							return
+						}
+						logger.Error("failed to update user", zap.String("userID", userID), zap.Error(err))
+						writeError(w, http.StatusInternalServerError, "failed to update user")
+						return
+					}
 				}
 				if req.BalanceDelta != nil {
 					idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))

--- a/internal/app/router_admin_users_test.go
+++ b/internal/app/router_admin_users_test.go
@@ -67,6 +67,13 @@ func TestAdminUsersCRUD(t *testing.T) {
 	if balanceRes.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", balanceRes.Code, balanceRes.Body.String())
 	}
+	var balanceProfile users.Profile
+	if err := json.Unmarshal(balanceRes.Body.Bytes(), &balanceProfile); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if balanceProfile.Username != "alice_2" || balanceProfile.LastName != "Updated" || balanceProfile.LanguageCode != "ru" {
+		t.Fatalf("expected profile fields unchanged after balance update, got %+v", balanceProfile)
+	}
 
 	banReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID+"/ban", strings.NewReader(`{"isBanned":true,"reason":"manual"}`))
 	banReq.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))


### PR DESCRIPTION
### Motivation
- Admin requests that only adjust a user's balance should not accidentally overwrite or clear profile fields when empty JSON fields are provided in the same request.  
- The route previously called `UpdateByID` unconditionally which could replace stored `username`/`firstName`/`lastName`/`languageCode` with empty values.  
- Preserve existing profile data while keeping wallet adjustments persisted via `walletService.Adjust` and its DB-backed `postToDB` path when configured.

### Description
- Changed the admin user PUT handler to first fetch the current profile using `userService.GetByID` and only call `userService.UpdateByID` when at least one profile field is explicitly provided.  
- Kept the existing balance adjustment flow that calls `walletService.Adjust(...)` with idempotency and validation unchanged.  
- Added a regression assertion in `internal/app/router_admin_users_test.go` to verify profile fields remain unchanged after a balance-only admin update.  
- Modified files: `internal/app/router.go` and `internal/app/router_admin_users_test.go`.

### Testing
- Ran `go test ./internal/app` and the test suite passed successfully.  
- New regression assertion verifies that a balance-only PUT does not mutate `username`/`lastName`/`languageCode` and the test succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d6fea03c832cb900a8faecd6567e)