### PR TITLE
Fix failing app tests: use created user IDs instead of hardcoded tg_1

### DIFF
--- a/internal/app/router_events_test.go
+++ b/internal/app/router_events_test.go
@@ -40,7 +40,8 @@ func TestEventsVoteDebitsWalletAndIsIdempotent(t *testing.T) {
 		},
 	})
 	userService := users.NewService(users.NewInMemoryRepository())
-	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+	created, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"})
+	if err != nil {
 		t.Fatalf("SyncTelegramProfile() error = %v", err)
 	}
 	handler := NewHandler(
@@ -58,9 +59,9 @@ func TestEventsVoteDebitsWalletAndIsIdempotent(t *testing.T) {
 		ClientConfigResponse{},
 	)
 	adminToken := buildToken(t, "admin-1")
-	userToken := buildToken(t, "tg_1")
+	userToken := buildToken(t, created.ID)
 
-	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID, bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
 	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
 	adjustReq.Header.Set("Idempotency-Key", "adj-seed")
 	adjustRes := httptest.NewRecorder()
@@ -137,7 +138,8 @@ func TestAdminGeneralSettingsAffectVotePlatformFee(t *testing.T) {
 		},
 	})
 	userService := users.NewService(users.NewInMemoryRepository())
-	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+	created, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"})
+	if err != nil {
 		t.Fatalf("SyncTelegramProfile() error = %v", err)
 	}
 	handler := NewHandler(
@@ -155,7 +157,7 @@ func TestAdminGeneralSettingsAffectVotePlatformFee(t *testing.T) {
 		ClientConfigResponse{},
 	)
 	adminToken := buildToken(t, "admin-1")
-	userToken := buildToken(t, "tg_1")
+	userToken := buildToken(t, created.ID)
 
 	settingsReq := httptest.NewRequest(http.MethodPut, "/api/admin/settings/general", bytes.NewReader([]byte(`{"votePlatformFeePercent":15}`)))
 	settingsReq.Header.Set("Authorization", "Bearer "+adminToken)
@@ -165,7 +167,7 @@ func TestAdminGeneralSettingsAffectVotePlatformFee(t *testing.T) {
 		t.Fatalf("settings status=%d body=%s", settingsRes.Code, settingsRes.Body.String())
 	}
 
-	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID, bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
 	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
 	adjustReq.Header.Set("Idempotency-Key", "adj-seed")
 	adjustRes := httptest.NewRecorder()
@@ -224,7 +226,8 @@ func TestEventsHistoryReturnsUserEventVotes(t *testing.T) {
 		},
 	})
 	userService := users.NewService(users.NewInMemoryRepository())
-	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+	created, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"})
+	if err != nil {
 		t.Fatalf("SyncTelegramProfile() error = %v", err)
 	}
 	handler := NewHandler(
@@ -242,9 +245,9 @@ func TestEventsHistoryReturnsUserEventVotes(t *testing.T) {
 		ClientConfigResponse{},
 	)
 	adminToken := buildToken(t, "admin-1")
-	userToken := buildToken(t, "tg_1")
+	userToken := buildToken(t, created.ID)
 
-	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID, bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
 	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
 	adjustReq.Header.Set("Idempotency-Key", "adj-seed")
 	adjustRes := httptest.NewRecorder()
@@ -313,11 +316,12 @@ func TestWeeklyRewardClaimCreditsWalletAndRespects24h(t *testing.T) {
 		t.Fatalf("UpdateSettings() error = %v", err)
 	}
 	userService := users.NewService(users.NewInMemoryRepository())
-	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+	created, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"})
+	if err != nil {
 		t.Fatalf("SyncTelegramProfile() error = %v", err)
 	}
 	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), userService, nil, nil, nil, nil, eventsService, ClientConfigResponse{})
-	userToken := buildToken(t, "tg_1")
+	userToken := buildToken(t, created.ID)
 
 	claimReq := httptest.NewRequest(http.MethodPost, "/api/rewards/weekly/claim", nil)
 	claimReq.Header.Set("Authorization", "Bearer "+userToken)

--- a/internal/app/router_wallet_test.go
+++ b/internal/app/router_wallet_test.go
@@ -16,7 +16,8 @@ import (
 
 func TestWalletAdminUserUpdateBalanceAndWithdrawIdempotency(t *testing.T) {
 	userService := users.NewService(users.NewInMemoryRepository())
-	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+	created, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"})
+	if err != nil {
 		t.Fatalf("SyncTelegramProfile() error = %v", err)
 	}
 	handler := NewHandler(
@@ -34,10 +35,10 @@ func TestWalletAdminUserUpdateBalanceAndWithdrawIdempotency(t *testing.T) {
 		ClientConfigResponse{},
 	)
 	adminToken := buildToken(t, "admin-1")
-	userToken := buildToken(t, "tg_1")
+	userToken := buildToken(t, created.ID)
 
 	adjustBody := []byte(`{"balanceDeltaINT":100,"balanceReason":"manual grant"}`)
-	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader(adjustBody))
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID, bytes.NewReader(adjustBody))
 	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
 	adjustReq.Header.Set("Idempotency-Key", "adj-1")
 	adjustRes := httptest.NewRecorder()
@@ -46,7 +47,7 @@ func TestWalletAdminUserUpdateBalanceAndWithdrawIdempotency(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", adjustRes.Code, adjustRes.Body.String())
 	}
 
-	replayReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader(adjustBody))
+	replayReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID, bytes.NewReader(adjustBody))
 	replayReq.Header.Set("Authorization", "Bearer "+adminToken)
 	replayReq.Header.Set("Idempotency-Key", "adj-1")
 	replayRes := httptest.NewRecorder()
@@ -115,7 +116,8 @@ func TestWalletAdminUserUpdateBalanceAndWithdrawIdempotency(t *testing.T) {
 
 func TestAdminUserBalanceAdjustRequiresAdmin(t *testing.T) {
 	userService := users.NewService(users.NewInMemoryRepository())
-	if _, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"}); err != nil {
+	created, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"})
+	if err != nil {
 		t.Fatalf("SyncTelegramProfile() error = %v", err)
 	}
 	handler := NewHandler(
@@ -133,8 +135,8 @@ func TestAdminUserBalanceAdjustRequiresAdmin(t *testing.T) {
 		ClientConfigResponse{},
 	)
 
-	req := httptest.NewRequest(http.MethodPut, "/api/admin/users/tg_1", bytes.NewReader([]byte(`{"balanceDeltaINT":10,"balanceReason":"test"}`)))
-	req.Header.Set("Authorization", "Bearer "+buildToken(t, "tg_1"))
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID, bytes.NewReader([]byte(`{"balanceDeltaINT":10,"balanceReason":"test"}`)))
+	req.Header.Set("Authorization", "Bearer "+buildToken(t, created.ID))
 	req.Header.Set("Idempotency-Key", "adj-1")
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)


### PR DESCRIPTION
### Motivation
- App-level tests were failing with `404 user not found` because tests used the hardcoded Telegram ID `tg_1` while `SyncTelegramProfile` returns an actual created user ID under the current DB/migration behavior. 
- Update tests to use the real returned user ID to ensure admin/wallet/events endpoints target an existing user and avoid false negatives in CI.

### Description
- Updated `internal/app/router_wallet_test.go` to capture the return value of `SyncTelegramProfile` into `created` and use `created.ID` for JWT subjects and admin route paths instead of `tg_1`.
- Updated `internal/app/router_events_test.go` to capture `created` from `SyncTelegramProfile` and replace hardcoded `tg_1` usages with `created.ID` for seeding balance, building tokens, and reward/vote requests.
- No production code was changed; only test wiring was adjusted so tests reflect current user identity semantics when seeding and authenticating users.

### Testing
- Ran `go test ./internal/app` and the suite passed successfully.
- Ran `go test ./...` and all packages passed successfully.

Checklist (aligned with repository tracking):
- [x] `M2.1` stability: fixed test-blocker in `internal/app` caused by user ID handling.
- [x] Update tests to use `SyncTelegramProfile` return (`created.ID`) and match JWT subjects.
- [ ] Audit remaining integration/e2e tests for other hardcoded user IDs (outstanding).
- [ ] Validate scenario-graph v2 orchestration tests where applicable (outstanding).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f18f2448832c9f4a701bd14cd86b)