### PR TITLE
Fix wallet ledger insert for admin balance adjustments

### DIFF
--- a/internal/wallet/service.go
+++ b/internal/wallet/service.go
@@ -181,14 +181,16 @@ FROM wallet_ledger WHERE idempotency_key = $1
 	}
 
 	entry := Entry{ID: uuid.NewString(), UserID: userID, Type: req.Type, Amount: req.Amount, Currency: GameCurrency, Reason: strings.TrimSpace(req.Reason), IdempotencyKey: strings.TrimSpace(req.IdempotencyKey), ActorID: strings.TrimSpace(req.ActorID), CreatedAt: s.now().UTC()}
-	if _, err = tx.ExecContext(ctx, `INSERT INTO wallet_ledger (id, user_id, tx_type, amount_int, currency, reason, idempotency_key, created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`, entry.ID, entry.UserID, entry.Type, entry.Amount, balance, entry.Currency, entry.Reason, entry.IdempotencyKey, entry.CreatedAt); err != nil {
+	balanceAfter := balance
+	if entry.Type == EntryTypeCredit {
+		balanceAfter += entry.Amount
+	} else {
+		balanceAfter -= entry.Amount
+	}
+	if _, err = tx.ExecContext(ctx, `INSERT INTO wallet_ledger (id, user_id, tx_type, amount_int, balance_after_int, currency, reason, idempotency_key, created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`, entry.ID, entry.UserID, entry.Type, entry.Amount, balanceAfter, entry.Currency, entry.Reason, entry.IdempotencyKey, entry.CreatedAt); err != nil {
 		return Entry{}, 0, err
 	}
-	if entry.Type == EntryTypeCredit {
-		balance += entry.Amount
-	} else {
-		balance -= entry.Amount
-	}
+	balance = balanceAfter
 	if _, err = tx.ExecContext(ctx, `UPDATE wallet_accounts SET balance_int=$2, updated_at=NOW(), version=version+1 WHERE user_id=$1`, userID, balance); err != nil {
 		return Entry{}, 0, err
 	}


### PR DESCRIPTION
### Motivation
- Fix runtime failures when performing admin wallet adjustments via `PUT /api/admin/users/{userId}` caused by the DB migration that expects `balance_after_int` in `wallet_ledger`.

### Description
- Compute `balanceAfter` and update `internal/wallet/service.go` to insert into `wallet_ledger` with `balance_after_int` and then update `wallet_accounts.balance_int` using the computed post-balance inside the same transaction.

### Testing
- Ran `go test ./internal/wallet ./internal/app -count=1` which passed.

Checklist (aligned to deliverable tracking):
- [x] Bugfix: ledger insert updated to include `balance_after_int` and argument ordering corrected.
- [x] Automated tests for `internal/wallet` and `internal/app` executed and succeeded.
- [ ] Verify broader `docs/implementation_plan.md` milestone M2.1 items remain to be completed.
- [ ] Further alignment with `docs/llm_stream_orchestration_plan.md` still required for full orchestration behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74736ec1c832c9cbb098df2aec105)