### PR TITLE
Add Redis-backed live event state and Postgres streamer repository, wire services

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -121,6 +121,9 @@ func main() {
 		streamerValidator = nil
 	}
 	streamersService := streamers.NewServiceWithValidator(streamerValidator)
+	if db != nil {
+		streamersService.SetStreamerRepository(streamers.NewPostgresStreamerRepository(db))
+	}
 	streamersService.SetMinLiveViewers(cfg.Client.MinViewers)
 	streamersService.SetLogger(logger.Named("streamers"))
 	gamesService := games.NewService()
@@ -131,6 +134,9 @@ func main() {
 	eventsService := events.NewService(nil)
 	if db != nil {
 		eventsService = events.NewPostgresService(db, nil)
+	}
+	if redisClient != nil {
+		eventsService.WithRedisLiveState(redisClient, 6*time.Hour)
 	}
 
 	streamCapture := buildStreamCapture(cfg, streamersService)

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -122,9 +122,14 @@ func (s *Service) CreateLiveEvent(ctx context.Context, req CreateLiveEventReques
 	if req.Duration <= 0 {
 		req.Duration = 5 * time.Minute
 	}
-	templateID := strings.TrimSpace(req.StreamerID) + ":" + strings.TrimSpace(req.TerminalID)
-	if s.db != nil {
-		if existing, ok, err := s.findActiveEventByTemplateDB(ctx, strings.TrimSpace(req.StreamerID), templateID, now); err != nil {
+	streamerID := strings.TrimSpace(req.StreamerID)
+	templateID := streamerID + ":" + strings.TrimSpace(req.TerminalID)
+	if s.redis != nil {
+		if existing, ok := s.findActiveEventByTemplateRedis(ctx, streamerID, templateID, now); ok {
+			return existing, ErrAlreadyActive
+		}
+	} else if s.db != nil {
+		if existing, ok, err := s.findActiveEventByTemplateDB(ctx, streamerID, templateID, now); err != nil {
 			return LiveEvent{}, err
 		} else if ok {
 			return existing, ErrAlreadyActive
@@ -132,18 +137,20 @@ func (s *Service) CreateLiveEvent(ctx context.Context, req CreateLiveEventReques
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, item := range s.items {
-		if item.event.StreamerID != strings.TrimSpace(req.StreamerID) || item.event.TemplateID != templateID {
-			continue
-		}
-		if isOpen(item.event, now) {
-			return item.event, ErrAlreadyActive
+	if s.redis == nil {
+		for _, item := range s.items {
+			if item.event.StreamerID != streamerID || item.event.TemplateID != templateID {
+				continue
+			}
+			if isOpen(item.event, now) {
+				return item.event, ErrAlreadyActive
+			}
 		}
 	}
 	event := LiveEvent{
 		ID:              uuid.NewString(),
 		TemplateID:      templateID,
-		StreamerID:      strings.TrimSpace(req.StreamerID),
+		StreamerID:      streamerID,
 		ScenarioID:      strings.TrimSpace(req.ScenarioID),
 		TransitionID:    strings.TrimSpace(req.TransitionID),
 		TerminalID:      strings.TrimSpace(req.TerminalID),
@@ -164,14 +171,23 @@ func (s *Service) CreateLiveEvent(ctx context.Context, req CreateLiveEventReques
 		userVotes:      map[string]voteRecord{},
 	}
 	s.items[event.ID] = state
-	if s.db != nil {
+	if s.redis != nil {
+		if err := s.persistLiveState(ctx, event); err != nil {
+			delete(s.items, event.ID)
+			return LiveEvent{}, err
+		}
+		if s.db != nil {
+			if err := s.persistLiveEventHistoryFromRedis(ctx, event.ID, now); err != nil {
+				delete(s.items, event.ID)
+				_ = s.deleteLiveState(ctx, event)
+				return LiveEvent{}, err
+			}
+		}
+	} else if s.db != nil {
 		if err := s.insertLiveEventDB(ctx, event, now); err != nil {
 			delete(s.items, event.ID)
 			return LiveEvent{}, err
 		}
-	}
-	if s.redis != nil {
-		_ = s.persistLiveState(ctx, event)
 	}
 	return event, nil
 }
@@ -398,12 +414,11 @@ func (s *Service) rollbackWeeklyRewardClaimDB(userID string, claimedAt string) {
 
 func (s *Service) ListLiveByStreamer(ctx context.Context, streamerID string) []LiveEvent {
 	if s.redis != nil {
-		if event, ok := s.readActiveEventFromRedis(ctx, streamerID); ok {
-			now := time.Now().UTC()
-			if isOpen(event, now) {
-				return []LiveEvent{event}
-			}
+		items := s.listOpenEventsFromRedis(ctx, streamerID, time.Now().UTC())
+		if len(items) > 0 {
+			s.cacheLoadedEvents(items)
 		}
+		return items
 	}
 	if s.db != nil {
 		if items, err := s.listOpenEventsByStreamerDB(ctx, strings.TrimSpace(streamerID), time.Now().UTC()); err == nil && len(items) > 0 {
@@ -451,7 +466,11 @@ func (s *Service) Vote(ctx context.Context, req VoteRequest) (LiveEvent, error) 
 				return event, nil
 			}
 		}
-		if err := s.ensureLiveEventLoaded(ctx, strings.TrimSpace(req.EventID), strings.TrimSpace(req.StreamerID)); err != nil {
+		if s.redis != nil {
+			if err := s.ensureLiveEventLoadedFromRedis(ctx, strings.TrimSpace(req.EventID), strings.TrimSpace(req.StreamerID)); err != nil {
+				return LiveEvent{}, err
+			}
+		} else if err := s.ensureLiveEventLoaded(ctx, strings.TrimSpace(req.EventID), strings.TrimSpace(req.StreamerID)); err != nil {
 			return LiveEvent{}, err
 		}
 	}
@@ -494,13 +513,21 @@ func (s *Service) Vote(ctx context.Context, req VoteRequest) (LiveEvent, error) 
 	userVote.Amount += req.Amount
 	item.userVotes[strings.TrimSpace(req.UserID)] = userVote
 	item.processedVotes[strings.TrimSpace(req.IdempotencyKey)] = voteRecord{OptionID: optionID, Amount: req.Amount}
-	if s.db != nil {
-		if err := s.persistVoteDB(ctx, item.event, req, optionID); err != nil {
+	if s.redis != nil {
+		if err := s.persistLiveState(ctx, item.event); err != nil {
 			return LiveEvent{}, err
 		}
 	}
-	if s.redis != nil {
-		_ = s.persistLiveState(ctx, item.event)
+	if s.db != nil {
+		eventForHistory := item.event
+		if s.redis != nil {
+			if redisEvent, ok := s.readLiveEventStateFromRedis(ctx, item.event.ID); ok {
+				eventForHistory = redisEvent
+			}
+		}
+		if err := s.persistVoteDB(ctx, eventForHistory, req, optionID); err != nil {
+			return LiveEvent{}, err
+		}
 	}
 	optionPool := item.event.Totals[optionID]
 	coefficient := calculateCoefficient(item.event.DistributableINT, optionPool)
@@ -544,34 +571,160 @@ func (s *Service) persistLiveState(ctx context.Context, event LiveEvent) error {
 	if ttl <= 0 {
 		ttl = 6 * time.Hour
 	}
-	stateKey := fmt.Sprintf("live_event:%s:state", event.ID)
-	activeKey := fmt.Sprintf("streamer:%s:active_event", event.StreamerID)
-	b, err := json.Marshal(event)
+	stateKey := liveEventStateKey(event.ID)
+	latestKey := latestActiveEventKey(event.StreamerID)
+	activeSetKey := activeEventsSetKey(event.StreamerID)
+	templateKey := activeTemplateKey(event.StreamerID, event.TemplateID)
+	b, err := json.Marshal(redisLiveEventState{Event: event, StreamerID: event.StreamerID})
 	if err != nil {
 		return err
 	}
 	if err = s.redis.Set(ctx, stateKey, b, ttl).Err(); err != nil {
 		return err
 	}
-	return s.redis.Set(ctx, activeKey, event.ID, ttl).Err()
+	if err = s.redis.SAdd(ctx, activeSetKey, event.ID).Err(); err != nil {
+		return err
+	}
+	if err = s.redis.Expire(ctx, activeSetKey, ttl).Err(); err != nil {
+		return err
+	}
+	if err = s.redis.Set(ctx, latestKey, event.ID, ttl).Err(); err != nil {
+		return err
+	}
+	return s.redis.Set(ctx, templateKey, event.ID, ttl).Err()
 }
 
-func (s *Service) readActiveEventFromRedis(ctx context.Context, streamerID string) (LiveEvent, bool) {
-	activeKey := fmt.Sprintf("streamer:%s:active_event", streamerID)
-	eventID, err := s.redis.Get(ctx, activeKey).Result()
+func (s *Service) deleteLiveState(ctx context.Context, event LiveEvent) error {
+	if s.redis == nil {
+		return nil
+	}
+	if err := s.redis.SRem(ctx, activeEventsSetKey(event.StreamerID), event.ID).Err(); err != nil {
+		return err
+	}
+	return s.redis.Del(ctx,
+		liveEventStateKey(event.ID),
+		latestActiveEventKey(event.StreamerID),
+		activeTemplateKey(event.StreamerID, event.TemplateID),
+	).Err()
+}
+
+func (s *Service) findActiveEventByTemplateRedis(ctx context.Context, streamerID, templateID string, now time.Time) (LiveEvent, bool) {
+	if s.redis == nil {
+		return LiveEvent{}, false
+	}
+	eventID, err := s.redis.Get(ctx, activeTemplateKey(streamerID, templateID)).Result()
 	if err != nil || strings.TrimSpace(eventID) == "" {
 		return LiveEvent{}, false
 	}
-	stateKey := fmt.Sprintf("live_event:%s:state", strings.TrimSpace(eventID))
-	raw, err := s.redis.Get(ctx, stateKey).Bytes()
+	event, ok := s.readLiveEventStateFromRedis(ctx, eventID)
+	if !ok || !isOpen(event, now) {
+		return LiveEvent{}, false
+	}
+	return event, true
+}
+
+func (s *Service) listOpenEventsFromRedis(ctx context.Context, streamerID string, now time.Time) []LiveEvent {
+	if s.redis == nil || strings.TrimSpace(streamerID) == "" {
+		return []LiveEvent{}
+	}
+	ids, err := s.redis.SMembers(ctx, activeEventsSetKey(streamerID)).Result()
+	if err != nil || len(ids) == 0 {
+		if event, ok := s.readLatestActiveEventFromRedis(ctx, streamerID); ok && isOpen(event, now) {
+			return []LiveEvent{event}
+		}
+		return []LiveEvent{}
+	}
+	items := make([]LiveEvent, 0, len(ids))
+	for _, id := range ids {
+		event, ok := s.readLiveEventStateFromRedis(ctx, id)
+		if !ok || !isOpen(event, now) {
+			continue
+		}
+		event.Status = "open"
+		items = append(items, event)
+	}
+	return items
+}
+
+func (s *Service) readLatestActiveEventFromRedis(ctx context.Context, streamerID string) (LiveEvent, bool) {
+	eventID, err := s.redis.Get(ctx, latestActiveEventKey(streamerID)).Result()
+	if err != nil || strings.TrimSpace(eventID) == "" {
+		return LiveEvent{}, false
+	}
+	return s.readLiveEventStateFromRedis(ctx, eventID)
+}
+
+func (s *Service) readLiveEventStateFromRedis(ctx context.Context, eventID string) (LiveEvent, bool) {
+	if s.redis == nil || strings.TrimSpace(eventID) == "" {
+		return LiveEvent{}, false
+	}
+	raw, err := s.redis.Get(ctx, liveEventStateKey(eventID)).Bytes()
 	if err != nil {
 		return LiveEvent{}, false
+	}
+	var wrapped redisLiveEventState
+	if err = json.Unmarshal(raw, &wrapped); err == nil && strings.TrimSpace(wrapped.Event.ID) != "" {
+		wrapped.Event.StreamerID = firstNonEmpty(strings.TrimSpace(wrapped.StreamerID), strings.TrimSpace(wrapped.Event.StreamerID))
+		return wrapped.Event, true
 	}
 	var event LiveEvent
 	if err = json.Unmarshal(raw, &event); err != nil {
 		return LiveEvent{}, false
 	}
 	return event, true
+}
+
+func (s *Service) ensureLiveEventLoadedFromRedis(ctx context.Context, eventID, streamerID string) error {
+	s.mu.RLock()
+	item, ok := s.items[eventID]
+	s.mu.RUnlock()
+	if ok && item.event.StreamerID == streamerID {
+		return nil
+	}
+	event, found := s.readLiveEventStateFromRedis(ctx, eventID)
+	if !found || event.StreamerID != streamerID {
+		return ErrEventNotFound
+	}
+	s.cacheLoadedEvents([]LiveEvent{event})
+	return nil
+}
+
+func (s *Service) persistLiveEventHistoryFromRedis(ctx context.Context, eventID string, openedAt time.Time) error {
+	event, ok := s.readLiveEventStateFromRedis(ctx, eventID)
+	if !ok {
+		return ErrEventNotFound
+	}
+	return s.insertLiveEventDB(ctx, event, openedAt)
+}
+
+func liveEventStateKey(eventID string) string {
+	return fmt.Sprintf("live_event:%s:state", strings.TrimSpace(eventID))
+}
+
+func latestActiveEventKey(streamerID string) string {
+	return fmt.Sprintf("streamer:%s:active_event", strings.TrimSpace(streamerID))
+}
+
+func activeEventsSetKey(streamerID string) string {
+	return fmt.Sprintf("streamer:%s:active_events", strings.TrimSpace(streamerID))
+}
+
+func activeTemplateKey(streamerID, templateID string) string {
+	return fmt.Sprintf("streamer:%s:template:%s:active_event", strings.TrimSpace(streamerID), strings.TrimSpace(templateID))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+type redisLiveEventState struct {
+	Event      LiveEvent `json:"event"`
+	StreamerID string    `json:"streamerId"`
 }
 
 type dbVoteRecord struct {

--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -3,10 +3,13 @@ package events
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
 )
 
 func TestListLiveByStreamer(t *testing.T) {
@@ -298,5 +301,99 @@ func TestPostgresVotePersistsVoteHistoryAndTotals(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet db expectations: %v", err)
+	}
+}
+
+func TestRedisLiveEventCreateUsesRedisBeforePostgresHistory(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	defer redisClient.Close() //nolint:errcheck
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	svc := NewPostgresService(db, nil)
+	svc.WithRedisLiveState(redisClient, time.Hour)
+
+	streamerID := "00000000-0000-0000-0000-000000000101"
+	scenarioID := "00000000-0000-0000-0000-000000000102"
+	mock.ExpectExec("INSERT INTO live_event_history").
+		WithArgs(sqlmock.AnyArg(), streamerID, scenarioID, streamerID+":terminal-redis", "transition-redis", "terminal-redis", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "open", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	created, err := svc.CreateLiveEvent(context.Background(), CreateLiveEventRequest{
+		StreamerID:      streamerID,
+		ScenarioID:      scenarioID,
+		TransitionID:    "transition-redis",
+		TerminalID:      "terminal-redis",
+		Title:           map[string]string{"ru": "Победитель карты"},
+		DefaultLanguage: "ru",
+		Options:         []Option{{ID: "ct", Title: map[string]string{"ru": "CT"}}},
+		Duration:        time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("CreateLiveEvent() error = %v", err)
+	}
+	if _, ok := svc.readLiveEventStateFromRedis(context.Background(), created.ID); !ok {
+		t.Fatalf("expected event state to be written to Redis")
+	}
+
+	if _, err := svc.CreateLiveEvent(context.Background(), CreateLiveEventRequest{
+		StreamerID:      streamerID,
+		ScenarioID:      scenarioID,
+		TransitionID:    "transition-redis",
+		TerminalID:      "terminal-redis",
+		Title:           map[string]string{"ru": "Победитель карты"},
+		DefaultLanguage: "ru",
+		Options:         []Option{{ID: "ct", Title: map[string]string{"ru": "CT"}}},
+		Duration:        time.Minute,
+	}); !errors.Is(err, ErrAlreadyActive) {
+		t.Fatalf("expected duplicate active event from Redis, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet db expectations: %v", err)
+	}
+}
+
+func TestListLiveByStreamerUsesRedisAsActiveSourceWhenPostgresExists(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	defer redisClient.Close() //nolint:errcheck
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	svc := NewPostgresService(db, nil)
+	svc.WithRedisLiveState(redisClient, time.Hour)
+	event := LiveEvent{
+		ID:              "event-redis-list",
+		TemplateID:      "00000000-0000-0000-0000-000000000201:terminal-1",
+		StreamerID:      "00000000-0000-0000-0000-000000000201",
+		ScenarioID:      "00000000-0000-0000-0000-000000000202",
+		TerminalID:      "terminal-1",
+		Title:           map[string]string{"ru": "Победитель карты"},
+		DefaultLanguage: "ru",
+		Options:         []Option{{ID: "ct", Title: map[string]string{"ru": "CT"}}},
+		ClosesAt:        time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+		Status:          "open",
+		Totals:          map[string]int64{"ct": 0},
+	}
+	if err := svc.persistLiveState(context.Background(), event); err != nil {
+		t.Fatalf("persistLiveState() error = %v", err)
+	}
+
+	items := svc.ListLiveByStreamer(context.Background(), event.StreamerID)
+	if len(items) != 1 || items[0].ID != event.ID {
+		t.Fatalf("expected Redis live event, got %#v", items)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected db calls: %v", err)
 	}
 }

--- a/internal/streamers/postgres_repository.go
+++ b/internal/streamers/postgres_repository.go
@@ -1,0 +1,208 @@
+package streamers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// PostgresStreamerRepository persists user-submitted streamers in the streamers table.
+// The database status column models operational availability (active/inactive/disabled),
+// while the user-facing submission moderation status is kept in metadata.submissionStatus.
+type PostgresStreamerRepository struct {
+	db *sql.DB
+}
+
+func NewPostgresStreamerRepository(db *sql.DB) *PostgresStreamerRepository {
+	return &PostgresStreamerRepository{db: db}
+}
+
+func (r *PostgresStreamerRepository) List(ctx context.Context, query, status string, page int) ([]Streamer, error) {
+	if r == nil || r.db == nil {
+		return []Streamer{}, nil
+	}
+	rows, err := r.db.QueryContext(ctx, `
+SELECT id::text, twitch_username, display_name, status, metadata
+FROM streamers
+ORDER BY created_at DESC, id DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	items := make([]Streamer, 0)
+	for rows.Next() {
+		item, scanErr := scanStreamer(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return filterStreamers(items, query, status, page), nil
+}
+
+func (r *PostgresStreamerRepository) GetByID(ctx context.Context, id string) (Streamer, bool, error) {
+	if r == nil || r.db == nil || strings.TrimSpace(id) == "" {
+		return Streamer{}, false, nil
+	}
+	row := r.db.QueryRowContext(ctx, `
+SELECT id::text, twitch_username, display_name, status, metadata
+FROM streamers
+WHERE id = $1`, strings.TrimSpace(id))
+	item, err := scanStreamer(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Streamer{}, false, nil
+	}
+	if err != nil {
+		return Streamer{}, false, err
+	}
+	return item, true, nil
+}
+
+func (r *PostgresStreamerRepository) Upsert(ctx context.Context, item Streamer) (Streamer, error) {
+	if r == nil || r.db == nil {
+		return item, nil
+	}
+	item = normalizeStreamerForStorage(item)
+	metadata, err := marshalStreamerMetadata(item)
+	if err != nil {
+		return Streamer{}, err
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Streamer{}, err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var existingID string
+	err = tx.QueryRowContext(ctx, `
+SELECT id::text
+FROM streamers
+WHERE lower(twitch_username) = lower($1)
+FOR UPDATE`, item.TwitchNickname).Scan(&existingID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return Streamer{}, err
+	}
+	if existingID != "" {
+		item.ID = existingID
+		_, err = tx.ExecContext(ctx, `
+UPDATE streamers
+SET twitch_username = $2,
+    display_name = $3,
+    status = $4,
+    metadata = $5::jsonb
+WHERE id = $1`, item.ID, item.TwitchNickname, item.DisplayName, dbStreamerStatus(item.Status), string(metadata))
+		if err != nil {
+			return Streamer{}, err
+		}
+	} else {
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO streamers (id, twitch_username, display_name, status, metadata)
+VALUES ($1, $2, $3, $4, $5::jsonb)`, item.ID, item.TwitchNickname, item.DisplayName, dbStreamerStatus(item.Status), string(metadata))
+		if err != nil {
+			return Streamer{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return Streamer{}, err
+	}
+	return item, nil
+}
+
+func (r *PostgresStreamerRepository) Delete(ctx context.Context, id string) error {
+	if r == nil || r.db == nil || strings.TrimSpace(id) == "" {
+		return nil
+	}
+	_, err := r.db.ExecContext(ctx, `DELETE FROM streamers WHERE id = $1`, strings.TrimSpace(id))
+	return err
+}
+
+type streamerScanner interface {
+	Scan(dest ...any) error
+}
+
+type streamerMetadata struct {
+	Platform         string `json:"platform,omitempty"`
+	MiniIconURL      string `json:"miniIconUrl,omitempty"`
+	Online           bool   `json:"online,omitempty"`
+	Viewers          int    `json:"viewers,omitempty"`
+	AddedBy          string `json:"addedBy,omitempty"`
+	SubmissionStatus string `json:"submissionStatus,omitempty"`
+}
+
+func scanStreamer(scanner streamerScanner) (Streamer, error) {
+	var item Streamer
+	var dbStatus string
+	var metadataRaw []byte
+	if err := scanner.Scan(&item.ID, &item.TwitchNickname, &item.DisplayName, &dbStatus, &metadataRaw); err != nil {
+		return Streamer{}, err
+	}
+	metadata := streamerMetadata{}
+	if len(metadataRaw) > 0 {
+		if err := json.Unmarshal(metadataRaw, &metadata); err != nil {
+			return Streamer{}, err
+		}
+	}
+	item.Platform = firstNonEmptyStreamer(metadata.Platform, "twitch")
+	item.MiniIconURL = strings.TrimSpace(metadata.MiniIconURL)
+	item.Online = metadata.Online
+	item.Viewers = metadata.Viewers
+	item.AddedBy = strings.TrimSpace(metadata.AddedBy)
+	item.Status = firstNonEmptyStreamer(strings.TrimSpace(metadata.SubmissionStatus), appStreamerStatus(dbStatus))
+	return item, nil
+}
+
+func normalizeStreamerForStorage(item Streamer) Streamer {
+	item.ID = strings.TrimSpace(item.ID)
+	item.Platform = firstNonEmptyStreamer(strings.TrimSpace(item.Platform), "twitch")
+	item.TwitchNickname = strings.ToLower(strings.TrimSpace(item.TwitchNickname))
+	item.DisplayName = strings.TrimSpace(item.DisplayName)
+	item.MiniIconURL = strings.TrimSpace(item.MiniIconURL)
+	item.AddedBy = strings.TrimSpace(item.AddedBy)
+	item.Status = firstNonEmptyStreamer(strings.ToLower(strings.TrimSpace(item.Status)), "pending")
+	return item
+}
+
+func marshalStreamerMetadata(item Streamer) ([]byte, error) {
+	return json.Marshal(streamerMetadata{
+		Platform:         item.Platform,
+		MiniIconURL:      item.MiniIconURL,
+		Online:           item.Online,
+		Viewers:          item.Viewers,
+		AddedBy:          item.AddedBy,
+		SubmissionStatus: item.Status,
+	})
+}
+
+func dbStreamerStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "rejected":
+		return "inactive"
+	default:
+		return "active"
+	}
+}
+
+func appStreamerStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "inactive", "disabled":
+		return "rejected"
+	default:
+		return "approved"
+	}
+}
+
+func firstNonEmptyStreamer(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/streamers/postgres_repository_test.go
+++ b/internal/streamers/postgres_repository_test.go
@@ -1,0 +1,103 @@
+package streamers
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+)
+
+func TestServiceSubmitPersistsPostgresStreamerWithUUID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id::text
+FROM streamers
+WHERE lower(twitch_username) = lower($1)
+FOR UPDATE`)).
+		WithArgs("best_streamer").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectExec(regexp.QuoteMeta(`
+INSERT INTO streamers (id, twitch_username, display_name, status, metadata)
+VALUES ($1, $2, $3, $4, $5::jsonb)`)).
+		WithArgs(sqlmock.AnyArg(), "best_streamer", "Best Streamer", "active", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	svc := NewServiceWithValidator(validatorStub{displayName: "Best Streamer", miniIconURL: "https://cdn.twitch.tv/icon.png"})
+	svc.SetStreamerRepository(NewPostgresStreamerRepository(db))
+	var hookStreamerID string
+	svc.SetSubmissionHook(func(_ context.Context, streamerID string) error {
+		hookStreamerID = streamerID
+		return nil
+	})
+
+	sub, err := svc.Submit(context.Background(), "Best_Streamer", "user-1")
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if _, err := uuid.Parse(sub.ID); err != nil {
+		t.Fatalf("expected UUID streamer id, got %q: %v", sub.ID, err)
+	}
+	if hookStreamerID != sub.ID {
+		t.Fatalf("submission hook streamerID = %q, want %q", hookStreamerID, sub.ID)
+	}
+	items := svc.List(context.Background(), "best", "pending", 1)
+	if len(items) != 1 || items[0].ID != sub.ID {
+		t.Fatalf("expected cached submitted streamer after db insert, got %#v", items)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestPostgresStreamerRepositoryMapsMetadataSubmissionStatus(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	id := uuid.NewString()
+	metadata, err := json.Marshal(streamerMetadata{
+		Platform:         "twitch",
+		MiniIconURL:      "https://cdn.twitch.tv/icon.png",
+		Online:           true,
+		Viewers:          321,
+		AddedBy:          "user-1",
+		SubmissionStatus: "pending",
+	})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id::text, twitch_username, display_name, status, metadata
+FROM streamers
+WHERE id = $1`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "twitch_username", "display_name", "status", "metadata"}).
+			AddRow(id, "best_streamer", "Best Streamer", "active", metadata))
+
+	repo := NewPostgresStreamerRepository(db)
+	item, ok, err := repo.GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected streamer to be found")
+	}
+	if item.Status != "pending" || item.Platform != "twitch" || !item.Online || item.Viewers != 321 || item.AddedBy != "user-1" || item.MiniIconURL == "" {
+		t.Fatalf("unexpected mapped streamer: %#v", item)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/internal/streamers/service.go
+++ b/internal/streamers/service.go
@@ -2,6 +2,7 @@ package streamers
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"regexp"
@@ -56,10 +57,18 @@ type analysisState struct {
 	updatedAt string
 }
 
+type StreamerRepository interface {
+	List(ctx context.Context, query, status string, page int) ([]Streamer, error)
+	GetByID(ctx context.Context, id string) (Streamer, bool, error)
+	Upsert(ctx context.Context, item Streamer) (Streamer, error)
+	Delete(ctx context.Context, id string) error
+}
+
 type Service struct {
 	logger           *zap.Logger
 	mu               sync.RWMutex
 	items            []Streamer
+	streamerRepo     StreamerRepository
 	decisionRepo     DecisionRepository
 	analysis         map[string]analysisState
 	validator        TwitchValidator
@@ -75,6 +84,14 @@ type Service struct {
 
 func NewService() *Service {
 	return NewServiceWithValidator(noopTwitchValidator{})
+}
+
+func NewPostgresService(db *sql.DB, validator TwitchValidator) *Service {
+	svc := NewServiceWithValidator(validator)
+	if db != nil {
+		svc.SetStreamerRepository(NewPostgresStreamerRepository(db))
+	}
+	return svc
 }
 
 func NewServiceWithValidator(validator TwitchValidator) *Service {
@@ -118,6 +135,15 @@ func (s *Service) SetLogger(logger *zap.Logger) {
 	s.logger = logger
 }
 
+func (s *Service) SetStreamerRepository(repo StreamerRepository) {
+	if s == nil || repo == nil {
+		return
+	}
+	s.mu.Lock()
+	s.streamerRepo = repo
+	s.mu.Unlock()
+}
+
 func (s *Service) SetDecisionRepository(repo DecisionRepository) {
 	if s == nil || repo == nil {
 		return
@@ -151,44 +177,56 @@ func (s *Service) trackingStopHook() func(context.Context, string) error {
 	return s.onTrackingStop
 }
 
-func (s *Service) List(_ context.Context, query, status string, page int) []Streamer {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
+func (s *Service) List(ctx context.Context, query, status string, page int) []Streamer {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if page < 1 {
 		page = 1
 	}
-	needle := strings.ToLower(strings.TrimSpace(query))
-	statusFilter := strings.ToLower(strings.TrimSpace(status))
-	matches := make([]Streamer, 0, len(s.items))
-	for _, item := range s.items {
-		if needle != "" && !strings.Contains(strings.ToLower(item.TwitchNickname), needle) && !strings.Contains(strings.ToLower(item.DisplayName), needle) {
-			continue
+
+	s.mu.RLock()
+	repo := s.streamerRepo
+	s.mu.RUnlock()
+	if repo != nil {
+		items, err := repo.List(ctx, query, status, page)
+		if err == nil {
+			return items
 		}
-		if statusFilter != "" && strings.ToLower(item.Status) != statusFilter {
-			continue
+		if s.logger != nil {
+			s.logger.Error("failed to list streamers from repository", zap.Error(err))
 		}
-		matches = append(matches, item)
 	}
 
-	const pageSize = 20
-	start := (page - 1) * pageSize
-	if start >= len(matches) {
-		return []Streamer{}
-	}
-	end := start + pageSize
-	if end > len(matches) {
-		end = len(matches)
-	}
-	result := make([]Streamer, end-start)
-	copy(result, matches[start:end])
-	return result
-}
-
-func (s *Service) GetByID(_ context.Context, id string) (Streamer, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	return filterStreamers(s.items, query, status, page)
+}
+
+func (s *Service) GetByID(ctx context.Context, id string) (Streamer, bool) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	needle := strings.TrimSpace(id)
+	if needle == "" {
+		return Streamer{}, false
+	}
+
+	s.mu.RLock()
+	repo := s.streamerRepo
+	s.mu.RUnlock()
+	if repo != nil {
+		item, ok, err := repo.GetByID(ctx, needle)
+		if err == nil {
+			return item, ok
+		}
+		if s.logger != nil {
+			s.logger.Error("failed to load streamer from repository", zap.String("streamerID", needle), zap.Error(err))
+		}
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	for _, item := range s.items {
 		if item.ID == needle {
 			return item, true
@@ -197,21 +235,15 @@ func (s *Service) GetByID(_ context.Context, id string) (Streamer, bool) {
 	return Streamer{}, false
 }
 
-func (s *Service) ResolveStreamlinkChannel(_ context.Context, streamerID string) (string, error) {
+func (s *Service) ResolveStreamlinkChannel(ctx context.Context, streamerID string) (string, error) {
 	id := strings.TrimSpace(streamerID)
 	if id == "" {
 		return "", ErrNotFound
 	}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	for _, item := range s.items {
-		if item.ID == id {
-			if nickname := strings.TrimSpace(item.TwitchNickname); nickname != "" {
-				return nickname, nil
-			}
-			break
+	if item, ok := s.GetByID(ctx, id); ok {
+		if nickname := strings.TrimSpace(item.TwitchNickname); nickname != "" {
+			return nickname, nil
 		}
 	}
 
@@ -279,8 +311,7 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 		}
 	}
 
-	now := s.nowFn().UnixNano()
-	id := fmt.Sprintf("str_%d", now)
+	id := uuid.NewString()
 	streamer := Streamer{
 		ID:             id,
 		Platform:       "twitch",
@@ -293,8 +324,24 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 		Status:         "pending",
 	}
 
+	s.mu.RLock()
+	repo := s.streamerRepo
+	s.mu.RUnlock()
+	persistedNewStreamer := false
+	if repo != nil {
+		requestedID := id
+		stored, repoErr := repo.Upsert(ctx, streamer)
+		if repoErr != nil {
+			logger.Error("failed to persist streamer", zap.String("streamerID", id), zap.Error(repoErr))
+			return Submission{}, repoErr
+		}
+		streamer = stored
+		id = stored.ID
+		persistedNewStreamer = id == requestedID
+	}
+
 	s.mu.Lock()
-	s.items = append(s.items, streamer)
+	s.upsertCachedStreamerLocked(streamer)
 	s.mu.Unlock()
 
 	logger.Info("streamer stored and awaiting worker scheduling", zap.String("streamerID", id), zap.String("status", streamer.Status))
@@ -303,10 +350,13 @@ func (s *Service) Submit(ctx context.Context, twitchNickname, addedBy string) (S
 		logger.Info("starting streamer submission hook", zap.String("streamerID", id))
 		if err := hook(ctx, id); err != nil {
 			logger.Error("streamer submission hook failed", zap.String("streamerID", id), zap.Error(err))
-			s.mu.Lock()
-			if n := len(s.items); n > 0 && s.items[n-1].ID == id {
-				s.items = s.items[:n-1]
+			if repo != nil && persistedNewStreamer {
+				if deleteErr := repo.Delete(ctx, id); deleteErr != nil && s.logger != nil {
+					s.logger.Error("failed to rollback persisted streamer after hook error", zap.String("streamerID", id), zap.Error(deleteErr))
+				}
 			}
+			s.mu.Lock()
+			s.removeCachedStreamerLocked(id)
 			delete(s.analysis, id)
 			s.mu.Unlock()
 			return Submission{}, err
@@ -327,16 +377,7 @@ func (s *Service) StopTracking(ctx context.Context, streamerID string) error {
 		return ErrNotFound
 	}
 
-	s.mu.RLock()
-	exists := false
-	for _, item := range s.items {
-		if item.ID == id {
-			exists = true
-			break
-		}
-	}
-	s.mu.RUnlock()
-	if !exists {
+	if _, ok := s.GetByID(ctx, id); !ok {
 		return ErrNotFound
 	}
 
@@ -653,6 +694,60 @@ func inferDetectedGameKey(items []LLMDecision) string {
 		}
 	}
 	return ""
+}
+
+func filterStreamers(items []Streamer, query, status string, page int) []Streamer {
+	if page < 1 {
+		page = 1
+	}
+	needle := strings.ToLower(strings.TrimSpace(query))
+	statusFilter := strings.ToLower(strings.TrimSpace(status))
+	matches := make([]Streamer, 0, len(items))
+	for _, item := range items {
+		if needle != "" && !strings.Contains(strings.ToLower(item.TwitchNickname), needle) && !strings.Contains(strings.ToLower(item.DisplayName), needle) {
+			continue
+		}
+		if statusFilter != "" && strings.ToLower(item.Status) != statusFilter {
+			continue
+		}
+		matches = append(matches, item)
+	}
+
+	const pageSize = 20
+	start := (page - 1) * pageSize
+	if start >= len(matches) {
+		return []Streamer{}
+	}
+	end := start + pageSize
+	if end > len(matches) {
+		end = len(matches)
+	}
+	result := make([]Streamer, end-start)
+	copy(result, matches[start:end])
+	return result
+}
+
+func (s *Service) upsertCachedStreamerLocked(item Streamer) {
+	for idx, existing := range s.items {
+		if existing.ID == item.ID {
+			s.items[idx] = item
+			return
+		}
+	}
+	s.items = append(s.items, item)
+}
+
+func (s *Service) removeCachedStreamerLocked(id string) {
+	needle := strings.TrimSpace(id)
+	if needle == "" {
+		return
+	}
+	for idx, item := range s.items {
+		if item.ID == needle {
+			s.items = append(s.items[:idx], s.items[idx+1:]...)
+			return
+		}
+	}
 }
 
 func IsSupportedStatus(status string) bool {


### PR DESCRIPTION
### Motivation
- Introduce Redis-backed live event state to improve live-event performance and make Redis the source of truth for active events while still persisting history to Postgres. 
- Add a Postgres-backed streamer repository to persist streamer submissions and enable repository-backed listing and lookup. 
- Wire these persistence options into the main server and ensure hooks and rollbacks behave correctly when persistence or hooks fail.

### Description
- Implement Redis live-state support in `internal/events/service.go` with functions to persist/read/delete live state, maintain active sets, template indexes, and fall back/coordinate with Postgres history persistence via `WithRedisLiveState`, `persistLiveState`, `readLiveEventStateFromRedis`, `listOpenEventsFromRedis`, `ensureLiveEventLoadedFromRedis`, and related helpers. 
- Update event creation and voting logic to consult Redis first for active-event checks, write live state to Redis, and still persist vote history and event history to Postgres when a DB is configured (`CreateLiveEvent`, `Vote`). 
- Add `PostgresStreamerRepository` in `internal/streamers/postgres_repository.go` implementing `List`, `GetByID`, `Upsert`, and `Delete`, including metadata mapping and normalization helpers. 
- Extend `internal/streamers/service.go` to support an optional `StreamerRepository` (interface), use it for `List`/`GetByID`/`Submit`/`ResolveStreamlinkChannel`, provide `NewPostgresService`, and add cache upsert/remove helpers and safer hook rollback that deletes persisted rows on hook failure. 
- Wire repository and Redis live-state into the server in `cmd/server/main.go` by setting the streamer repository and calling `eventsService.WithRedisLiveState`. 
- Add unit tests for the new Redis-backed behavior and Postgres streamer repository: updates to `internal/events/service_test.go` and new `internal/streamers/postgres_repository_test.go`.

### Testing
- Ran the repository unit tests covering the new behavior including `TestRedisLiveEventCreateUsesRedisBeforePostgresHistory` and `TestListLiveByStreamerUsesRedisAsActiveSourceWhenPostgresExists` in `internal/events`, and the Postgres streamer repository tests in `internal/streamers`; all added tests passed. 
- Existing event and streamer unit tests were exercised together with the new tests during `go test ./...` and completed successfully. 
- SQL interactions in tests are validated with `sqlmock` and Redis usage is exercised with `miniredis` in the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc755f4120832cb16692cb046c6fbe)