### PR TITLE
fix: use UUID ids for Postgres scenario records

### DIFF
--- a/internal/prompts/game_scenario_postgres.go
+++ b/internal/prompts/game_scenario_postgres.go
@@ -57,7 +57,7 @@ ORDER BY game_slug ASC, version DESC, created_at DESC`)
 
 func (s *PostgresGameScenarioStore) Create(ctx context.Context, item GameScenario) (GameScenario, error) {
 	if item.ID == "" {
-		item.ID = "game-scenario-" + uuid.NewString()
+		item.ID = uuid.NewString()
 	}
 	if item.CreatedAt.IsZero() {
 		item.CreatedAt = time.Now().UTC()

--- a/internal/prompts/scenario_flow_postgres.go
+++ b/internal/prompts/scenario_flow_postgres.go
@@ -57,7 +57,7 @@ ORDER BY game_slug ASC, version DESC, created_at DESC`)
 
 func (s *PostgresScenarioPackageStore) Create(ctx context.Context, item ScenarioPackage) (ScenarioPackage, error) {
 	if item.ID == "" {
-		item.ID = "scenario-pkg-" + uuid.NewString()
+		item.ID = uuid.NewString()
 	}
 	if strings.TrimSpace(item.GameSlug) == "" {
 		item.GameSlug = "global"


### PR DESCRIPTION
### Motivation
- Inserting prefixed IDs like `scenario-pkg-<uuid>` and `game-scenario-<uuid>` into Postgres `UUID` columns caused `invalid input syntax for type uuid (SQLSTATE 22P02)`, so ID generation must produce plain UUIDs to match the `llm_scenarios` and `llm_game_scenarios` schema.

### Description
- Replace prefixed ID generation with plain UUIDs by using `uuid.NewString()` in `PostgresScenarioPackageStore.Create` (`internal/prompts/scenario_flow_postgres.go`).
- Replace prefixed ID generation with plain UUIDs by using `uuid.NewString()` in `PostgresGameScenarioStore.Create` (`internal/prompts/game_scenario_postgres.go`).

### Testing
- Ran `go test ./internal/prompts/...` which passed successfully and verifies the affected package behavior. 
- Checklist: [x] Fixed DB UUID mismatch, [x] Updated Postgres persistence for scenario packages and game scenarios, [ ] Full scenario-graph v2 alignment review (follow-up per M2.1 and `docs/llm_stream_orchestration_plan.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ee48cb90832c94fd2d6c96799e8f)