### PR TITLE
Persist admin general settings in database

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -129,6 +129,11 @@ func main() {
 		promptsService = prompts.NewPostgresService(db)
 	}
 	eventsService := events.NewService(nil)
+	if db != nil {
+		if err := eventsService.ConfigureSettingsPersistence(ctx, events.NewPostgresSettingsStore(db)); err != nil {
+			logger.Fatal("failed to configure admin general settings persistence", zap.Error(err))
+		}
+	}
 
 	streamCapture := buildStreamCapture(cfg, streamersService)
 	if configurableCapture, ok := streamCapture.(interface{ SetLogger(*zap.Logger) }); ok {

--- a/internal/events/admin_settings_postgres.go
+++ b/internal/events/admin_settings_postgres.go
@@ -1,0 +1,57 @@
+package events
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+const adminGeneralSettingsKey = "admin_general_settings"
+
+type PostgresSettingsStore struct {
+	db *sql.DB
+}
+
+func NewPostgresSettingsStore(db *sql.DB) *PostgresSettingsStore {
+	return &PostgresSettingsStore{db: db}
+}
+
+func (s *PostgresSettingsStore) Load(ctx context.Context) (Settings, bool, error) {
+	if s == nil || s.db == nil {
+		return Settings{}, false, nil
+	}
+	var payload []byte
+	err := s.db.QueryRowContext(ctx, `SELECT value_json FROM config WHERE key = $1`, adminGeneralSettingsKey).Scan(&payload)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return Settings{}, false, nil
+		}
+		return Settings{}, false, fmt.Errorf("load admin general settings: %w", err)
+	}
+	var settings Settings
+	if err := json.Unmarshal(payload, &settings); err != nil {
+		return Settings{}, false, fmt.Errorf("decode admin general settings: %w", err)
+	}
+	return settings, true, nil
+}
+
+func (s *PostgresSettingsStore) Save(ctx context.Context, settings Settings) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	payload, err := json.Marshal(settings)
+	if err != nil {
+		return fmt.Errorf("encode admin general settings: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO config (key, value_json, updated_at)
+VALUES ($1, $2, NOW())
+ON CONFLICT (key) DO UPDATE
+SET value_json = EXCLUDED.value_json,
+    updated_at = NOW()`, adminGeneralSettingsKey, payload)
+	if err != nil {
+		return fmt.Errorf("save admin general settings: %w", err)
+	}
+	return nil
+}

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -39,6 +39,12 @@ type Service struct {
 	nicknameChangeCost int64
 	weeklyRewardByDay  [7]int64
 	weeklyClaimsByUser map[string]weeklyClaimState
+	settingsStore      SettingsStore
+}
+
+type SettingsStore interface {
+	Load(ctx context.Context) (Settings, bool, error)
+	Save(ctx context.Context, settings Settings) error
 }
 
 type weeklyClaimState struct {
@@ -79,6 +85,25 @@ func NewService(seed []LiveEvent) *Service {
 		historyByUser:      map[string][]UserEventHistoryItem{},
 		weeklyClaimsByUser: map[string]weeklyClaimState{},
 	}
+}
+
+func (s *Service) ConfigureSettingsPersistence(ctx context.Context, store SettingsStore) error {
+	if store == nil {
+		return nil
+	}
+	loaded, ok, err := store.Load(ctx)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.settingsStore = store
+	if ok {
+		s.votePlatformFeeBPS = int64(math.Round(loaded.VotePlatformFeePercent * 100))
+		s.nicknameChangeCost = loaded.NicknameChangeCostINT
+		s.weeklyRewardByDay = loaded.WeeklyRewardByDayINT
+	}
+	return nil
 }
 
 func (s *Service) CreateLiveEvent(_ context.Context, req CreateLiveEventRequest) (LiveEvent, error) {
@@ -161,11 +186,18 @@ func (s *Service) UpdateSettings(settings Settings) (Settings, error) {
 	s.votePlatformFeeBPS = feeBPS
 	s.nicknameChangeCost = settings.NicknameChangeCostINT
 	s.weeklyRewardByDay = settings.WeeklyRewardByDayINT
-	return Settings{
+	store := s.settingsStore
+	current := Settings{
 		VotePlatformFeePercent: float64(s.votePlatformFeeBPS) / 100.0,
 		NicknameChangeCostINT:  s.nicknameChangeCost,
 		WeeklyRewardByDayINT:   s.weeklyRewardByDay,
-	}, nil
+	}
+	if store != nil {
+		if err := store.Save(context.Background(), current); err != nil {
+			return Settings{}, err
+		}
+	}
+	return current, nil
 }
 
 func (s *Service) ClaimWeeklyReward(userID string, now time.Time) (WeeklyRewardClaim, error) {

--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -169,3 +169,47 @@ func TestListUserHistoryReturnsLatestFirstWithoutDuplicatesForIdempotentVotes(t 
 		t.Fatalf("expected positive potential wins, got latest=%d oldest=%d", history[0].PotentialWinINT, history[1].PotentialWinINT)
 	}
 }
+
+type stubSettingsStore struct {
+	loaded Settings
+	ok     bool
+	saved  Settings
+}
+
+func (s *stubSettingsStore) Load(_ context.Context) (Settings, bool, error) {
+	return s.loaded, s.ok, nil
+}
+func (s *stubSettingsStore) Save(_ context.Context, settings Settings) error {
+	s.saved = settings
+	return nil
+}
+
+func TestConfigureSettingsPersistenceLoadsExistingSettings(t *testing.T) {
+	svc := NewService(nil)
+	store := &stubSettingsStore{ok: true, loaded: Settings{VotePlatformFeePercent: 12.5, NicknameChangeCostINT: 15, WeeklyRewardByDayINT: [7]int64{1, 2, 3, 4, 5, 6, 7}}}
+	if err := svc.ConfigureSettingsPersistence(context.Background(), store); err != nil {
+		t.Fatalf("ConfigureSettingsPersistence() error = %v", err)
+	}
+	got := svc.Settings()
+	if got.VotePlatformFeePercent != 12.5 || got.NicknameChangeCostINT != 15 || got.WeeklyRewardByDayINT[6] != 7 {
+		t.Fatalf("unexpected loaded settings: %+v", got)
+	}
+}
+
+func TestUpdateSettingsPersistsToStore(t *testing.T) {
+	svc := NewService(nil)
+	store := &stubSettingsStore{}
+	if err := svc.ConfigureSettingsPersistence(context.Background(), store); err != nil {
+		t.Fatalf("ConfigureSettingsPersistence() error = %v", err)
+	}
+	updated, err := svc.UpdateSettings(Settings{VotePlatformFeePercent: 17, NicknameChangeCostINT: 40})
+	if err != nil {
+		t.Fatalf("UpdateSettings() error = %v", err)
+	}
+	if store.saved.VotePlatformFeePercent != 17 || store.saved.NicknameChangeCostINT != 40 {
+		t.Fatalf("expected persisted settings, got %+v", store.saved)
+	}
+	if updated.VotePlatformFeePercent != 17 {
+		t.Fatalf("unexpected updated settings: %+v", updated)
+	}
+}

--- a/migrations/0020_config_table.down.sql
+++ b/migrations/0020_config_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS config;

--- a/migrations/0020_config_table.up.sql
+++ b/migrations/0020_config_table.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS config (
+    key TEXT PRIMARY KEY,
+    value_json JSONB NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
### Motivation
- Admin general settings (vote platform fee, nickname change cost, weekly rewards) must be persisted so they survive restarts and are manageable via admin surfaces and migrations specified in the ERD/docs. 
- Provide a DB-backed configuration surface to align runtime behavior with documented expectations for admin-managed configuration. 
- Checklist: [x] Admin settings persisted in DB-backed store; [x] Server wired to initialize settings from DB when PostgreSQL is present; [x] Migration added to create `config` table; [ ] Further M2.1 / scenario-graph v2 and additional admin surfaces remain to be implemented.

### Description
- Add a `SettingsStore` abstraction and a `settingsStore` field to `events.Service`, plus `ConfigureSettingsPersistence(ctx, store)` to load settings at startup. 
- Persist settings on change by saving current settings from `UpdateSettings` when a store is configured. 
- Implement `PostgresSettingsStore` in `internal/events/admin_settings_postgres.go` that reads/writes JSON into a `config` table using key `admin_general_settings`. 
- Wire persistence in `cmd/server/main.go` to call `ConfigureSettingsPersistence` when `db` is available, add migration `migrations/0020_config_table.*.sql`, and add unit tests for load/save behavior in `internal/events/service_test.go`.

### Testing
- Ran formatting and unit tests with `gofmt -w` then `go test ./internal/events ./internal/app ./cmd/server`, and all tests passed. 
- Added unit tests `TestConfigureSettingsPersistenceLoadsExistingSettings` and `TestUpdateSettingsPersistsToStore`, which succeeded under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d74c9fec832c998aeb1adeb16a27)