### PR TITLE
fix(events): restore ConfigureSettingsPersistence to unblock vet/tests

### DIFF
--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -157,6 +157,42 @@ func (s *Service) Settings() Settings {
 	}
 }
 
+func (s *Service) ConfigureSettingsPersistence(ctx context.Context, store SettingsStore) error {
+	s.mu.Lock()
+	s.settingsStore = store
+	s.mu.Unlock()
+	if store == nil {
+		return nil
+	}
+
+	loaded, ok, err := store.Load(ctx)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	if loaded.VotePlatformFeePercent < 0 || loaded.VotePlatformFeePercent > 100 {
+		return ErrInvalidVote
+	}
+	if loaded.NicknameChangeCostINT < 0 {
+		return ErrInvalidVote
+	}
+	for _, amount := range loaded.WeeklyRewardByDayINT {
+		if amount < 0 {
+			return ErrInvalidVote
+		}
+	}
+
+	feeBPS := int64(math.Round(loaded.VotePlatformFeePercent * 100))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.votePlatformFeeBPS = feeBPS
+	s.nicknameChangeCost = loaded.NicknameChangeCostINT
+	s.weeklyRewardByDay = loaded.WeeklyRewardByDayINT
+	return nil
+}
+
 func (s *Service) UpdateSettings(settings Settings) (Settings, error) {
 	if settings.VotePlatformFeePercent < 0 || settings.VotePlatformFeePercent > 100 {
 		return Settings{}, ErrInvalidVote


### PR DESCRIPTION
### Motivation
- Tests and `vet` were failing due to a missing `Service.ConfigureSettingsPersistence` method referenced from `internal/events/service_test.go`, so restore the runtime hook for persisted settings to fix the build. 
- Ensure persisted settings are validated and applied consistently with `UpdateSettings` to avoid invalid runtime configuration.

### Description
- Added `ConfigureSettingsPersistence(ctx context.Context, store SettingsStore) error` to `internal/events/service.go` to bind a `SettingsStore` to the service and load persisted settings on configuration. 
- The method validates loaded values (fee percent in `0..100`, non-negative `NicknameChangeCostINT`, and non-negative `WeeklyRewardByDayINT`) and applies them to in-memory state using the same BPS conversion (`math.Round(...)`).
- Keeps existing `UpdateSettings` behavior intact by continuing to call `settingsStore.Save(...)` when present.

Checklist (aligned to docs/implementation_plan.md M2.1 and llm_stream_orchestration_plan.md):
- [x] Restore `ConfigureSettingsPersistence` so runtime settings persistence wiring and tests compile.
- [ ] M2.1 full scope: remaining milestone work not covered by this fix.
- [ ] `llm_stream_orchestration_plan.md` alignment: orchestration changes not addressed here.

### Testing
- Ran `go test ./internal/events` and it passed successfully. 
- Ran `go test ./...` and the full test suite completed without failures, confirming the vet/test compile error is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5db771078832c81482aee656de87c)