### PR TITLE
Fix /api/admin/users listing failure after UUID schema updates

### DIFF
--- a/internal/users/postgres.go
+++ b/internal/users/postgres.go
@@ -100,7 +100,7 @@ func (r *PostgresRepository) List(ctx context.Context, query string, page, pageS
 SELECT COUNT(*)
 FROM users
 WHERE $1 = ''
-   OR id ILIKE $2
+   OR id::text ILIKE $2
    OR username ILIKE $2
    OR nickname ILIKE $2
    OR first_name ILIKE $2
@@ -117,7 +117,7 @@ WHERE $1 = ''
 SELECT id, telegram_id, username, nickname, first_name, last_name, language_code, referral_code, is_banned, ban_reason, banned_at, banned_until, created_at, updated_at
 FROM users
 WHERE $1 = ''
-   OR id ILIKE $2
+   OR id::text ILIKE $2
    OR username ILIKE $2
    OR nickname ILIKE $2
    OR first_name ILIKE $2


### PR DESCRIPTION
### Motivation
- The admin users listing endpoint failed with `failed to list users` because the SQL used `ILIKE` against `users.id` while the `id` column is now a `UUID`, and PostgreSQL rejects `ILIKE` on non-text types without a cast.

### Description
- Updated both list-related queries in `internal/users/postgres.go` to cast the `id` column to text (`id::text ILIKE $2`) for the `COUNT(*)` and `SELECT ... LIMIT/OFFSET` queries so search filtering works with UUID primary keys.

### Testing
- Ran targeted unit tests: `go test ./internal/users ./internal/app` and they passed.
- Checklist: [x] Root cause identified; [x] Fix applied to `internal/users/postgres.go`; [x] Targeted package tests passed; [ ] Run full test suite `go test ./...`; [ ] Validate against production-like DB snapshot before deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71a944004832cb69c7fb57943f84a)