### PR TITLE
Fix empty admin scenario packages list due to wrong DB column

### DIFF
--- a/internal/prompts/scenario_flow_postgres.go
+++ b/internal/prompts/scenario_flow_postgres.go
@@ -32,7 +32,7 @@ func NewPostgresScenarioPackageStore(db *sql.DB) *PostgresScenarioPackageStore {
 
 func (s *PostgresScenarioPackageStore) List(ctx context.Context) ([]ScenarioPackage, error) {
 	rows, err := s.db.QueryContext(ctx, `
-SELECT id, name, version, game_slug, llm_model_config_id, is_active,
+SELECT id, name, version, game_slug, model_config_id, is_active,
        nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
 FROM llm_scenarios
 ORDER BY game_slug ASC, version DESC, created_at DESC`)

--- a/internal/prompts/scenario_flow_postgres_test.go
+++ b/internal/prompts/scenario_flow_postgres_test.go
@@ -112,3 +112,40 @@ LIMIT 1`)).
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestPostgresScenarioPackageStoreList(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresScenarioPackageStore(db)
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	steps := `[{"id":"s1","name":"step-1","order":1}]`
+	transitions := `[]`
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, name, version, game_slug, model_config_id, is_active,
+       nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
+FROM llm_scenarios
+ORDER BY game_slug ASC, version DESC, created_at DESC`)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "version", "game_slug", "model_config_id", "is_active",
+			"nodes_json", "transitions_json", "metadata", "created_by", "activated_by", "created_at", "activated_at",
+		}).AddRow("scenario-pkg-1", "pkg", 2, "global", "", true, []byte(steps), []byte(transitions), []byte(`{}`), "admin", "admin", now, now))
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("store.List: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one item, got %d", len(items))
+	}
+	if items[0].ID != "scenario-pkg-1" {
+		t.Fatalf("unexpected id: %s", items[0].ID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- The admin endpoint for listing scenario packages could return no records because the Postgres list query referenced a stale column name (`llm_model_config_id`) that does not exist in the `llm_scenarios` table, causing DB query failure and fallback to in-memory state.

### Description
- Fixed the `SELECT` projection in `PostgresScenarioPackageStore.List` to use `model_config_id` instead of `llm_model_config_id` in `internal/prompts/scenario_flow_postgres.go`.
- Added a regression test `TestPostgresScenarioPackageStoreList` in `internal/prompts/scenario_flow_postgres_test.go` that verifies the `List` query and proper row scanning of `llm_scenarios` rows.
- No schema/migration changes were made in this patch; the change aligns query column names with existing migration `migrations/0005_llm.up.sql`.

### Testing
- Ran `go test ./internal/prompts -run TestPostgresScenarioPackageStore -count=1` and the tests passed successfully.
- Checklist (aligned with `docs/implementation_plan.md` / `docs/llm_stream_orchestration_plan.md`):
  - [x] Fix `PostgresScenarioPackageStore.List` query to use correct DB column.
  - [x] Add regression test to prevent this mismatch from recurring.
  - [ ] Perform full milestone **M2.1** verification across `docs/implementation_plan.md` (out of scope for this small fix).
  - [ ] Full review against `docs/llm_stream_orchestration_plan.md` behavioral requirements (out of scope for this small fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f5b1c6bc832cbe13c247ee97ec79)