### PR TITLE
Allow admin user balance updates when Idempotency-Key is omitted

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
 
@@ -888,8 +889,7 @@ func NewHandler(
 				if req.BalanceDelta != nil {
 					idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
 					if idempotencyKey == "" {
-						writeError(w, http.StatusBadRequest, wallet.ErrIdempotencyRequired.Error())
-						return
+						idempotencyKey = "admin-adjust-" + uuid.NewString()
 					}
 					if strings.TrimSpace(req.BalanceReason) == "" {
 						writeError(w, http.StatusBadRequest, "balanceReason is required when balanceDeltaINT is provided")

--- a/internal/app/router_admin_users_test.go
+++ b/internal/app/router_admin_users_test.go
@@ -75,6 +75,14 @@ func TestAdminUsersCRUD(t *testing.T) {
 		t.Fatalf("expected profile fields unchanged after balance update, got %+v", balanceProfile)
 	}
 
+	balanceNoKeyReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID, strings.NewReader(`{"balanceDeltaINT":5,"balanceReason":"manual correction"}`))
+	balanceNoKeyReq.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
+	balanceNoKeyRes := httptest.NewRecorder()
+	handler.ServeHTTP(balanceNoKeyRes, balanceNoKeyReq)
+	if balanceNoKeyRes.Code != http.StatusOK {
+		t.Fatalf("expected 200 without Idempotency-Key, got %d: %s", balanceNoKeyRes.Code, balanceNoKeyRes.Body.String())
+	}
+
 	banReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID+"/ban", strings.NewReader(`{"isBanned":true,"reason":"manual"}`))
 	banReq.Header.Set("Authorization", "Bearer "+buildToken(t, "admin-1"))
 	banRes := httptest.NewRecorder()


### PR DESCRIPTION
### Motivation
- Make admin balance adjustments robust when clients omit the `Idempotency-Key` header so admin corrections do not fail with a 400 validation error.

### Description
- Auto-generate an idempotency key `admin-adjust-<uuid>` for wallet adjustments when the `Idempotency-Key` header is empty by importing `github.com/google/uuid` and setting the generated key in the admin user update handler (change in `internal/app/router.go`).
- Add a unit test to verify an admin can update a user balance without providing `Idempotency-Key` (change in `internal/app/router_admin_users_test.go`).

### Testing
- Ran `go test ./internal/app` and the package tests completed successfully.
- Checklist: [x] Auto-generate idempotency key for admin adjustments, [x] Add router test for no-`Idempotency-Key` scenario, [x] Run unit tests; [ ] Update docs or migrations if needed, [ ] Align changes with `docs/implementation_plan.md` milestone M2.1 and `docs/llm_stream_orchestration_plan.md` where applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5da3153ec832c99bddef9c9ec3e06)