### PR TITLE
Fix media test compatibility with Go 1.23 (replace t.Chdir)

### DIFF
--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -12,6 +12,22 @@ import (
 	"time"
 )
 
+func chdirForTest(t *testing.T, dir string) {
+	t.Helper()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir(%q) error = %v", dir, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Fatalf("restore working directory to %q: %v", originalDir, err)
+		}
+	})
+}
+
 type fakeChannelResolver struct {
 	channel string
 	err     error
@@ -487,7 +503,7 @@ func TestStreamlinkCaptureAdapterContinuousUsesRequestedDurationWithoutSkippingS
 }
 
 func TestStreamlinkCaptureAdapterContinuousConcatListUsesAbsoluteSegmentPaths(t *testing.T) {
-	t.Chdir(t.TempDir())
+	chdirForTest(t, t.TempDir())
 	outDir := filepath.Join("tmp", "stream_chunks")
 	runner := &fakeCommandRunner{}
 	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{


### PR DESCRIPTION
### Motivation
- The `internal/media` tests used the Go 1.24-only `t.Chdir(...)`, causing `go vet` to fail against the module's `go 1.23` target; the goal is to restore vet/build compatibility without changing test semantics.
- The change must preserve the existing `TestStreamlinkCaptureAdapterContinuousConcatListUsesAbsoluteSegmentPaths` behavior that validates absolute concat segment paths.

### Description
- Add a small test helper `chdirForTest(t, dir)` that uses `os.Getwd`, `os.Chdir` and `t.Cleanup` to change and restore the working directory in a vet-safe way.
- Replace the single `t.Chdir(t.TempDir())` call in `TestStreamlinkCaptureAdapterContinuousConcatListUsesAbsoluteSegmentPaths` with `chdirForTest(t, t.TempDir())`.
- The only modified file is `internal/media/adapters_test.go` and no production code or test assertions were changed.

### Testing
- Ran `go test ./internal/media` and it passed successfully.
- Ran `go vet ./...` and it completed without errors.
- Ran `go test ./...` and the full test suite passed.

Checklist aligned with M2.1 / `docs/llm_stream_orchestration_plan.md`:
- [x] Make `internal/media` tests compatible with `go 1.23` by removing `t.Chdir` usage.
- [x] Preserve absolute-segment-path validation in the continuous concat test.
- [ ] Re-introduce scenario-package persistence in storage (PostgreSQL) after scenario-only cleanup stabilizes.
- [ ] Implement match-session lifecycle and remaining M2.1 orchestration tasks as listed in the implementation plan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb54132c28832ca7111edde856309c)