### PR TITLE
Use source segment counts for LLM chunks: add `segmentCount` and migrate from `segmentSeconds`

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -58,8 +58,8 @@ business logic and immediate backend scope.
 - [ ] Re-introduce scenario-package persistence in storage (PostgreSQL) after the scenario-only cleanup baseline stabilizes.
 - [x] Implement stream capture worker pipeline:
   `streamlink -> media chunking -> previous_state + new_chunk -> updated_state`,
-  including step-level `segmentSeconds` assembly from contiguous source segments
-  so no seconds are skipped between LLM chunks, plus cleanup of consumed source
+  including step-level `segmentCount` assembly from contiguous source segments
+  so no source segments are skipped between LLM chunks, plus cleanup of consumed source
   segments, assembled local videos, and stale artifacts from interrupted sessions.
 - [ ] Implement match-session lifecycle so one detected match is tracked as one
   chat/session with explicit persisted state JSON.

--- a/docs/llm_stream_orchestration_plan.md
+++ b/docs/llm_stream_orchestration_plan.md
@@ -59,9 +59,9 @@ Current orchestration uses only the model below:
   - transition by priority,
   - stay-on-step fallback.
 - Wire worker to prefer scenario package execution when present.
-- Preserve continuous video coverage when applying each step `segmentSeconds`: capture
+- Preserve continuous video coverage when applying each step `segmentCount`: capture
   a continuous per-streamer source timeline and assemble LLM chunks from consecutive
-  segments without dropping any seconds between adjacent LLM requests, and clean
+  segments without dropping any source segments between adjacent LLM requests, and clean
   up consumed local source/assembled video files after they are no longer needed.
 
 ## Deferred (next iteration)

--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -41,8 +41,8 @@
 - **Assertions**: 99% of clients receive updates within 1 s; dropped message rate < 0.5%.
 
 ### S7 – Streamlink Capture Cadence & Idempotency
-- **Path**: background `streamlink -> 1-second source segments -> assembled LLM chunk` scheduler for active streamers.
-- **Profile**: 100 active streamers across 15 minutes with mixed Scenario Package v2 `segmentSeconds` values (for example 10, 15, and 30 seconds).
+- **Path**: background `streamlink -> source segment files -> assembled LLM chunk` scheduler for active streamers.
+- **Profile**: 100 active streamers across 15 minutes with mixed Scenario Package v2 `segmentCount` values (for example 10, 15, and 30 source segments).
 - **Assertions**: no streamer executes more than one capture cycle per configured step window; duplicate scheduler starts do not increase chunk volume; worker busy skips remain below 1% after warm-up; assembled LLM chunks advance through contiguous segment indexes with no gaps or duplicates; consumed source segments, analyzed/uploaded local videos, and stale interrupted-session artifacts do not accumulate on disk.
 
 ## Metrics Collection

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -98,11 +98,11 @@ FUNPOT_DATABASE_CONN_MAX_LIFETIME=30m
 > the previous capture overruns the window.
 >
 > Stream capture now runs as a long-lived Streamlink→FFmpeg pipeline per streamer
-> and cuts sequential 1-second source segments continuously (`%09d.mp4`).
-> The worker assembles the exact number of consecutive source segments requested
-> by the active Scenario Package v2 step `segmentSeconds`, so admins can tune
-> LLM chunk length while preserving contiguous coverage with no skipped seconds
-> between chunks.
+> and cuts sequential source segment files continuously (`%09d.mp4`; FFmpeg uses a 1-second target, but stream-copy keyframes can make wall-clock duration vary).
+> The worker assembles the exact number of consecutive source segment files requested
+> by the active Scenario Package v2 step `segmentCount`, so admins can tune
+> how many files are sent in each LLM chunk while preserving contiguous coverage
+> with no skipped source segments between chunks.
 >
 > Each assembled step-sized chunk is analyzed immediately by the worker, then
 > the local assembled video is deleted after analysis/upload; consumed 1-second
@@ -225,7 +225,7 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/admin/llm/model-configs` / `POST /api/admin/llm/model-configs` – admin CRUD entrypoints for reusable LLM model configs (model + execution params + free-form metadata JSON).
 - `PUT /api/admin/llm/model-configs/{id}` / `DELETE /api/admin/llm/model-configs/{id}` / `POST /api/admin/llm/model-configs/{id}/activate` – update, remove, and switch active model configuration.
 - `GET /api/admin/llm/scenario-packages` / `POST /api/admin/llm/scenario-packages` – admin CRUD for scenario graph packages with per-game versioning and activation. Admin can provide explicit graph `transitions` (`fromStepId`, `toStepId`, `condition`, `priority`) for branch routing and optional strict-linear `packageTransitions` (single connector: `toPackageId`, `priority`, optional `action=stop_tracking`, optional `finalStateOptionId`) for package-to-package routing (`A -> B -> N`) or terminal stop behavior. Package payload also supports `finalCondition` (logical expression for final mini-game decision), `finalStateOptions` (predefined `{id,name,condition,finalStateJson,finalLabel}` choices), and derived `potentialState` in API responses (all detected state keys/value variants aggregated from step `responseSchemaJson`). If step `transitions` are omitted backend auto-links steps linearly by `order` (`step_i -> step_(i+1)` uses target `entryCondition`); when the initial step has its own `entryCondition` backend also adds fallback transitions from non-initial steps back to initial using that condition.
-- Scenario steps support per-step tuning: `segmentSeconds` (default `15` for `initial=true`, otherwise `30`) and `maxRequests` (default `0` = unlimited). When a non-initial step exceeds `maxRequests`, runtime returns to initial step; when initial exceeds its own limit, streamer tracking stops.
+- Scenario steps support per-step tuning: `segmentCount` (default `15` for `initial=true`, otherwise `30`; legacy `segmentSeconds` is accepted as an alias) and `maxRequests` (default `0` = unlimited). When a non-initial step exceeds `maxRequests`, runtime returns to initial step; when initial exceeds its own limit, streamer tracking stops.
 
 - `GET /api/admin/llm/scenario-packages/{id}/graph` – returns a UI-ready visual graph payload (`nodes + edges + groups`) for scenario-graph editors/renderers.
 - Legacy prompt-version/state-schema/rule-set admin surfaces are removed from runtime; scenario-packages + model-configs are the supported LLM control surfaces.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1753,10 +1753,15 @@ components:
         responseSchemaJson:
           type: string
           description: JSON schema/template contract that the LLM response must follow exactly (legacy coercion is not applied).
+        segmentCount:
+          type: integer
+          minimum: 1
+          description: Number of consecutive source video segments to assemble for each LLM request. Defaults to 15 for the initial step and 30 for all other steps.
         segmentSeconds:
           type: integer
           minimum: 1
-          description: Video segment duration in seconds for this step. Defaults to 15 for the initial step and 30 for all other steps.
+          deprecated: true
+          description: Deprecated alias for segmentCount kept for backwards compatibility; value is interpreted as a source segment count, not wall-clock seconds.
         maxRequests:
           type: integer
           minimum: 0
@@ -1772,10 +1777,15 @@ components:
         - $ref: '#/components/schemas/ScenarioStepRequest'
         - type: object
           properties:
+            segmentCount:
+              type: integer
+              minimum: 1
+              description: Number of consecutive source video segments to assemble for each LLM request. Defaults to 15 for the initial step and 30 for all other steps.
             segmentSeconds:
               type: integer
               minimum: 1
-              description: Video segment duration in seconds for this step. Defaults to 15 for the initial step and 30 for all other steps.
+              deprecated: true
+              description: Deprecated alias for segmentCount kept for backwards compatibility; value is interpreted as a source segment count, not wall-clock seconds.
             maxRequests:
               type: integer
               minimum: 0

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -71,6 +71,7 @@ func scenarioPackageRequestToCreateRequest(req scenarioPackageCreateRequest, act
 			EntryCondition:     step.EntryCondition,
 			PromptTemplate:     step.PromptTemplate,
 			ResponseSchemaJSON: step.ResponseSchemaJSON,
+			SegmentCount:       step.SegmentCount,
 			SegmentSeconds:     step.SegmentSeconds,
 			MaxRequests:        step.MaxRequests,
 			Initial:            step.Initial,
@@ -193,6 +194,7 @@ type scenarioStepRequest struct {
 	EntryCondition     string `json:"entryCondition"`
 	PromptTemplate     string `json:"promptTemplate"`
 	ResponseSchemaJSON string `json:"responseSchemaJson"`
+	SegmentCount       int    `json:"segmentCount"`
 	SegmentSeconds     int    `json:"segmentSeconds"`
 	MaxRequests        int    `json:"maxRequests"`
 	Initial            bool   `json:"initial"`

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -65,7 +65,7 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 				"gameSlug":           "global",
 				"promptTemplate":     "detect",
 				"responseSchemaJson": "{}",
-				"segmentSeconds":     15,
+				"segmentCount":       15,
 				"maxRequests":        4,
 				"initial":            true,
 				"order":              1,
@@ -116,8 +116,8 @@ func TestAdminLLMScenarioPackageRoutes(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected first step object, got %#v", steps[0])
 	}
-	if got, _ := firstStep["segmentSeconds"].(float64); int(got) != 15 {
-		t.Fatalf("expected segmentSeconds=15, got %#v", firstStep["segmentSeconds"])
+	if got, _ := firstStep["segmentCount"].(float64); int(got) != 15 {
+		t.Fatalf("expected segmentCount=15, got %#v", firstStep["segmentCount"])
 	}
 	if got, _ := firstStep["maxRequests"].(float64); int(got) != 4 {
 		t.Fatalf("expected maxRequests=4, got %#v", firstStep["maxRequests"])

--- a/internal/media/adapters.go
+++ b/internal/media/adapters.go
@@ -150,9 +150,19 @@ func (a *StreamlinkCaptureAdapter) CaptureWithDuration(ctx context.Context, stre
 		duration = a.cfg.CaptureTimeout
 	}
 	if a.continuous {
-		return a.captureContinuous(ctx, streamerID, duration)
+		return a.CaptureWithSegmentCount(ctx, streamerID, continuousSegmentCount(duration))
 	}
 	return a.captureSingle(ctx, streamerID, duration)
+}
+
+func (a *StreamlinkCaptureAdapter) CaptureWithSegmentCount(ctx context.Context, streamerID string, segmentCount int) (ChunkRef, error) {
+	if segmentCount <= 0 {
+		segmentCount = continuousSegmentCount(a.cfg.CaptureTimeout)
+	}
+	if a.continuous {
+		return a.captureContinuousSegments(ctx, streamerID, segmentCount)
+	}
+	return a.captureSingle(ctx, streamerID, time.Duration(segmentCount)*continuousCaptureSegmentUnit)
 }
 
 func (a *StreamlinkCaptureAdapter) captureSingle(ctx context.Context, streamerID string, captureTimeout time.Duration) (ChunkRef, error) {
@@ -291,6 +301,10 @@ func (a *StreamlinkCaptureAdapter) captureSingle(ctx context.Context, streamerID
 }
 
 func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, streamerID string, captureTimeout time.Duration) (ChunkRef, error) {
+	return a.captureContinuousSegments(ctx, streamerID, continuousSegmentCount(captureTimeout))
+}
+
+func (a *StreamlinkCaptureAdapter) captureContinuousSegments(ctx context.Context, streamerID string, segmentCount int) (ChunkRef, error) {
 	logger := a.logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -320,10 +334,12 @@ func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, stream
 		return ChunkRef{}, session.lastErr
 	}
 
-	segmentCount := continuousSegmentCount(captureTimeout)
+	if segmentCount <= 0 {
+		segmentCount = continuousSegmentCount(a.cfg.CaptureTimeout)
+	}
 	targetIndex := session.nextIndex
 	lastIndex := targetIndex + segmentCount - 1
-	deadline := time.Now().Add(captureTimeout + continuousCaptureSegmentUnit + streamlinkCaptureShutdownGracePeriod)
+	deadline := time.Now().Add(time.Duration(segmentCount)*continuousCaptureSegmentUnit + continuousCaptureSegmentUnit + streamlinkCaptureShutdownGracePeriod)
 	lastObservedSize := int64(-1)
 	var lastSizeChangedAt time.Time
 	for {
@@ -341,7 +357,7 @@ func (a *StreamlinkCaptureAdapter) captureContinuous(ctx context.Context, stream
 				return ChunkRef{}, err
 			}
 			session.nextIndex += segmentCount
-			logger.Info("continuous stream chunk assembled", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.Int("firstSegmentIndex", targetIndex), zap.Int("lastSegmentIndex", lastIndex), zap.Int("segmentSeconds", segmentCount))
+			logger.Info("continuous stream chunk assembled", zap.String("streamerID", id), zap.String("chunkPath", chunkPath), zap.Int("firstSegmentIndex", targetIndex), zap.Int("lastSegmentIndex", lastIndex), zap.Int("segmentCount", segmentCount))
 			return ChunkRef{Reference: chunkPath, CapturedAt: a.nowFn().UTC()}, nil
 		}
 		if !segmentsReady {

--- a/internal/media/adapters_test.go
+++ b/internal/media/adapters_test.go
@@ -432,6 +432,45 @@ func TestStreamlinkCaptureAdapterContinuousAcceptsStableSegmentWithoutNextChunk(
 	}
 }
 
+func TestStreamlinkCaptureAdapterContinuousUsesRequestedSegmentCount(t *testing.T) {
+	outDir := t.TempDir()
+	runner := &fakeCommandRunner{}
+	adapter := NewStreamlinkCaptureAdapter(StreamlinkCaptureConfig{
+		OutputDir:    outDir,
+		FFmpegBinary: "ffmpeg-bin",
+	}, nil, runner)
+	adapter.continuous = true
+
+	segmentsDir := filepath.Join(outDir, "str_live", "live_segments")
+	if err := os.MkdirAll(segmentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir segments: %v", err)
+	}
+	for idx := 1; idx <= 4; idx++ {
+		path := filepath.Join(segmentsDir, fmt.Sprintf("%09d.mp4", idx))
+		if err := os.WriteFile(path, []byte("segment"), 0o644); err != nil {
+			t.Fatalf("write segment: %v", err)
+		}
+	}
+	adapter.sessions["str_live"] = &continuousCaptureSession{
+		streamerID:  "str_live",
+		channel:     "str_live",
+		segmentsDir: segmentsDir,
+		nextIndex:   1,
+		started:     true,
+	}
+
+	chunk, err := adapter.CaptureWithSegmentCount(context.Background(), "str_live", 2)
+	if err != nil {
+		t.Fatalf("CaptureWithSegmentCount() error = %v", err)
+	}
+	if filepath.Base(chunk.Reference) != "000000001-000000002.mp4" {
+		t.Fatalf("chunk path = %q", chunk.Reference)
+	}
+	if adapter.sessions["str_live"].nextIndex != 3 {
+		t.Fatalf("next index = %d, want 3", adapter.sessions["str_live"].nextIndex)
+	}
+}
+
 func TestStreamlinkCaptureAdapterContinuousUsesRequestedDurationWithoutSkippingSegments(t *testing.T) {
 	outDir := t.TempDir()
 	runner := &fakeCommandRunner{}

--- a/internal/media/worker.go
+++ b/internal/media/worker.go
@@ -74,6 +74,10 @@ type StepDurationCapture interface {
 	CaptureWithDuration(ctx context.Context, streamerID string, duration time.Duration) (ChunkRef, error)
 }
 
+type StepSegmentCapture interface {
+	CaptureWithSegmentCount(ctx context.Context, streamerID string, segmentCount int) (ChunkRef, error)
+}
+
 type StageClassifier interface {
 	Classify(ctx context.Context, input StageRequest) (StageClassification, error)
 }
@@ -270,7 +274,7 @@ func (w *Worker) ProcessStreamer(ctx context.Context, streamerID string) (stream
 		return lastDecision, ErrTrackingStop
 	}
 
-	chunk, err := w.captureWithRetry(ctx, id, execution.Step.SegmentSeconds)
+	chunk, err := w.captureWithRetry(ctx, id, execution.Step.SegmentCount)
 	if err != nil {
 		if errors.Is(err, ErrStreamlinkAdBreak) {
 			logger.Info("stream chunk capture skipped because stream is on ad break", zap.String("streamerID", id), zap.Error(err))
@@ -359,19 +363,18 @@ func defaultTrackerState() string {
 	return `{}`
 }
 
-func (w *Worker) captureWithRetry(ctx context.Context, streamerID string, segmentSeconds int) (ChunkRef, error) {
+func (w *Worker) captureWithRetry(ctx context.Context, streamerID string, segmentCount int) (ChunkRef, error) {
 	attempts := w.captureRetryCount + 1
 	if attempts <= 0 {
 		attempts = 1
 	}
-	duration := time.Duration(segmentSeconds) * time.Second
-	if duration <= 0 {
-		duration = 30 * time.Second
+	if segmentCount <= 0 {
+		segmentCount = 30
 	}
 
 	var lastErr error
 	for attempt := 1; attempt <= attempts; attempt++ {
-		chunk, err := w.captureChunk(ctx, streamerID, duration)
+		chunk, err := w.captureChunk(ctx, streamerID, segmentCount)
 		if err == nil {
 			return chunk, nil
 		}
@@ -386,9 +389,12 @@ func (w *Worker) captureWithRetry(ctx context.Context, streamerID string, segmen
 	return ChunkRef{}, lastErr
 }
 
-func (w *Worker) captureChunk(ctx context.Context, streamerID string, duration time.Duration) (ChunkRef, error) {
+func (w *Worker) captureChunk(ctx context.Context, streamerID string, segmentCount int) (ChunkRef, error) {
+	if segmentedCapture, ok := w.capture.(StepSegmentCapture); ok {
+		return segmentedCapture.CaptureWithSegmentCount(ctx, streamerID, segmentCount)
+	}
 	if timedCapture, ok := w.capture.(StepDurationCapture); ok {
-		return timedCapture.CaptureWithDuration(ctx, streamerID, duration)
+		return timedCapture.CaptureWithDuration(ctx, streamerID, time.Duration(segmentCount)*time.Second)
 	}
 	return w.capture.Capture(ctx, streamerID)
 }
@@ -909,7 +915,7 @@ func (w *Worker) processScenarioPackage(ctx context.Context, runID, streamerID s
 	step := execution.Step
 	entering := execution.Entering
 	previousState := execution.PreviousState
-	logger.Info("scenario step selected", zap.String("streamerID", streamerID), zap.String("scenarioPackageID", pkg.ID), zap.String("stepID", step.ID), zap.Int("segmentSeconds", step.SegmentSeconds), zap.Int("maxRequests", step.MaxRequests))
+	logger.Info("scenario step selected", zap.String("streamerID", streamerID), zap.String("scenarioPackageID", pkg.ID), zap.String("stepID", step.ID), zap.Int("segmentCount", step.SegmentCount), zap.Int("maxRequests", step.MaxRequests))
 	if strings.TrimSpace(pkg.LLMModelConfigID) == "" {
 		return streamers.LLMDecision{}, prompts.ErrInvalidScenarioModelRef
 	}

--- a/internal/media/worker_test.go
+++ b/internal/media/worker_test.go
@@ -17,10 +17,11 @@ import (
 )
 
 type fakeCapture struct {
-	chunk          ChunkRef
-	err            error
-	lastDuration   time.Duration
-	captureInvoked int
+	chunk            ChunkRef
+	err              error
+	lastDuration     time.Duration
+	lastSegmentCount int
+	captureInvoked   int
 }
 
 func (f *fakeCapture) Capture(_ context.Context, _ string) (ChunkRef, error) {
@@ -33,6 +34,11 @@ func (f *fakeCapture) Capture(_ context.Context, _ string) (ChunkRef, error) {
 
 func (f *fakeCapture) CaptureWithDuration(ctx context.Context, streamerID string, duration time.Duration) (ChunkRef, error) {
 	f.lastDuration = duration
+	return f.Capture(ctx, streamerID)
+}
+
+func (f *fakeCapture) CaptureWithSegmentCount(ctx context.Context, streamerID string, segmentCount int) (ChunkRef, error) {
+	f.lastSegmentCount = segmentCount
 	return f.Capture(ctx, streamerID)
 }
 
@@ -744,7 +750,7 @@ func TestWorkerProcessScenarioPackageUsesPackageModelConfigWhenStepModelMissing(
 	}
 }
 
-func TestWorkerProcessStreamerUsesStepSegmentDuration(t *testing.T) {
+func TestWorkerProcessStreamerUsesStepSegmentCount(t *testing.T) {
 	capture := &fakeCapture{chunk: ChunkRef{Reference: "chunk-1", CapturedAt: time.Now().UTC()}}
 	worker := NewWorker(
 		capture,
@@ -755,7 +761,7 @@ func TestWorkerProcessStreamerUsesStepSegmentDuration(t *testing.T) {
 				GameSlug:         "global",
 				LLMModelConfigID: "cfg-default",
 				Steps: []prompts.ScenarioStep{
-					{ID: "initial", Name: "Initial", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1, SegmentSeconds: 15},
+					{ID: "initial", Name: "Initial", PromptTemplate: "detect", ResponseSchemaJSON: `{}`, Initial: true, Order: 1, SegmentCount: 15},
 				},
 			},
 			llmModelConfig: prompts.LLMModelConfig{ID: "cfg-default", Model: "gemini-2.5-flash"},
@@ -769,8 +775,8 @@ func TestWorkerProcessStreamerUsesStepSegmentDuration(t *testing.T) {
 	if _, err := worker.ProcessStreamer(context.Background(), "streamer-1"); err != nil {
 		t.Fatalf("process streamer: %v", err)
 	}
-	if capture.lastDuration != 15*time.Second {
-		t.Fatalf("capture duration = %v, want 15s", capture.lastDuration)
+	if capture.lastSegmentCount != 15 {
+		t.Fatalf("capture segment count = %d, want 15", capture.lastSegmentCount)
 	}
 }
 

--- a/internal/prompts/scenario_flow.go
+++ b/internal/prompts/scenario_flow.go
@@ -31,7 +31,8 @@ type ScenarioStep struct {
 	EntryCondition     string    `json:"entryCondition,omitempty"`
 	PromptTemplate     string    `json:"promptTemplate"`
 	ResponseSchemaJSON string    `json:"responseSchemaJson"`
-	SegmentSeconds     int       `json:"segmentSeconds,omitempty"`
+	SegmentCount       int       `json:"segmentCount,omitempty"`
+	SegmentSeconds     int       `json:"segmentSeconds,omitempty"` // Deprecated: use SegmentCount.
 	MaxRequests        int       `json:"maxRequests,omitempty"`
 	Initial            bool      `json:"initial"`
 	Order              int       `json:"order"`
@@ -240,12 +241,18 @@ func normalizeScenarioSteps(steps []ScenarioStep, fallbackGameSlug string, now t
 		if strings.TrimSpace(normalized[i].GameSlug) == "" {
 			normalized[i].GameSlug = fallbackGameSlug
 		}
-		if normalized[i].SegmentSeconds <= 0 {
+		if normalized[i].SegmentCount <= 0 {
+			normalized[i].SegmentCount = normalized[i].SegmentSeconds
+		}
+		if normalized[i].SegmentCount <= 0 {
 			if normalized[i].Initial {
-				normalized[i].SegmentSeconds = 15
+				normalized[i].SegmentCount = 15
 			} else {
-				normalized[i].SegmentSeconds = 30
+				normalized[i].SegmentCount = 30
 			}
+		}
+		if normalized[i].SegmentSeconds <= 0 {
+			normalized[i].SegmentSeconds = normalized[i].SegmentCount
 		}
 		if normalized[i].MaxRequests < 0 {
 			normalized[i].MaxRequests = 0

--- a/internal/prompts/scenario_flow_test.go
+++ b/internal/prompts/scenario_flow_test.go
@@ -593,11 +593,11 @@ func TestScenarioPackageCreateAppliesStepDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create scenario package: %v", err)
 	}
-	if item.Steps[0].SegmentSeconds != 15 {
-		t.Fatalf("expected initial step segment default 15s, got %d", item.Steps[0].SegmentSeconds)
+	if item.Steps[0].SegmentCount != 15 {
+		t.Fatalf("expected initial step segment count default 15, got %d", item.Steps[0].SegmentCount)
 	}
-	if item.Steps[1].SegmentSeconds != 30 {
-		t.Fatalf("expected non-initial step segment default 30s, got %d", item.Steps[1].SegmentSeconds)
+	if item.Steps[1].SegmentCount != 30 {
+		t.Fatalf("expected non-initial step segment count default 30, got %d", item.Steps[1].SegmentCount)
 	}
 	if item.Steps[0].MaxRequests != 0 || item.Steps[1].MaxRequests != 0 {
 		t.Fatalf("expected maxRequests default 0 (unlimited), got %#v", item.Steps)


### PR DESCRIPTION
### Motivation
- Align stream capture and scenario orchestration to operate on discrete source segment files instead of wall-clock seconds to avoid dropped or overlapping footage when assembling LLM chunks.
- Provide a backwards-compatible transition away from the legacy `segmentSeconds` semantics while allowing admins to tune how many source files are included per LLM request.

### Description
- Introduce `segmentCount` on scenario steps and make `segmentSeconds` a deprecated alias, updating the OpenAPI schema to expose `segmentCount` and mark `segmentSeconds` as deprecated.
- Update internal models and normalization (`prompts.ScenarioStep`, `normalizeScenarioSteps`) to default and migrate values from `segmentSeconds` into `segmentCount` and keep both populated for compatibility.
- Extend the stream capture API with `CaptureWithSegmentCount` and related continuous capture flow so the worker and adapter assemble N source segment files (instead of N seconds) per LLM chunk, and update logging fields to `segmentCount`.
- Wire worker logic to use `ScenarioStep.SegmentCount` end-to-end (`captureWithRetry`, `captureChunk`, `ProcessStreamer`, `processScenarioPackage`) and preserve compatibility with duration-based adapters by converting counts to durations when necessary.
- Update docs and examples in `docs/*` to reflect the new `segmentCount` terminology and capture behavior.
- Update request/response mappers and router types to accept `segmentCount` and pass it into the prompts layer.

### Testing
- Updated and ran unit tests including `TestWorkerProcessStreamerUsesStepSegmentCount`, `TestStreamlinkCaptureAdapterContinuousUsesRequestedSegmentCount`, `TestScenarioPackageCreateAppliesStepDefaults`, and admin scenario package route tests as part of `go test ./...`.
- All updated unit tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc74daf92c832c8249ad532217929d)