### PR TITLE
Unify scenario storage into `llm_scenarios` with metadata-based kinds

### DIFF
--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -300,6 +300,21 @@ func TestAdminLLMGameScenarioRoutes(t *testing.T) {
 		t.Fatalf("expected created id, got %#v", created)
 	}
 
+	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/game-scenarios", nil)
+	listReq.Header.Set("Authorization", "Bearer "+adminToken)
+	listRes := httptest.NewRecorder()
+	handler.ServeHTTP(listRes, listReq)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("game scenario list status=%d body=%s", listRes.Code, listRes.Body.String())
+	}
+	var listed []map[string]any
+	if err := json.Unmarshal(listRes.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode game scenario list: %v", err)
+	}
+	if len(listed) != 1 || listed[0]["id"] != id || listed[0]["gameSlug"] != "cs2" {
+		t.Fatalf("expected created game scenario in list, got %#v", listed)
+	}
+
 	getReq := httptest.NewRequest(http.MethodGet, "/api/admin/llm/game-scenarios/"+id, nil)
 	getReq.Header.Set("Authorization", "Bearer "+adminToken)
 	getRes := httptest.NewRecorder()

--- a/internal/prompts/game_scenario_postgres.go
+++ b/internal/prompts/game_scenario_postgres.go
@@ -30,12 +30,19 @@ func NewPostgresGameScenarioStore(db *sql.DB) *PostgresGameScenarioStore {
 	return &PostgresGameScenarioStore{db: db}
 }
 
+const gameScenarioStorageSlugPrefix = "game_scenario:"
+
+func gameScenarioStorageSlug(gameSlug string) string {
+	return gameScenarioStorageSlugPrefix + strings.TrimSpace(gameSlug)
+}
+
 func (s *PostgresGameScenarioStore) List(ctx context.Context) ([]GameScenario, error) {
 	rows, err := s.db.QueryContext(ctx, `
 SELECT id, name, version, game_slug, is_active, initial_node_id,
-       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
-FROM llm_game_scenarios
-ORDER BY game_slug ASC, version DESC, created_at DESC`)
+       nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
+FROM llm_scenarios
+WHERE metadata->>'kind' = 'game_scenario'
+ORDER BY COALESCE(metadata->>'gameSlug', game_slug) ASC, version DESC, created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -67,13 +74,13 @@ func (s *PostgresGameScenarioStore) Create(ctx context.Context, item GameScenari
 	}
 
 	var version int
-	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(version), 0) + 1 FROM llm_game_scenarios WHERE game_slug = $1`, item.GameSlug).Scan(&version); err != nil {
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(version), 0) + 1 FROM llm_scenarios WHERE COALESCE(metadata->>'gameSlug', game_slug) = $1 AND metadata->>'kind' = 'game_scenario'`, item.GameSlug).Scan(&version); err != nil {
 		return GameScenario{}, err
 	}
 	item.Version = version
 
 	var hasActive bool
-	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM llm_game_scenarios WHERE is_active = TRUE)`).Scan(&hasActive); err != nil {
+	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM llm_scenarios WHERE is_active = TRUE AND metadata->>'kind' = 'game_scenario')`).Scan(&hasActive); err != nil {
 		return GameScenario{}, err
 	}
 	if !hasActive {
@@ -88,13 +95,13 @@ func (s *PostgresGameScenarioStore) Create(ctx context.Context, item GameScenari
 	}
 
 	_, err = s.db.ExecContext(ctx, `
-INSERT INTO llm_game_scenarios (
+INSERT INTO llm_scenarios (
 	id, game_slug, name, version, is_active, initial_node_id,
-	nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
+	nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11, $12)`,
-		item.ID, item.GameSlug, item.Name, item.Version, item.IsActive, item.InitialNodeID,
-		nodesJSON, transitionsJSON, item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt),
+VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9::jsonb, $10, $11, $12, $13)`,
+		item.ID, gameScenarioStorageSlug(item.GameSlug), item.Name, item.Version, item.IsActive, item.InitialNodeID,
+		nodesJSON, transitionsJSON, gameScenarioMetadataJSON(item), item.CreatedBy, item.ActivatedBy, item.CreatedAt, nullableTime(item.ActivatedAt),
 	)
 	if err != nil {
 		return GameScenario{}, err
@@ -109,18 +116,19 @@ func (s *PostgresGameScenarioStore) Update(ctx context.Context, item GameScenari
 	}
 
 	res, err := s.db.ExecContext(ctx, `
-UPDATE llm_game_scenarios
+UPDATE llm_scenarios
 SET game_slug = $2,
 	name = $3,
 	is_active = $4,
 	initial_node_id = $5,
 	nodes_json = $6::jsonb,
 	transitions_json = $7::jsonb,
-	activated_by = $8,
-	activated_at = $9
-WHERE id = $1`,
-		item.ID, item.GameSlug, item.Name, item.IsActive, item.InitialNodeID,
-		nodesJSON, transitionsJSON, item.ActivatedBy, nullableTime(item.ActivatedAt),
+	metadata = $8::jsonb,
+	activated_by = $9,
+	activated_at = $10
+WHERE id = $1 AND metadata->>'kind' = 'game_scenario'`,
+		item.ID, gameScenarioStorageSlug(item.GameSlug), item.Name, item.IsActive, item.InitialNodeID,
+		nodesJSON, transitionsJSON, gameScenarioMetadataJSON(item), item.ActivatedBy, nullableTime(item.ActivatedAt),
 	)
 	if err != nil {
 		return GameScenario{}, err
@@ -143,7 +151,7 @@ func (s *PostgresGameScenarioStore) Delete(ctx context.Context, id string) error
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	res, err := tx.ExecContext(ctx, `DELETE FROM llm_game_scenarios WHERE id = $1`, id)
+	res, err := tx.ExecContext(ctx, `DELETE FROM llm_scenarios WHERE id = $1 AND metadata->>'kind' = 'game_scenario'`, id)
 	if err != nil {
 		return err
 	}
@@ -155,7 +163,8 @@ func (s *PostgresGameScenarioStore) Delete(ctx context.Context, id string) error
 		var replacementID string
 		err = tx.QueryRowContext(ctx, `
 SELECT id
-FROM llm_game_scenarios
+FROM llm_scenarios
+WHERE metadata->>'kind' = 'game_scenario'
 ORDER BY created_at DESC, id DESC
 LIMIT 1`).Scan(&replacementID)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -163,7 +172,7 @@ LIMIT 1`).Scan(&replacementID)
 		}
 		if replacementID != "" {
 			now := time.Now().UTC()
-			if _, err := tx.ExecContext(ctx, `UPDATE llm_game_scenarios SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1`, replacementID, item.ActivatedBy, now); err != nil {
+			if _, err := tx.ExecContext(ctx, `UPDATE llm_scenarios SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 AND metadata->>'kind' = 'game_scenario'`, replacementID, item.ActivatedBy, now); err != nil {
 				return err
 			}
 		}
@@ -186,10 +195,10 @@ func (s *PostgresGameScenarioStore) SetActive(ctx context.Context, id string, ac
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	if _, err := tx.ExecContext(ctx, `UPDATE llm_game_scenarios SET is_active = FALSE, activated_by = '', activated_at = NULL WHERE is_active = TRUE`); err != nil {
+	if _, err := tx.ExecContext(ctx, `UPDATE llm_scenarios SET is_active = FALSE, activated_by = '', activated_at = NULL WHERE is_active = TRUE AND metadata->>'kind' = 'game_scenario'`); err != nil {
 		return GameScenario{}, err
 	}
-	res, err := tx.ExecContext(ctx, `UPDATE llm_game_scenarios SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1`, id, actorID, now)
+	res, err := tx.ExecContext(ctx, `UPDATE llm_scenarios SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 AND metadata->>'kind' = 'game_scenario'`, id, actorID, now)
 	if err != nil {
 		return GameScenario{}, err
 	}
@@ -206,9 +215,9 @@ func (s *PostgresGameScenarioStore) SetActive(ctx context.Context, id string, ac
 func (s *PostgresGameScenarioStore) GetByID(ctx context.Context, id string) (GameScenario, error) {
 	row := s.db.QueryRowContext(ctx, `
 SELECT id, name, version, game_slug, is_active, initial_node_id,
-       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
-FROM llm_game_scenarios
-WHERE id = $1`, id)
+       nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
+FROM llm_scenarios
+WHERE id = $1 AND metadata->>'kind' = 'game_scenario'`, id)
 	item, err := scanGameScenario(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return GameScenario{}, ErrGameScenarioNotFound
@@ -219,9 +228,9 @@ WHERE id = $1`, id)
 func (s *PostgresGameScenarioStore) GetActiveByGameSlug(ctx context.Context, gameSlug string) (GameScenario, error) {
 	row := s.db.QueryRowContext(ctx, `
 SELECT id, name, version, game_slug, is_active, initial_node_id,
-       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
-FROM llm_game_scenarios
-WHERE game_slug = $1 AND is_active = TRUE
+       nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
+FROM llm_scenarios
+WHERE COALESCE(metadata->>'gameSlug', game_slug) = $1 AND is_active = TRUE AND metadata->>'kind' = 'game_scenario'
 LIMIT 1`, gameSlug)
 	item, err := scanGameScenario(row)
 	if err == nil {
@@ -232,9 +241,9 @@ LIMIT 1`, gameSlug)
 	}
 	fallback := s.db.QueryRowContext(ctx, `
 SELECT id, name, version, game_slug, is_active, initial_node_id,
-       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
-FROM llm_game_scenarios
-WHERE is_active = TRUE
+       nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
+FROM llm_scenarios
+WHERE is_active = TRUE AND metadata->>'kind' = 'game_scenario'
 ORDER BY created_at DESC, id DESC
 LIMIT 1`)
 	item, err = scanGameScenario(fallback)
@@ -253,6 +262,7 @@ func scanGameScenario(scanner gameScenarioScanner) (GameScenario, error) {
 	var activatedAt sql.NullTime
 	var nodesRaw []byte
 	var transitionsRaw []byte
+	var metadataRaw []byte
 	err := scanner.Scan(
 		&item.ID,
 		&item.Name,
@@ -262,6 +272,7 @@ func scanGameScenario(scanner gameScenarioScanner) (GameScenario, error) {
 		&item.InitialNodeID,
 		&nodesRaw,
 		&transitionsRaw,
+		&metadataRaw,
 		&item.CreatedBy,
 		&item.ActivatedBy,
 		&item.CreatedAt,
@@ -280,10 +291,29 @@ func scanGameScenario(scanner gameScenarioScanner) (GameScenario, error) {
 			return GameScenario{}, fmt.Errorf("unmarshal transitions_json: %w", err)
 		}
 	}
+	if len(metadataRaw) > 0 {
+		var metadata struct {
+			GameSlug string `json:"gameSlug"`
+		}
+		if err := json.Unmarshal(metadataRaw, &metadata); err != nil {
+			return GameScenario{}, fmt.Errorf("unmarshal metadata: %w", err)
+		}
+		if strings.TrimSpace(metadata.GameSlug) != "" {
+			item.GameSlug = strings.TrimSpace(metadata.GameSlug)
+		}
+	}
 	if activatedAt.Valid {
 		item.ActivatedAt = activatedAt.Time
 	}
 	return item, nil
+}
+
+func gameScenarioMetadataJSON(item GameScenario) []byte {
+	raw, _ := json.Marshal(map[string]string{
+		"kind":     "game_scenario",
+		"gameSlug": strings.TrimSpace(item.GameSlug),
+	})
+	return raw
 }
 
 func encodeGameScenarioPayload(item GameScenario) ([]byte, []byte, error) {

--- a/internal/prompts/game_scenario_postgres_test.go
+++ b/internal/prompts/game_scenario_postgres_test.go
@@ -19,24 +19,25 @@ func TestPostgresGameScenarioStoreCreate(t *testing.T) {
 	store := NewPostgresGameScenarioStore(db)
 	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(version), 0) + 1 FROM llm_game_scenarios WHERE game_slug = $1`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(version), 0) + 1 FROM llm_scenarios WHERE COALESCE(metadata->>'gameSlug', game_slug) = $1 AND metadata->>'kind' = 'game_scenario'`)).
 		WithArgs("cs2").
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(1))
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (SELECT 1 FROM llm_game_scenarios WHERE is_active = TRUE)`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (SELECT 1 FROM llm_scenarios WHERE is_active = TRUE AND metadata->>'kind' = 'game_scenario')`)).
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 	mock.ExpectExec(regexp.QuoteMeta(`
-INSERT INTO llm_game_scenarios (
+INSERT INTO llm_scenarios (
 	id, game_slug, name, version, is_active, initial_node_id,
-	nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
+	nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11, $12)`)).
+VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9::jsonb, $10, $11, $12, $13)`)).
 		WithArgs(
 			sqlmock.AnyArg(),
-			"cs2",
+			"game_scenario:cs2",
 			"scenario",
 			1,
 			true,
 			"n1",
+			sqlmock.AnyArg(),
 			sqlmock.AnyArg(),
 			sqlmock.AnyArg(),
 			"admin",
@@ -68,6 +69,103 @@ VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11, $12)`)).
 	}
 }
 
+func TestPostgresGameScenarioStoreListReturnsAdminGameSlug(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresGameScenarioStore(db)
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	nodes := `[{"id":"n1","scenarioPackageId":"pkg-1"}]`
+	transitions := `[]`
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, name, version, game_slug, is_active, initial_node_id,
+       nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
+FROM llm_scenarios
+WHERE metadata->>'kind' = 'game_scenario'
+ORDER BY COALESCE(metadata->>'gameSlug', game_slug) ASC, version DESC, created_at DESC`)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "version", "game_slug", "is_active", "initial_node_id",
+			"nodes_json", "transitions_json", "metadata", "created_by", "activated_by", "created_at", "activated_at",
+		}).AddRow("game-scenario-1", "scenario", 1, "game_scenario:cs2", true, "n1", []byte(nodes), []byte(transitions), []byte(`{"gameSlug":"cs2","kind":"game_scenario"}`), "admin", "admin", now, now))
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("store.List: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one item, got %d", len(items))
+	}
+	if items[0].GameSlug != "cs2" {
+		t.Fatalf("expected admin game slug cs2, got %s", items[0].GameSlug)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestPostgresGameScenarioStoreUpdateUsesStorageSlugAndReloads(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresGameScenarioStore(db)
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	nodes := `[{"id":"n1","scenarioPackageId":"pkg-1"}]`
+	transitions := `[]`
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+UPDATE llm_scenarios
+SET game_slug = $2,
+	name = $3,
+	is_active = $4,
+	initial_node_id = $5,
+	nodes_json = $6::jsonb,
+	transitions_json = $7::jsonb,
+	metadata = $8::jsonb,
+	activated_by = $9,
+	activated_at = $10
+WHERE id = $1 AND metadata->>'kind' = 'game_scenario'`)).
+		WithArgs("game-scenario-1", "game_scenario:cs2", "updated", true, "n1", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "admin", now).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, name, version, game_slug, is_active, initial_node_id,
+       nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
+FROM llm_scenarios
+WHERE id = $1 AND metadata->>'kind' = 'game_scenario'`)).
+		WithArgs("game-scenario-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "version", "game_slug", "is_active", "initial_node_id",
+			"nodes_json", "transitions_json", "metadata", "created_by", "activated_by", "created_at", "activated_at",
+		}).AddRow("game-scenario-1", "updated", 2, "game_scenario:cs2", true, "n1", []byte(nodes), []byte(transitions), []byte(`{"gameSlug":"cs2","kind":"game_scenario"}`), "admin", "admin", now, now))
+
+	item, err := store.Update(context.Background(), GameScenario{
+		ID:            "game-scenario-1",
+		Name:          "updated",
+		GameSlug:      "cs2",
+		Version:       2,
+		IsActive:      true,
+		InitialNodeID: "n1",
+		Nodes:         []GameScenarioNode{{ID: "n1", ScenarioPackageID: "pkg-1"}},
+		ActivatedBy:   "admin",
+		ActivatedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("store.Update: %v", err)
+	}
+	if item.GameSlug != "cs2" || item.Name != "updated" {
+		t.Fatalf("unexpected updated item: %#v", item)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestPostgresGameScenarioStoreGetActiveByGameSlugFallsBackToGlobal(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -82,27 +180,27 @@ func TestPostgresGameScenarioStoreGetActiveByGameSlugFallsBackToGlobal(t *testin
 
 	mock.ExpectQuery(regexp.QuoteMeta(`
 SELECT id, name, version, game_slug, is_active, initial_node_id,
-       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
-FROM llm_game_scenarios
-WHERE game_slug = $1 AND is_active = TRUE
+       nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
+FROM llm_scenarios
+WHERE COALESCE(metadata->>'gameSlug', game_slug) = $1 AND is_active = TRUE AND metadata->>'kind' = 'game_scenario'
 LIMIT 1`)).
 		WithArgs("dota2").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "name", "version", "game_slug", "is_active", "initial_node_id",
-			"nodes_json", "transitions_json", "created_by", "activated_by", "created_at", "activated_at",
+			"nodes_json", "transitions_json", "metadata", "created_by", "activated_by", "created_at", "activated_at",
 		}))
 
 	mock.ExpectQuery(regexp.QuoteMeta(`
 SELECT id, name, version, game_slug, is_active, initial_node_id,
-       nodes_json, transitions_json, created_by, activated_by, created_at, activated_at
-FROM llm_game_scenarios
-WHERE is_active = TRUE
+       nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
+FROM llm_scenarios
+WHERE is_active = TRUE AND metadata->>'kind' = 'game_scenario'
 ORDER BY created_at DESC, id DESC
 LIMIT 1`)).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "name", "version", "game_slug", "is_active", "initial_node_id",
-			"nodes_json", "transitions_json", "created_by", "activated_by", "created_at", "activated_at",
-		}).AddRow("game-scenario-1", "scenario", 1, "cs2", true, "n1", []byte(nodes), []byte(transitions), "admin", "admin", now, now))
+			"nodes_json", "transitions_json", "metadata", "created_by", "activated_by", "created_at", "activated_at",
+		}).AddRow("game-scenario-1", "scenario", 1, "cs2", true, "n1", []byte(nodes), []byte(transitions), []byte(`{"gameSlug":"cs2","kind":"game_scenario"}`), "admin", "admin", now, now))
 
 	item, err := store.GetActiveByGameSlug(context.Background(), "dota2")
 	if err != nil {

--- a/internal/prompts/scenario_flow_postgres.go
+++ b/internal/prompts/scenario_flow_postgres.go
@@ -35,6 +35,7 @@ func (s *PostgresScenarioPackageStore) List(ctx context.Context) ([]ScenarioPack
 SELECT id, name, version, game_slug, model_config_id, is_active,
        nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
 FROM llm_scenarios
+WHERE (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')
 ORDER BY game_slug ASC, version DESC, created_at DESC`)
 	if err != nil {
 		return nil, err
@@ -67,13 +68,13 @@ func (s *PostgresScenarioPackageStore) Create(ctx context.Context, item Scenario
 	}
 
 	var version int
-	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(version), 0) + 1 FROM llm_scenarios WHERE game_slug = $1`, item.GameSlug).Scan(&version); err != nil {
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(version), 0) + 1 FROM llm_scenarios WHERE game_slug = $1 AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')`, item.GameSlug).Scan(&version); err != nil {
 		return ScenarioPackage{}, err
 	}
 	item.Version = version
 
 	var hasAny bool
-	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM llm_scenarios WHERE game_slug = $1)`, item.GameSlug).Scan(&hasAny); err != nil {
+	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM llm_scenarios WHERE game_slug = $1 AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package'))`, item.GameSlug).Scan(&hasAny); err != nil {
 		return ScenarioPackage{}, err
 	}
 	if !hasAny {
@@ -123,7 +124,7 @@ SET game_slug = $2,
 	is_active = $9,
 	activated_by = $10,
 	activated_at = $11
-WHERE id = $1`,
+WHERE id = $1 AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')`,
 		item.ID, item.GameSlug, item.Name, item.LLMModelConfigID, initialStepID(item.Steps), stepsJSON, legacyStepTransitionsJSON(item.Transitions), scenarioMetadataJSON(item),
 		item.IsActive, item.ActivatedBy, nullableTime(item.ActivatedAt),
 	)
@@ -148,7 +149,7 @@ func (s *PostgresScenarioPackageStore) Delete(ctx context.Context, id string) er
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	res, err := tx.ExecContext(ctx, `DELETE FROM llm_scenarios WHERE id = $1`, id)
+	res, err := tx.ExecContext(ctx, `DELETE FROM llm_scenarios WHERE id = $1 AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')`, id)
 	if err != nil {
 		return err
 	}
@@ -161,7 +162,7 @@ func (s *PostgresScenarioPackageStore) Delete(ctx context.Context, id string) er
 		err = tx.QueryRowContext(ctx, `
 SELECT id
 FROM llm_scenarios
-WHERE game_slug = $1
+WHERE game_slug = $1 AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')
 ORDER BY version DESC, created_at DESC, id DESC
 LIMIT 1`, item.GameSlug).Scan(&replacementID)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -169,7 +170,7 @@ LIMIT 1`, item.GameSlug).Scan(&replacementID)
 		}
 		if replacementID != "" {
 			now := time.Now().UTC()
-			if _, err := tx.ExecContext(ctx, `UPDATE llm_scenarios SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1`, replacementID, item.ActivatedBy, now); err != nil {
+			if _, err := tx.ExecContext(ctx, `UPDATE llm_scenarios SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')`, replacementID, item.ActivatedBy, now); err != nil {
 				return err
 			}
 		}
@@ -193,10 +194,10 @@ func (s *PostgresScenarioPackageStore) SetActive(ctx context.Context, id string,
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	if _, err := tx.ExecContext(ctx, `UPDATE llm_scenarios SET is_active = FALSE WHERE game_slug = $1 AND is_active = TRUE`, item.GameSlug); err != nil {
+	if _, err := tx.ExecContext(ctx, `UPDATE llm_scenarios SET is_active = FALSE WHERE game_slug = $1 AND is_active = TRUE AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')`, item.GameSlug); err != nil {
 		return ScenarioPackage{}, err
 	}
-	res, err := tx.ExecContext(ctx, `UPDATE llm_scenarios SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1`, id, actorID, now)
+	res, err := tx.ExecContext(ctx, `UPDATE llm_scenarios SET is_active = TRUE, activated_by = $2, activated_at = $3 WHERE id = $1 AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')`, id, actorID, now)
 	if err != nil {
 		return ScenarioPackage{}, err
 	}
@@ -215,7 +216,7 @@ func (s *PostgresScenarioPackageStore) GetByID(ctx context.Context, id string) (
 SELECT id, name, version, game_slug, model_config_id, is_active,
        nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
 FROM llm_scenarios
-WHERE id = $1`, id)
+WHERE id = $1 AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')`, id)
 	item, err := scanScenarioPackage(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ScenarioPackage{}, ErrScenarioPackageNotFound
@@ -228,7 +229,7 @@ func (s *PostgresScenarioPackageStore) GetActiveByGameSlug(ctx context.Context, 
 SELECT id, name, version, game_slug, model_config_id, is_active,
        nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
 FROM llm_scenarios
-WHERE game_slug = $1 AND is_active = TRUE
+WHERE game_slug = $1 AND is_active = TRUE AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')
 LIMIT 1`, gameSlug)
 	item, err := scanScenarioPackage(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -323,10 +324,16 @@ func legacyStepTransitionsJSON(transitions []ScenarioTransition) []byte {
 }
 
 func scenarioMetadataJSON(item ScenarioPackage) []byte {
-	raw, _ := json.Marshal(transitionsPayload{
-		PackageTransitions: item.PackageTransitions,
-		FinalStateOptions:  item.FinalStateOptions,
-		FinalCondition:     strings.TrimSpace(item.FinalCondition),
+	raw, _ := json.Marshal(struct {
+		Kind string `json:"kind"`
+		transitionsPayload
+	}{
+		Kind: "scenario_package",
+		transitionsPayload: transitionsPayload{
+			PackageTransitions: item.PackageTransitions,
+			FinalStateOptions:  item.FinalStateOptions,
+			FinalCondition:     strings.TrimSpace(item.FinalCondition),
+		},
 	})
 	return raw
 }

--- a/internal/prompts/scenario_flow_postgres_test.go
+++ b/internal/prompts/scenario_flow_postgres_test.go
@@ -19,10 +19,10 @@ func TestPostgresScenarioPackageStoreCreate(t *testing.T) {
 	store := NewPostgresScenarioPackageStore(db)
 	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(version), 0) + 1 FROM llm_scenarios WHERE game_slug = $1`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(version), 0) + 1 FROM llm_scenarios WHERE game_slug = $1 AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')`)).
 		WithArgs("global").
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(1))
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (SELECT 1 FROM llm_scenarios WHERE game_slug = $1)`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (SELECT 1 FROM llm_scenarios WHERE game_slug = $1 AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package'))`)).
 		WithArgs("global").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 	mock.ExpectExec(regexp.QuoteMeta(`
@@ -90,7 +90,7 @@ func TestPostgresScenarioPackageStoreGetActiveByGameSlug(t *testing.T) {
 SELECT id, name, version, game_slug, model_config_id, is_active,
        nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
 FROM llm_scenarios
-WHERE game_slug = $1 AND is_active = TRUE
+WHERE game_slug = $1 AND is_active = TRUE AND (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')
 LIMIT 1`)).
 		WithArgs("global").
 		WillReturnRows(sqlmock.NewRows([]string{
@@ -129,6 +129,7 @@ func TestPostgresScenarioPackageStoreList(t *testing.T) {
 SELECT id, name, version, game_slug, model_config_id, is_active,
        nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
 FROM llm_scenarios
+WHERE (metadata->>'kind' IS NULL OR metadata->>'kind' = 'scenario_package')
 ORDER BY game_slug ASC, version DESC, created_at DESC`)).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "name", "version", "game_slug", "model_config_id", "is_active",


### PR DESCRIPTION
### Motivation

- Consolidate separate tables for game scenarios and scenario packages into a single `llm_scenarios` storage and distinguish types via a `metadata.kind` field.

### Description

- Replaced usages of `llm_game_scenarios` with `llm_scenarios` and added `metadata` JSON handling for `game_scenario` and `scenario_package` kinds. 
- Added `gameScenarioStorageSlug` prefix and store-side metadata builders `gameScenarioMetadataJSON` and `scenarioMetadataJSON` and updated `scanGameScenario` to read `gameSlug` from metadata when present. 
- Updated all CRUD and activation queries (`List`, `Create`, `Update`, `Delete`, `SetActive`, `GetByID`, `GetActiveByGameSlug`) to filter by `metadata->>'kind'` or allow `NULL` for legacy `scenario_package` entries. 
- Adjusted `scenario_package` metadata to embed `Kind: "scenario_package"` and updated encoding functions to produce the new metadata shape. 
- Updated and added SQL-backed unit tests and an admin router test to reflect new queries, storage slug usage, and metadata fields.

### Testing

- Ran updated unit tests including `TestPostgresGameScenarioStoreCreate`, `TestPostgresGameScenarioStoreListReturnsAdminGameSlug`, `TestPostgresGameScenarioStoreUpdateUsesStorageSlugAndReloads`, `TestPostgresGameScenarioStoreGetActiveByGameSlugFallsBackToGlobal`, `TestPostgresScenarioPackageStoreCreate`, `TestPostgresScenarioPackageStoreGetActiveByGameSlug`, `TestPostgresScenarioPackageStoreList`, and modified `TestAdminLLMGameScenarioRoutes` using `sqlmock` and `httptest`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2bf37e90832cad6a3efa20a6c737)