### PR TITLE
Refactor continuous segment finalization, treat no-data as non-failure, and add tests

### DIFF
--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -334,26 +334,7 @@ func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, stream
 		}
 
 		segmentPaths, segmentsReady := continuousSegmentPaths(session.segmentsDir, targetIndex, segmentCount)
-		nextSegmentPath := filepath.Join(session.segmentsDir, fmt.Sprintf("%09d.mp4", lastIndex+1))
-		nextInfo, nextErr := os.Stat(nextSegmentPath)
-		segmentFinalized := nextErr == nil && nextInfo.Size() > 0
-		finalizedByStability := false
-		if !segmentFinalized && segmentCount == 1 && segmentsReady {
-			info, statErr := os.Stat(segmentPaths[0])
-			if statErr == nil && info.Size() > 0 {
-				if info.Size() != lastObservedSize {
-					lastObservedSize = info.Size()
-					lastSizeChangedAt = time.Now()
-				}
-				stableByObservedSize := !lastSizeChangedAt.IsZero() && time.Since(lastSizeChangedAt) >= continuousSegmentStabilityWindow
-				stableByModTime := time.Since(info.ModTime()) >= continuousSegmentStabilityWindow
-				nearDeadline := time.Until(deadline) <= continuousSegmentStabilityWindow
-				if stableByObservedSize && stableByModTime && nearDeadline {
-					segmentFinalized = true
-					finalizedByStability = true
-				}
-			}
-		}
+		segmentFinalized, finalizedByStability := a.continuousSegmentRangeFinalized(session.segmentsDir, segmentPaths, lastIndex, segmentsReady, &lastObservedSize, &lastSizeChangedAt)
 		if segmentsReady && segmentFinalized {
 			chunkPath, err := a.assembleContinuousChunk(ctx, session, targetIndex, segmentPaths, finalizedByStability)
 			if err != nil {
@@ -372,6 +353,34 @@ func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, stream
 		}
 		time.Sleep(250 * time.Millisecond)
 	}
+}
+
+func (a *StreamlinkCaptureAdapter) continuousSegmentRangeFinalized(segmentsDir string, segmentPaths []string, lastIndex int, segmentsReady bool, lastObservedSize *int64, lastSizeChangedAt *time.Time) (bool, bool) {
+	nextSegmentPath := filepath.Join(segmentsDir, fmt.Sprintf("%09d.mp4", lastIndex+1))
+	nextInfo, nextErr := os.Stat(nextSegmentPath)
+	if nextErr == nil && nextInfo.Size() > 0 {
+		return true, false
+	}
+	if !segmentsReady || len(segmentPaths) == 0 {
+		return false, false
+	}
+
+	lastSegmentPath := segmentPaths[len(segmentPaths)-1]
+	info, statErr := os.Stat(lastSegmentPath)
+	if statErr != nil || info.Size() <= 0 {
+		return false, false
+	}
+	previousObservedSize := *lastObservedSize
+	if info.Size() != *lastObservedSize {
+		*lastObservedSize = info.Size()
+		*lastSizeChangedAt = time.Now()
+	}
+	stableByObservedSize := !lastSizeChangedAt.IsZero() && time.Since(*lastSizeChangedAt) >= continuousSegmentStabilityWindow
+	stableByModTime := time.Since(info.ModTime()) >= continuousSegmentStabilityWindow
+	if stableByModTime && (stableByObservedSize || previousObservedSize < 0) {
+		return true, true
+	}
+	return false, false
 }
 
 func (a *StreamlinkCaptureAdapter) ensureContinuousSession(streamerID, channel string) (*continuousCaptureSession, error) {

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -502,6 +502,49 @@ func TestStreamlinkCaptureAdapterContinuousUsesRequestedDurationWithoutSkippingS
 	}
 }
 
+func TestStreamlinkCaptureAdapterContinuousAssemblesStableRangeWithoutNextSegment(t *testing.T) {
+	outDir := t.TempDir()
+	runner := &fakeCommandRunner{}
+	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
+		OutputDir:    outDir,
+		FFmpegBinary: "ffmpeg-bin",
+	}, nil, runner)
+
+	segmentsDir := filepath.Join(outDir, "str_live", "live_segments")
+	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	past := time.Now().Add(-2 * continuousSegmentStabilityWindow)
+	for i := 1; i <= 3; i++ {
+		segmentPath := filepath.Join(segmentsDir, fmt.Sprintf("%09d.mp4", i))
+		if err := os.WriteFile(segmentPath, []byte(fmt.Sprintf("segment-%d", i)), 0o644); err != nil {
+			t.Fatalf("WriteFile(%d) error = %v", i, err)
+		}
+		if err := os.Chtimes(segmentPath, past, past); err != nil {
+			t.Fatalf("Chtimes(%d) error = %v", i, err)
+		}
+	}
+
+	adapter.sessions["str_live"] = &continuousCaptureSession{
+		streamerID:  "str_live",
+		channel:     "live_channel",
+		segmentsDir: segmentsDir,
+		nextIndex:   1,
+		started:     true,
+	}
+
+	chunk, err := adapter.captureContinuous(context.Background(), "str_live", 3*time.Second)
+	if err != nil {
+		t.Fatalf("captureContinuous() error = %v", err)
+	}
+	if filepath.Base(chunk.Reference) != "000000001-000000003.mp4" {
+		t.Fatalf("chunk path = %q", chunk.Reference)
+	}
+	if adapter.sessions["str_live"].nextIndex != 4 {
+		t.Fatalf("nextIndex after capture = %d, want 4", adapter.sessions["str_live"].nextIndex)
+	}
+}
+
 func TestStreamlinkCaptureAdapterContinuousConcatListUsesAbsoluteSegmentPaths(t *testing.T) {
 	chdirForTest(t, t.TempDir())
 	outDir := filepath.Join("tmp", "stream_chunks")

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -277,6 +277,11 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 			w.metrics.recordCycle(ctx, id, "ad_break")
 			return streamers.LLMDecision{}, nil
 		}
+		if errors.Is(err, ErrStreamlinkNoData) {
+			logger.Warn("stream chunk capture skipped because no continuous stream data is ready", zap.String("streamerID", id), zap.Error(err))
+			w.metrics.recordCycle(ctx, id, "no_data")
+			return streamers.LLMDecision{}, nil
+		}
 		if errors.Is(err, ErrStreamlinkStreamEnded) {
 			if finalizer, ok := w.chunkPublisher.(ChunkFinalizer); ok {
 				if finalizeErr := finalizer.Finalize(ctx, id, time.Now().UTC()); finalizeErr != nil {

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -560,6 +560,22 @@ func TestWorkerProcessStreamerSkipsAdBreakWithoutFailingCycle(t *testing.T) {
 	}
 }
 
+func TestWorkerProcessStreamerSkipsNoDataWithoutFailingCycle(t *testing.T) {
+	runStore := &countingRunStore{}
+	worker := NewWorker(&fakeCapture{err: ErrStreamlinkNoData}, fakeClassifier{}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, runStore, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})
+
+	got, err := worker.ProcessStreamer(context.Background(), "str-nodata")
+	if err != nil {
+		t.Fatalf("ProcessStreamer() error = %v", err)
+	}
+	if got != (streamers.LLMDecision{}) {
+		t.Fatalf("expected zero decision when no stream data is ready, got %#v", got)
+	}
+	if runStore.count != 0 {
+		t.Fatalf("expected no-data capture to skip run creation, got %d runs", runStore.count)
+	}
+}
+
 func TestWorkerProcessStreamerSkipsEndedStreamWithoutFailingCycle(t *testing.T) {
 	runStore := &countingRunStore{}
 	worker := NewWorker(&fakeCapture{err: ErrStreamlinkStreamEnded}, fakeClassifier{}, fakePromptResolver{prompts: []prompts.PromptVersion{{Stage: "custom", Position: 1, IsActive: true, Template: "x", Model: "gemini", MaxTokens: 1, TimeoutMS: 1}}}, runStore, &fakeDecisionStore{}, NewInMemoryLocker(), WorkerConfig{MinConfidence: 0.5})


### PR DESCRIPTION
### Motivation
- Consolidate the logic that determines when a continuous segment range is finalized so it can detect stable ranges even if the next segment file is not yet present.
- Ensure the worker does not mark a tracking cycle as failed when continuous capture reports no ready data and instead skips the cycle cleanly.
- Add unit tests to cover assembling stable ranges without a following segment and skipping a no-data capture in the worker.

### Description
- Extracted the segment-range finalization logic into `continuousSegmentRangeFinalized` and updated `captureContinuous` to call it.
- `continuousSegmentRangeFinalized` checks for a next segment, validates the last segment file, and uses observed size and modification time to determine stability.
- Updated `Worker.ProcessStreamer` to treat `ErrStreamlinkNoData` as a non-failure case, record a `no_data` cycle metric, and return a zero decision instead of failing the cycle.
- Added `TestStreamlinkCaptureAdapterContinuousAssemblesStableRangeWithoutNextSegment` to verify assembling a stable segment range when the next segment file is absent.
- Added `TestWorkerProcessStreamerSkipsNoDataWithoutFailingCycle` to verify the worker skips a no-data capture without creating a run or failing the cycle.

### Testing
- Ran the modified media package unit tests including the new `TestStreamlinkCaptureAdapterContinuousAssemblesStableRangeWithoutNextSegment`, and they passed.
- Ran the worker package unit tests including the new `TestWorkerProcessStreamerSkipsNoDataWithoutFailingCycle`, and they passed.
- Ran the repository test suite for the affected packages (`go test ./internal/media` and related worker tests), and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb59a098a8832ca607f77b79086339)