### PR TITLE
Streamlink continuous capture: assemble contiguous 1s segments into step-sized chunks and cleanup

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -56,8 +56,11 @@ business logic and immediate backend scope.
   (`/api/admin/llm/scenario-packages` + activation + graph).
 - [x] Remove legacy admin surfaces for prompt versions, state schemas, rule sets, and model-config CRUD across code + docs.
 - [ ] Re-introduce scenario-package persistence in storage (PostgreSQL) after the scenario-only cleanup baseline stabilizes.
-- [ ] Implement stream capture worker pipeline:
-  `streamlink -> media chunking -> previous_state + new_chunk -> updated_state`.
+- [x] Implement stream capture worker pipeline:
+  `streamlink -> media chunking -> previous_state + new_chunk -> updated_state`,
+  including step-level `segmentSeconds` assembly from contiguous source segments
+  so no seconds are skipped between LLM chunks, plus cleanup of consumed source
+  segments, assembled local videos, and stale artifacts from interrupted sessions.
 - [ ] Implement match-session lifecycle so one detected match is tracked as one
   chat/session with explicit persisted state JSON.
 - [ ] Ship the initial Counter-Strike tracker flow:

--- a/docs/llm_stream_orchestration_plan.md
+++ b/docs/llm_stream_orchestration_plan.md
@@ -59,6 +59,10 @@ Current orchestration uses only the model below:
   - transition by priority,
   - stay-on-step fallback.
 - Wire worker to prefer scenario package execution when present.
+- Preserve continuous video coverage when applying each step `segmentSeconds`: capture
+  a continuous per-streamer source timeline and assemble LLM chunks from consecutive
+  segments without dropping any seconds between adjacent LLM requests, and clean
+  up consumed local source/assembled video files after they are no longer needed.
 
 ## Deferred (next iteration)
 - Database persistence and versioning for scenario packages.

--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -41,9 +41,9 @@
 - **Assertions**: 99% of clients receive updates within 1 s; dropped message rate < 0.5%.
 
 ### S7 – Streamlink Capture Cadence & Idempotency
-- **Path**: background `streamlink -> LLM` scheduler for active streamers.
-- **Profile**: 100 active streamers across 15 minutes with a fixed 10-second capture cadence.
-- **Assertions**: no streamer executes more than one capture cycle per 10-second window; duplicate scheduler starts do not increase chunk volume; worker busy skips remain below 1% after warm-up.
+- **Path**: background `streamlink -> 1-second source segments -> assembled LLM chunk` scheduler for active streamers.
+- **Profile**: 100 active streamers across 15 minutes with mixed Scenario Package v2 `segmentSeconds` values (for example 10, 15, and 30 seconds).
+- **Assertions**: no streamer executes more than one capture cycle per configured step window; duplicate scheduler starts do not increase chunk volume; worker busy skips remain below 1% after warm-up; assembled LLM chunks advance through contiguous segment indexes with no gaps or duplicates; consumed source segments, analyzed/uploaded local videos, and stale interrupted-session artifacts do not accumulate on disk.
 
 ## Metrics Collection
 - Export `http_server_duration_seconds` (histograms) to Prometheus.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -98,10 +98,17 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 > the previous capture overruns the window.
 >
 > Stream capture now runs as a long-lived Streamlink→FFmpeg pipeline per streamer
-> and cuts sequential ~30s segments continuously (`%09d.mp4`) to minimize boundary
-> loss between chunks.
+> and cuts sequential 1-second source segments continuously (`%09d.mp4`).
+> The worker assembles the exact number of consecutive source segments requested
+> by the active Scenario Package v2 step `segmentSeconds`, so admins can tune
+> LLM chunk length while preserving contiguous coverage with no skipped seconds
+> between chunks.
 >
-> Each ~30s chunk is analyzed immediately by the worker.
+> Each assembled step-sized chunk is analyzed immediately by the worker, then
+> the local assembled video is deleted after analysis/upload; consumed 1-second
+> source segments are deleted as soon as they are assembled into an LLM chunk.
+> When a new continuous capture session starts, stale local stream artifacts from
+> previous interrupted sessions are removed from the streamer output directory.
 > In parallel, chunks are accumulated and merged via `ffmpeg -c copy` (no re-encoding)
 > into ~2-minute windows (`FUNPOT_STREAMLINK_ARCHIVE_AGGREGATE_COUNT` controls batch size),
 > then uploaded to Bunny Stream when Bunny credentials are configured.

--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -44,6 +44,7 @@ const defaultPreferredStreamQuality = "1080p60,1080p,720p60,720p,936p60,936p,648
 const defaultStreamlinkCaptureTimeout = 30 * time.Second
 const streamlinkCaptureShutdownGracePeriod = 5 * time.Second
 const continuousSegmentStabilityWindow = 1500 * time.Millisecond
+const continuousCaptureSegmentUnit = time.Second
 
 type StreamlinkChannelResolver interface {
 	ResolveStreamlinkChannel(ctx context.Context, streamerID string) (string, error)
@@ -97,6 +98,7 @@ type continuousCaptureSession struct {
 }
 
 func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver StreamlinkChannelResolver, runner StreamlinkCommandRunner) *StreamlinkCaptureAdapter {
+	usesDefaultRunner := runner == nil
 	if strings.TrimSpace(cfg.BinaryPath) == "" {
 		cfg.BinaryPath = "streamlink"
 	}
@@ -123,7 +125,7 @@ func NewStreamlinkCaptureAdapter(cfg StreamlinkCaptureConfig, resolver Streamlin
 		runner:     runner,
 		normalizer: NewFFmpegChunkNormalizer(cfg.FFmpegBinary, runner),
 		nowFn:      time.Now,
-		continuous: false,
+		continuous: usesDefaultRunner,
 		sessions:   make(map[string]*continuousCaptureSession),
 	}
 }
@@ -318,8 +320,10 @@ func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, stream
 		return ChunkRef{}, session.lastErr
 	}
 
+	segmentCount := continuousSegmentCount(captureTimeout)
 	targetIndex := session.nextIndex
-	deadline := time.Now().Add(captureTimeout + streamlinkCaptureShutdownGracePeriod)
+	lastIndex := targetIndex + segmentCount - 1
+	deadline := time.Now().Add(captureTimeout + continuousCaptureSegmentUnit + streamlinkCaptureShutdownGracePeriod)
 	lastObservedSize := int64(-1)
 	var lastSizeChangedAt time.Time
 	for {
@@ -328,45 +332,43 @@ func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, stream
 			return ChunkRef{}, ctx.Err()
 		default:
 		}
-		segmentPath := filepath.Join(session.segmentsDir, fmt.Sprintf("%09d.mp4", targetIndex))
-		info, statErr := os.Stat(segmentPath)
-		nextSegmentPath := filepath.Join(session.segmentsDir, fmt.Sprintf("%09d.mp4", targetIndex+1))
+
+		segmentPaths, segmentsReady := continuousSegmentPaths(session.segmentsDir, targetIndex, segmentCount)
+		nextSegmentPath := filepath.Join(session.segmentsDir, fmt.Sprintf("%09d.mp4", lastIndex+1))
 		nextInfo, nextErr := os.Stat(nextSegmentPath)
 		segmentFinalized := nextErr == nil && nextInfo.Size() > 0
 		finalizedByStability := false
-		if statErr == nil && info.Size() > 0 {
-			if info.Size() != lastObservedSize {
-				lastObservedSize = info.Size()
-				lastSizeChangedAt = time.Now()
-			}
-			stableByObservedSize := !lastSizeChangedAt.IsZero() && time.Since(lastSizeChangedAt) >= continuousSegmentStabilityWindow
-			stableByModTime := time.Since(info.ModTime()) >= continuousSegmentStabilityWindow
-			nearDeadline := time.Until(deadline) <= continuousSegmentStabilityWindow
-			if !segmentFinalized && stableByObservedSize && stableByModTime && nearDeadline {
-				segmentFinalized = true
-				finalizedByStability = true
+		if !segmentFinalized && segmentCount == 1 && segmentsReady {
+			info, statErr := os.Stat(segmentPaths[0])
+			if statErr == nil && info.Size() > 0 {
+				if info.Size() != lastObservedSize {
+					lastObservedSize = info.Size()
+					lastSizeChangedAt = time.Now()
+				}
+				stableByObservedSize := !lastSizeChangedAt.IsZero() && time.Since(lastSizeChangedAt) >= continuousSegmentStabilityWindow
+				stableByModTime := time.Since(info.ModTime()) >= continuousSegmentStabilityWindow
+				nearDeadline := time.Until(deadline) <= continuousSegmentStabilityWindow
+				if stableByObservedSize && stableByModTime && nearDeadline {
+					segmentFinalized = true
+					finalizedByStability = true
+				}
 			}
 		}
-		if statErr == nil && info.Size() > 0 && segmentFinalized {
-			chunkPath := filepath.Join(filepath.Dir(session.segmentsDir), fmt.Sprintf("%s.mp4", sanitizeToken(fmt.Sprintf("%09d", targetIndex))))
-			if finalizedByStability {
-				if err := copyFile(segmentPath, chunkPath); err != nil {
-					return ChunkRef{}, err
-				}
-			} else {
-				if err := os.Rename(segmentPath, chunkPath); err != nil {
-					return ChunkRef{}, err
-				}
+		if segmentsReady && segmentFinalized {
+			chunkPath, err := a.assembleContinuousChunk(ctx, session, targetIndex, segmentPaths, finalizedByStability)
+			if err != nil {
+				return ChunkRef{}, err
 			}
-			session.nextIndex++
+			session.nextIndex += segmentCount
+			logger.Info("continuous stream chunk assembled", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.Int("firstSegmentIndex", targetIndex), zap.Int("lastSegmentIndex", lastIndex), zap.Int("segmentSeconds", segmentCount))
 			return ChunkRef{Reference: chunkPath, CapturedAt: a.nowFn().UTC()}, nil
 		}
-		if statErr != nil {
+		if !segmentsReady {
 			lastObservedSize = -1
 			lastSizeChangedAt = time.Time{}
 		}
 		if time.Now().After(deadline) {
-			return ChunkRef{}, fmt.Errorf("%w: no continuous segment available before deadline", ErrStreamlinkNoData)
+			return ChunkRef{}, fmt.Errorf("%w: no continuous segment range %09d-%09d available before deadline", ErrStreamlinkNoData, targetIndex, lastIndex)
 		}
 		time.Sleep(250 * time.Millisecond)
 	}
@@ -395,12 +397,7 @@ func (a *StreamlinkCaptureAdapter) ensureContinuousSession(streamerID, channel s
 	if err := os.MkdirAll(session.segmentsDir, 0o755); err != nil {
 		return nil, err
 	}
-	for _, entry := range []string{"*.ts", "*.mp4"} {
-		matches, _ := filepath.Glob(filepath.Join(session.segmentsDir, entry))
-		for _, m := range matches {
-			_ = os.Remove(m)
-		}
-	}
+	cleanupContinuousSessionFiles(filepath.Dir(session.segmentsDir), session.segmentsDir)
 	session.started = true
 	session.lastErr = nil
 	go a.runContinuousSession(session)
@@ -418,7 +415,7 @@ func (a *StreamlinkCaptureAdapter) runContinuousSession(session *continuousCaptu
 		"-c", "copy",
 		"-f", "segment",
 		"-segment_format", "mp4",
-		"-segment_time", formatStreamlinkDurationArg(a.cfg.CaptureTimeout),
+		"-segment_time", formatStreamlinkDurationArg(continuousCaptureSegmentUnit),
 		"-segment_start_number", "1",
 		"-reset_timestamps", "1",
 		"-movflags", "+faststart",
@@ -466,6 +463,99 @@ func (a *StreamlinkCaptureAdapter) setSessionError(streamerID string, err error)
 	}
 	session.lastErr = err
 	session.started = false
+}
+
+func continuousSegmentCount(duration time.Duration) int {
+	if duration <= 0 {
+		duration = defaultStreamlinkCaptureTimeout
+	}
+	count := int(duration.Round(time.Second) / continuousCaptureSegmentUnit)
+	if count <= 0 {
+		count = 1
+	}
+	return count
+}
+
+func continuousSegmentPaths(segmentsDir string, startIndex, count int) ([]string, bool) {
+	if count <= 0 {
+		count = 1
+	}
+	paths := make([]string, 0, count)
+	for idx := startIndex; idx < startIndex+count; idx++ {
+		path := filepath.Join(segmentsDir, fmt.Sprintf("%09d.mp4", idx))
+		info, err := os.Stat(path)
+		if err != nil || info.Size() <= 0 {
+			return paths, false
+		}
+		paths = append(paths, path)
+	}
+	return paths, true
+}
+
+func (a *StreamlinkCaptureAdapter) assembleContinuousChunk(ctx context.Context, session *continuousCaptureSession, startIndex int, segmentPaths []string, copyOnly bool) (string, error) {
+	if len(segmentPaths) == 0 {
+		return "", ErrStreamlinkNoData
+	}
+	endIndex := startIndex + len(segmentPaths) - 1
+	chunkName := fmt.Sprintf("%09d.mp4", startIndex)
+	if len(segmentPaths) > 1 {
+		chunkName = fmt.Sprintf("%09d-%09d.mp4", startIndex, endIndex)
+	}
+	chunkPath := filepath.Join(filepath.Dir(session.segmentsDir), chunkName)
+	if len(segmentPaths) == 1 {
+		if copyOnly {
+			if err := copyFile(segmentPaths[0], chunkPath); err != nil {
+				return "", err
+			}
+			cleanupContinuousSegments(segmentPaths)
+		} else if err := os.Rename(segmentPaths[0], chunkPath); err != nil {
+			return "", err
+		}
+		return chunkPath, nil
+	}
+
+	listPath := filepath.Join(session.segmentsDir, fmt.Sprintf("concat_%09d_%09d.txt", startIndex, endIndex))
+	var list strings.Builder
+	for _, segmentPath := range segmentPaths {
+		list.WriteString("file '")
+		list.WriteString(strings.ReplaceAll(segmentPath, "'", "'\\''"))
+		list.WriteString("'\n")
+	}
+	if err := os.WriteFile(listPath, []byte(list.String()), 0o644); err != nil {
+		return "", err
+	}
+	defer os.Remove(listPath) //nolint:errcheck
+
+	var stderr strings.Builder
+	args := []string{"-y", "-f", "concat", "-safe", "0", "-i", listPath, "-c", "copy", "-movflags", "+faststart", chunkPath}
+	if err := a.runner.Run(ctx, io.Discard, &stderr, a.cfg.FFmpegBinary, args...); err != nil {
+		_ = os.Remove(chunkPath)
+		return "", fmt.Errorf("ffmpeg concat continuous segments failed: %w (stderr=%s)", err, strings.TrimSpace(stderr.String()))
+	}
+	cleanupContinuousSegments(segmentPaths)
+	return chunkPath, nil
+}
+
+func cleanupContinuousSegments(segmentPaths []string) {
+	for _, segmentPath := range segmentPaths {
+		_ = os.Remove(segmentPath)
+	}
+}
+
+func cleanupContinuousSessionFiles(streamerDir, segmentsDir string) {
+	for _, pattern := range []string{
+		filepath.Join(segmentsDir, "*.ts"),
+		filepath.Join(segmentsDir, "*.mp4"),
+		filepath.Join(segmentsDir, "concat_*.txt"),
+		filepath.Join(streamerDir, "*.ts"),
+		filepath.Join(streamerDir, "*.mp4"),
+		filepath.Join(streamerDir, "concat_*.txt"),
+	} {
+		matches, _ := filepath.Glob(pattern)
+		for _, match := range matches {
+			_ = os.Remove(match)
+		}
+	}
 }
 
 func formatStreamlinkDurationArg(value time.Duration) string {

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -3,6 +3,7 @@ package media
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -196,12 +197,12 @@ func TestNewStreamlinkCaptureAdapterKeepsConfiguredCaptureTimeout(t *testing.T) 
 	}
 }
 
-func TestNewStreamlinkCaptureAdapterDisablesContinuousModeForDefaultRunner(t *testing.T) {
+func TestNewStreamlinkCaptureAdapterEnablesContinuousModeForDefaultRunner(t *testing.T) {
 	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
 		OutputDir: t.TempDir(),
 	}, nil, nil)
-	if adapter.continuous {
-		t.Fatalf("expected non-continuous mode for default runner")
+	if !adapter.continuous {
+		t.Fatalf("expected continuous mode for default runner")
 	}
 }
 
@@ -317,6 +318,42 @@ func TestFFmpegChunkNormalizerRemuxesTSChunksToMP4(t *testing.T) {
 	}
 }
 
+func TestCleanupContinuousSessionFilesRemovesStaleLocalArtifacts(t *testing.T) {
+	streamerDir := t.TempDir()
+	segmentsDir := filepath.Join(streamerDir, "live_segments")
+	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	staleFiles := []string{
+		filepath.Join(streamerDir, "000000001-000000003.mp4"),
+		filepath.Join(streamerDir, "old.ts"),
+		filepath.Join(streamerDir, "concat_old.txt"),
+		filepath.Join(segmentsDir, "000000001.mp4"),
+		filepath.Join(segmentsDir, "old.ts"),
+		filepath.Join(segmentsDir, "concat_old.txt"),
+	}
+	for _, path := range staleFiles {
+		if err := os.WriteFile(path, []byte("stale"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+	}
+	keepPath := filepath.Join(streamerDir, "keep.json")
+	if err := os.WriteFile(keepPath, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("WriteFile(keep) error = %v", err)
+	}
+
+	cleanupContinuousSessionFiles(streamerDir, segmentsDir)
+
+	for _, path := range staleFiles {
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected stale artifact %s to be removed, err=%v", path, err)
+		}
+	}
+	if _, err := os.Stat(keepPath); err != nil {
+		t.Fatalf("expected unrelated file to remain, err=%v", err)
+	}
+}
+
 func TestNormalizeStreamlinkQualityPrefers1080p(t *testing.T) {
 	for _, input := range []string{"", "best", " BEST "} {
 		if got := normalizeStreamlinkQuality(input); got != defaultPreferredStreamQuality {
@@ -356,7 +393,7 @@ func TestStreamlinkCaptureAdapterContinuousAcceptsStableSegmentWithoutNextChunk(
 		started:     true,
 	}
 
-	chunk, err := adapter.captureContinuous(context.Background(), "str_live", 30*time.Second)
+	chunk, err := adapter.captureContinuous(context.Background(), "str_live", time.Second)
 	if err != nil {
 		t.Fatalf("captureContinuous() error = %v", err)
 	}
@@ -366,8 +403,78 @@ func TestStreamlinkCaptureAdapterContinuousAcceptsStableSegmentWithoutNextChunk(
 	if filepath.Base(chunk.Reference) != "000000001.mp4" {
 		t.Fatalf("chunk path = %q, want renamed stable segment", chunk.Reference)
 	}
-	if _, err := os.Stat(segmentPath); err != nil {
-		t.Fatalf("expected source segment to remain for in-progress writer, err=%v", err)
+	if _, err := os.Stat(segmentPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected consumed source segment to be removed, err=%v", err)
+	}
+}
+
+func TestStreamlinkCaptureAdapterContinuousUsesRequestedDurationWithoutSkippingSegments(t *testing.T) {
+	outDir := t.TempDir()
+	runner := &fakeCommandRunner{}
+	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
+		OutputDir:    outDir,
+		FFmpegBinary: "ffmpeg-bin",
+	}, nil, runner)
+
+	segmentsDir := filepath.Join(outDir, "str_live", "live_segments")
+	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	for i := 1; i <= 6; i++ {
+		segmentPath := filepath.Join(segmentsDir, fmt.Sprintf("%09d.mp4", i))
+		if err := os.WriteFile(segmentPath, []byte(fmt.Sprintf("segment-%d", i)), 0o644); err != nil {
+			t.Fatalf("WriteFile(%d) error = %v", i, err)
+		}
+	}
+
+	adapter.sessions["str_live"] = &continuousCaptureSession{
+		streamerID:  "str_live",
+		channel:     "live_channel",
+		segmentsDir: segmentsDir,
+		nextIndex:   1,
+		started:     true,
+	}
+
+	first, err := adapter.captureContinuous(context.Background(), "str_live", 3*time.Second)
+	if err != nil {
+		t.Fatalf("first captureContinuous() error = %v", err)
+	}
+	if filepath.Base(first.Reference) != "000000001-000000003.mp4" {
+		t.Fatalf("first chunk path = %q", first.Reference)
+	}
+	if adapter.sessions["str_live"].nextIndex != 4 {
+		t.Fatalf("nextIndex after first capture = %d, want 4", adapter.sessions["str_live"].nextIndex)
+	}
+
+	second, err := adapter.captureContinuous(context.Background(), "str_live", 2*time.Second)
+	if err != nil {
+		t.Fatalf("second captureContinuous() error = %v", err)
+	}
+	if filepath.Base(second.Reference) != "000000004-000000005.mp4" {
+		t.Fatalf("second chunk path = %q", second.Reference)
+	}
+	if adapter.sessions["str_live"].nextIndex != 6 {
+		t.Fatalf("nextIndex after second capture = %d, want 6", adapter.sessions["str_live"].nextIndex)
+	}
+
+	for i := 1; i <= 5; i++ {
+		segmentPath := filepath.Join(segmentsDir, fmt.Sprintf("%09d.mp4", i))
+		if _, err := os.Stat(segmentPath); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected consumed segment %d to be removed, err=%v", i, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(segmentsDir, "000000006.mp4")); err != nil {
+		t.Fatalf("expected unused segment 6 to remain, err=%v", err)
+	}
+
+	if len(runner.argsHistory) != 2 {
+		t.Fatalf("ffmpeg concat invocations = %d, want 2", len(runner.argsHistory))
+	}
+	for _, args := range runner.argsHistory {
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, "-f concat") || !strings.Contains(joined, "-c copy") {
+			t.Fatalf("expected concat demuxer with stream copy, got %q", joined)
+		}
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Preserve continuous video coverage for LLM orchestration by assembling contiguous 1-second source segments into configured step-sized LLM chunks without skipping seconds. 
- Avoid disk accumulation from consumed source segments, assembled local videos, and stale artifacts from interrupted sessions.
- Reflect the runtime change in docs and load-testing scenarios to describe Scenario Package v2 `segmentSeconds` behavior.

### Description
- Implement continuous capture improvements in `internal/media/adapters.go`: add `continuousCaptureSegmentUnit`, segment counting/resolution utilities (`continuousSegmentCount`, `continuousSegmentPaths`), chunk assembler `assembleContinuousChunk`, and cleanup helpers `cleanupContinuousSegments` and `cleanupContinuousSessionFiles`.
- Update `NewStreamlinkCaptureAdapter` to enable continuous mode automatically for the default runner and to perform session directory cleanup on start. 
- Revise `captureContinuous` logic to wait for a contiguous range of segments, assemble multi-segment chunks via ffmpeg concat for >1 segments, rename or copy single segments, advance `nextIndex` by the assembled segment count, and return clearer deadline errors. 
- Update local setup, orchestration, implementation plan, and load-testing documentation to describe 1-second source segments, step-sized assembly, deletion semantics, and load-test assertions for contiguous segments and artifact cleanup. 
- Add/modify unit tests in `internal/media/adapters_test.go` to cover enabling continuous mode for the default runner, cleanup of stale artifacts, stable-single-segment handling, and multi-segment assembly behavior including segment removal and ffmpeg concat invocation assertions.

### Testing
- Ran unit tests for the media package with `go test ./internal/media`, including new tests `TestNewStreamlinkCaptureAdapterEnablesContinuousModeForDefaultRunner`, `TestCleanupContinuousSessionFilesRemovesStaleLocalArtifacts`, and `TestStreamlinkCaptureAdapterContinuousUsesRequestedDurationWithoutSkippingSegments`, and they all passed.
- Existing `internal/media` tests were re-run and continued to pass after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3be31ce0832c9342426b5bbd4ffa)