### PR TITLE
Persist LLM decision history to Postgres and wire up repositories

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -123,6 +123,7 @@ func main() {
 	streamersService := streamers.NewServiceWithValidator(streamerValidator)
 	if db != nil {
 		streamersService.SetStreamerRepository(streamers.NewPostgresStreamerRepository(db))
+		streamersService.SetDecisionRepository(streamers.NewPostgresDecisionRepository(db))
 	}
 	streamersService.SetMinLiveViewers(cfg.Client.MinViewers)
 	streamersService.SetLogger(logger.Named("streamers"))

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -10,7 +10,9 @@
 - **games** `(id uuid PK, streamer_id uuid FK streamers, title text, rules_json jsonb, status text CHECK (status IN ('draft','active','closed','paused')), start_at timestamptz, end_at timestamptz)`
 - **events** `(id uuid PK, streamer_id uuid FK streamers, game_id uuid FK games, title text, options_json jsonb, state text CHECK (state IN ('live','closed','cancelled')), closes_at timestamptz, totals_json jsonb, result_json jsonb, source_clip_id uuid FK media_clips, prompt_versions_json jsonb, confidence numeric(4,2), created_at timestamptz, updated_at timestamptz)` with indexes on `(streamer_id, state)`, `(game_id, state)`.
 - **votes** `(id uuid PK, event_id uuid FK events, user_id uuid FK users, option_id text, cost_int bigint, idempotency_key text, created_at timestamptz)` with unique constraint `(user_id, event_id)` and indexes `(event_id)`, `(idempotency_key)`.
-- **media_clips** `(id uuid PK, streamer_id uuid FK streamers, url text, thumbnail_url text, started_at timestamptz, duration_sec int, source text DEFAULT 'bunny', created_at timestamptz)`.
+- **streamer_uploaded_videos** `(id uuid PK, streamer_id uuid FK streamers, provider text, video_id text, title text, url text, status text, duration_s int, size_bytes bigint, mime_type text, metadata jsonb, created_at timestamptz, updated_at timestamptz)` stores Bunny/object-storage metadata only; video bytes stay outside PostgreSQL.
+- **media_clips** `(id uuid PK, streamer_id uuid FK streamers, uploaded_video_id uuid FK streamer_uploaded_videos, url text, duration_s int, source_type text, source_id uuid, status text, metadata jsonb, created_at timestamptz, updated_at timestamptz)`.
+- **llm_request_logs** `(id uuid PK, streamer_id uuid FK streamers, scenario_id uuid FK llm_scenarios, model_config_id uuid FK llm_model_configs, request_type text, status text, provider_request_id text, sanitized input_json jsonb, sanitized output_json jsonb, token/latency/cost counters, error_message text, created_at timestamptz, expires_at timestamptz)` stores compact scenario-step decision/request audit data with retention; decision fields are packed into the existing JSON columns to avoid a duplicate history table.
 - **prompts** `(id uuid PK, scope text CHECK (scope IN ('session','game','per_clip')), streamer_id uuid FK streamers NULLABLE, game_id uuid FK games NULLABLE, version text, body_text text, schema_version text, status text CHECK (status IN ('active','inactive')), created_by uuid FK users, created_at timestamptz)`.
 - **config** `(key text PK, value_json jsonb, updated_at timestamptz)`.
 - **idempotency** `(id uuid PK, key text unique, first_seen_at timestamptz, last_seen_at timestamptz, response_cache_json jsonb)`.
@@ -20,11 +22,13 @@
 - `users` 1—n `wallet_ledger`, `payments`, `votes`.
 - `referrals` optionally link `users` to inviter.
 - `streamers` reference `users` via `added_by`.
-- `games`, `events`, `media_clips` tie to `streamers`.
+- `games`, `events`, `media_clips`, `streamer_uploaded_videos`, and `llm_request_logs` tie to `streamers`.
 - `events` belong to a `game` (optional) and may reference a `media_clip`.
 - `votes` belong to both `events` and `users`.
 - `prompts` optionally scoped by streamer/game.
+- `llm_request_logs.provider_request_id` carries the app-level decision id when a decision is recorded, while sanitized `input_json`/`output_json` preserve prompt/state metadata without storing video bytes or unsanitized inline media.
 
 ## Partitioning Strategy (Future)
 - Partition `wallet_ledger` by month once record counts exceed 10M.
 - Partition `votes` by `(streamer_id HASH)` or `(created_at RANGE)` depending on access patterns.
+- Partition or periodically purge `llm_request_logs` by `expires_at`/`created_at` when request volume grows; keep only compact state deltas and sanitized payloads in PostgreSQL.

--- a/internal/media/video_store_postgres.go
+++ b/internal/media/video_store_postgres.go
@@ -25,11 +25,13 @@ func (s *PostgresUploadedVideoStore) Save(ctx context.Context, streamerID string
 		return nil
 	}
 	const query = `
-INSERT INTO streamer_uploaded_videos (streamer_id, video_id, title, url, created_at)
-VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (streamer_id, video_id)
-DO UPDATE SET title = EXCLUDED.title,
+INSERT INTO streamer_uploaded_videos (streamer_id, provider, video_id, title, url, status, created_at)
+VALUES ($1, 'bunny', $2, $3, $4, 'ready', $5)
+ON CONFLICT (provider, video_id)
+DO UPDATE SET streamer_id = EXCLUDED.streamer_id,
+              title = EXCLUDED.title,
               url = EXCLUDED.url,
+              status = EXCLUDED.status,
               created_at = EXCLUDED.created_at`
 	if _, err := s.db.ExecContext(ctx, query, key, strings.TrimSpace(item.ID), strings.TrimSpace(item.Title), strings.TrimSpace(item.URL), strings.TrimSpace(item.CreatedAt)); err != nil {
 		return fmt.Errorf("save uploaded video metadata: %w", err)

--- a/internal/streamers/decision_postgres_repository.go
+++ b/internal/streamers/decision_postgres_repository.go
@@ -1,0 +1,316 @@
+package streamers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PostgresDecisionRepository stores durable LLM decision history in the existing
+// llm_request_logs table. Video bytes stay in object storage; only sanitized
+// references and payload summaries are written to PostgreSQL.
+type PostgresDecisionRepository struct {
+	db *sql.DB
+}
+
+func NewPostgresDecisionRepository(db *sql.DB) *PostgresDecisionRepository {
+	return &PostgresDecisionRepository{db: db}
+}
+
+func (r *PostgresDecisionRepository) RecordLLMDecision(ctx context.Context, item LLMDecision) error {
+	if r == nil || r.db == nil {
+		return nil
+	}
+	item = normalizeDecisionForPostgres(item)
+	if strings.TrimSpace(item.StreamerID) == "" {
+		return nil
+	}
+	createdAt := nullableTimeFromString(item.CreatedAt)
+	if !createdAt.Valid {
+		createdAt = sql.NullTime{Time: time.Now().UTC(), Valid: true}
+	}
+	inputJSON, outputJSON, err := marshalLLMDecisionLogPayloads(item)
+	if err != nil {
+		return err
+	}
+	const query = `
+	INSERT INTO llm_request_logs (
+	    streamer_id, request_type, status, provider_request_id,
+	    input_json, output_json, prompt_tokens, completion_tokens,
+	    total_tokens, latency_ms, error_message, created_at
+	)
+	VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, $8, $9, $10, $11, $12)`
+	if _, err := r.db.ExecContext(ctx, query,
+		item.StreamerID,
+		item.Stage,
+		"success",
+		firstNonEmptyStreamer(item.ID, item.RequestRef),
+		string(inputJSON),
+		string(outputJSON),
+		item.TokensIn,
+		item.TokensOut,
+		item.TokensIn+item.TokensOut,
+		item.LatencyMS,
+		"",
+		createdAt,
+	); err != nil {
+		return fmt.Errorf("record llm decision request log: %w", err)
+	}
+	return nil
+}
+
+func (r *PostgresDecisionRepository) ListLLMDecisions(ctx context.Context, streamerID string, limit int) ([]LLMDecision, error) {
+	if r == nil || r.db == nil || strings.TrimSpace(streamerID) == "" {
+		return []LLMDecision{}, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	const query = selectLLMRequestLogDecisionColumns + `
+	FROM llm_request_logs
+	WHERE streamer_id = $1
+	ORDER BY created_at DESC, id DESC
+	LIMIT $2`
+	rows, err := r.db.QueryContext(ctx, query, strings.TrimSpace(streamerID), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list llm decisions: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+	return scanLLMRequestLogDecisionRows(rows)
+}
+
+func (r *PostgresDecisionRepository) ListAllLLMDecisions(ctx context.Context, streamerID string) ([]LLMDecision, error) {
+	if r == nil || r.db == nil || strings.TrimSpace(streamerID) == "" {
+		return []LLMDecision{}, nil
+	}
+	const query = selectLLMRequestLogDecisionColumns + `
+	FROM llm_request_logs
+	WHERE streamer_id = $1
+	ORDER BY created_at ASC, id ASC`
+	rows, err := r.db.QueryContext(ctx, query, strings.TrimSpace(streamerID))
+	if err != nil {
+		return nil, fmt.Errorf("list all llm decisions: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+	return scanLLMRequestLogDecisionRows(rows)
+}
+
+func (r *PostgresDecisionRepository) DeleteAllLLMDecisions(ctx context.Context, streamerID string) (int, error) {
+	if r == nil || r.db == nil || strings.TrimSpace(streamerID) == "" {
+		return 0, nil
+	}
+	res, err := r.db.ExecContext(ctx, `DELETE FROM llm_request_logs WHERE streamer_id = $1`, strings.TrimSpace(streamerID))
+	if err != nil {
+		return 0, fmt.Errorf("delete llm request logs: %w", err)
+	}
+	deleted, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count deleted llm request logs: %w", err)
+	}
+	return int(deleted), nil
+}
+
+const selectLLMRequestLogDecisionColumns = `
+	SELECT id::text, streamer_id::text, request_type, provider_request_id,
+	       input_json, output_json, prompt_tokens, completion_tokens,
+	       latency_ms, created_at`
+
+func scanLLMRequestLogDecisionRows(rows *sql.Rows) ([]LLMDecision, error) {
+	items := make([]LLMDecision, 0)
+	for rows.Next() {
+		item, err := scanLLMRequestLogDecision(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate llm decisions: %w", err)
+	}
+	return items, nil
+}
+
+type llmDecisionScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanLLMRequestLogDecision(scanner llmDecisionScanner) (LLMDecision, error) {
+	var (
+		logID             string
+		streamerID        string
+		requestType       string
+		providerRequestID string
+		inputRaw          []byte
+		outputRaw         []byte
+		promptTokens      int
+		completionTokens  int
+		latencyMS         int64
+		createdAt         time.Time
+	)
+	if err := scanner.Scan(
+		&logID, &streamerID, &requestType, &providerRequestID,
+		&inputRaw, &outputRaw, &promptTokens, &completionTokens,
+		&latencyMS, &createdAt,
+	); err != nil {
+		return LLMDecision{}, fmt.Errorf("scan llm decision request log: %w", err)
+	}
+	inputPayload := llmDecisionInputPayload{}
+	if len(inputRaw) > 0 {
+		if err := json.Unmarshal(inputRaw, &inputPayload); err != nil {
+			return LLMDecision{}, fmt.Errorf("decode llm decision input_json: %w", err)
+		}
+	}
+	outputPayload := llmDecisionOutputPayload{}
+	if len(outputRaw) > 0 {
+		if err := json.Unmarshal(outputRaw, &outputPayload); err != nil {
+			return LLMDecision{}, fmt.Errorf("decode llm decision output_json: %w", err)
+		}
+	}
+	item := LLMDecision{
+		ID:                 firstNonEmptyStreamer(outputPayload.DecisionID, providerRequestID, logID),
+		RunID:              inputPayload.RunID,
+		StreamerID:         streamerID,
+		Stage:              firstNonEmptyStreamer(outputPayload.Stage, requestType),
+		Label:              outputPayload.Label,
+		Confidence:         outputPayload.Confidence,
+		ChunkCapturedAt:    inputPayload.ChunkCapturedAt,
+		PromptVersionID:    inputPayload.PromptVersionID,
+		PromptText:         inputPayload.PromptText,
+		Model:              inputPayload.Model,
+		Temperature:        inputPayload.Temperature,
+		MaxTokens:          inputPayload.MaxTokens,
+		TimeoutMS:          inputPayload.TimeoutMS,
+		ChunkRef:           inputPayload.ChunkRef,
+		RequestRef:         inputPayload.RequestRef,
+		ResponseRef:        outputPayload.ResponseRef,
+		RequestPayload:     inputPayload.RequestPayload,
+		ResponsePayload:    outputPayload.ResponsePayload,
+		RawResponse:        outputPayload.RawResponse,
+		TokensIn:           promptTokens,
+		TokensOut:          completionTokens,
+		LatencyMS:          latencyMS,
+		TransitionOutcome:  outputPayload.TransitionOutcome,
+		TransitionToStep:   outputPayload.TransitionToStep,
+		TransitionTerminal: outputPayload.TransitionTerminal,
+		PreviousStateJSON:  inputPayload.PreviousStateJSON,
+		UpdatedStateJSON:   outputPayload.UpdatedStateJSON,
+		EvidenceDeltaJSON:  outputPayload.EvidenceDeltaJSON,
+		ConflictsJSON:      outputPayload.ConflictsJSON,
+		FinalOutcome:       outputPayload.FinalOutcome,
+		CreatedAt:          createdAt.UTC().Format(time.RFC3339Nano),
+	}
+	return item, nil
+}
+
+type llmDecisionInputPayload struct {
+	RunID             string  `json:"runId,omitempty"`
+	ChunkCapturedAt   string  `json:"chunkCapturedAt,omitempty"`
+	PromptVersionID   string  `json:"promptVersionId,omitempty"`
+	PromptText        string  `json:"promptText,omitempty"`
+	Model             string  `json:"model,omitempty"`
+	Temperature       float64 `json:"temperature,omitempty"`
+	MaxTokens         int     `json:"maxTokens,omitempty"`
+	TimeoutMS         int     `json:"timeoutMs,omitempty"`
+	ChunkRef          string  `json:"chunkRef,omitempty"`
+	RequestRef        string  `json:"requestRef,omitempty"`
+	RequestPayload    string  `json:"requestPayload,omitempty"`
+	PreviousStateJSON string  `json:"previousStateJson,omitempty"`
+}
+
+type llmDecisionOutputPayload struct {
+	DecisionID         string  `json:"decisionId,omitempty"`
+	Stage              string  `json:"stage,omitempty"`
+	Label              string  `json:"label,omitempty"`
+	Confidence         float64 `json:"confidence,omitempty"`
+	ResponseRef        string  `json:"responseRef,omitempty"`
+	ResponsePayload    string  `json:"responsePayload,omitempty"`
+	RawResponse        string  `json:"rawResponse,omitempty"`
+	TransitionOutcome  string  `json:"transitionOutcome,omitempty"`
+	TransitionToStep   string  `json:"transitionToStep,omitempty"`
+	TransitionTerminal bool    `json:"transitionTerminal,omitempty"`
+	UpdatedStateJSON   string  `json:"updatedStateJson,omitempty"`
+	EvidenceDeltaJSON  string  `json:"evidenceDeltaJson,omitempty"`
+	ConflictsJSON      string  `json:"conflictsJson,omitempty"`
+	FinalOutcome       string  `json:"finalOutcome,omitempty"`
+}
+
+func marshalLLMDecisionLogPayloads(item LLMDecision) ([]byte, []byte, error) {
+	inputJSON, err := json.Marshal(llmDecisionInputPayload{
+		RunID:             item.RunID,
+		ChunkCapturedAt:   item.ChunkCapturedAt,
+		PromptVersionID:   item.PromptVersionID,
+		PromptText:        item.PromptText,
+		Model:             item.Model,
+		Temperature:       item.Temperature,
+		MaxTokens:         item.MaxTokens,
+		TimeoutMS:         item.TimeoutMS,
+		ChunkRef:          item.ChunkRef,
+		RequestRef:        item.RequestRef,
+		RequestPayload:    item.RequestPayload,
+		PreviousStateJSON: item.PreviousStateJSON,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal llm decision input_json: %w", err)
+	}
+	outputJSON, err := json.Marshal(llmDecisionOutputPayload{
+		DecisionID:         item.ID,
+		Stage:              item.Stage,
+		Label:              item.Label,
+		Confidence:         item.Confidence,
+		ResponseRef:        item.ResponseRef,
+		ResponsePayload:    item.ResponsePayload,
+		RawResponse:        item.RawResponse,
+		TransitionOutcome:  item.TransitionOutcome,
+		TransitionToStep:   item.TransitionToStep,
+		TransitionTerminal: item.TransitionTerminal,
+		UpdatedStateJSON:   item.UpdatedStateJSON,
+		EvidenceDeltaJSON:  item.EvidenceDeltaJSON,
+		ConflictsJSON:      item.ConflictsJSON,
+		FinalOutcome:       item.FinalOutcome,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal llm decision output_json: %w", err)
+	}
+	return inputJSON, outputJSON, nil
+}
+
+func normalizeDecisionForPostgres(item LLMDecision) LLMDecision {
+	item.ID = strings.TrimSpace(item.ID)
+	item.RunID = strings.TrimSpace(item.RunID)
+	item.StreamerID = strings.TrimSpace(item.StreamerID)
+	item.Stage = strings.TrimSpace(item.Stage)
+	item.Label = strings.TrimSpace(item.Label)
+	item.PromptVersionID = strings.TrimSpace(item.PromptVersionID)
+	item.PromptText = strings.TrimSpace(item.PromptText)
+	item.Model = strings.TrimSpace(item.Model)
+	item.ChunkRef = strings.TrimSpace(item.ChunkRef)
+	item.RequestRef = strings.TrimSpace(item.RequestRef)
+	item.ResponseRef = strings.TrimSpace(item.ResponseRef)
+	item.RequestPayload = strings.TrimSpace(item.RequestPayload)
+	item.ResponsePayload = strings.TrimSpace(item.ResponsePayload)
+	item.RawResponse = strings.TrimSpace(item.RawResponse)
+	item.TransitionOutcome = strings.TrimSpace(item.TransitionOutcome)
+	item.TransitionToStep = strings.TrimSpace(item.TransitionToStep)
+	item.PreviousStateJSON = strings.TrimSpace(item.PreviousStateJSON)
+	item.UpdatedStateJSON = strings.TrimSpace(item.UpdatedStateJSON)
+	item.EvidenceDeltaJSON = strings.TrimSpace(item.EvidenceDeltaJSON)
+	item.ConflictsJSON = strings.TrimSpace(item.ConflictsJSON)
+	item.FinalOutcome = strings.TrimSpace(item.FinalOutcome)
+	item.CreatedAt = strings.TrimSpace(item.CreatedAt)
+	return item
+}
+
+func nullableTimeFromString(value string) sql.NullTime {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return sql.NullTime{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, trimmed)
+	if err != nil {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: parsed.UTC(), Valid: true}
+}

--- a/internal/streamers/postgres_repository_test.go
+++ b/internal/streamers/postgres_repository_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
@@ -100,4 +101,107 @@ WHERE id = $1`)).
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
 	}
+}
+
+func TestPostgresDecisionRepositoryRecordsDecisionAndRequestLog(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	mock.ExpectExec("INSERT INTO llm_request_logs").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	repo := NewPostgresDecisionRepository(db)
+	err = repo.RecordLLMDecision(context.Background(), LLMDecision{
+		ID:               "llm_1",
+		RunID:            "run-1",
+		StreamerID:       uuid.NewString(),
+		Stage:            "cs2_mode",
+		Label:            "competitive",
+		Confidence:       0.91,
+		ChunkCapturedAt:  "2026-05-07T10:00:00Z",
+		PromptVersionID:  "prompt-1",
+		PromptText:       "detect mode",
+		Model:            "gemini-2.0-flash",
+		Temperature:      0.2,
+		MaxTokens:        512,
+		TimeoutMS:        30000,
+		ChunkRef:         "https://player.mediadelivery.net/video.mp4",
+		RequestRef:       "req-1",
+		ResponseRef:      "200",
+		RequestPayload:   `{"contents":[]}`,
+		ResponsePayload:  `{"candidates":[]}`,
+		RawResponse:      `{"mode":"competitive"}`,
+		TokensIn:         111,
+		TokensOut:        22,
+		LatencyMS:        1234,
+		UpdatedStateJSON: `{"mode":"competitive"}`,
+		CreatedAt:        "2026-05-07T10:00:01Z",
+	})
+	if err != nil {
+		t.Fatalf("RecordLLMDecision() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestPostgresDecisionRepositoryListsAndDeletesHistory(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	streamerID := uuid.NewString()
+	createdAt := time.Date(2026, 5, 7, 10, 0, 1, 0, time.UTC)
+	inputJSON := `{"runId":"run-1","chunkCapturedAt":"2026-05-07T10:00:00Z","promptVersionId":"prompt-1","promptText":"detect mode","model":"gemini-2.0-flash","temperature":0.2,"maxTokens":512,"timeoutMs":30000,"chunkRef":"video-url","requestRef":"req-1","requestPayload":"{\\\"contents\\\":[]}","previousStateJson":"{\\\"game\\\":\\\"cs2\\\"}"}`
+	outputJSON := `{"decisionId":"llm_1","stage":"cs2_mode","label":"competitive","confidence":0.91,"responseRef":"200","responsePayload":"{\\\"candidates\\\":[]}","rawResponse":"{\\\"mode\\\":\\\"competitive\\\"}","transitionOutcome":"competitive","transitionToStep":"cs2_match","updatedStateJson":"{\\\"mode\\\":\\\"competitive\\\"}","evidenceDeltaJson":"{}","conflictsJson":"{}"}`
+	mock.ExpectQuery("SELECT id::text, streamer_id::text, request_type").
+		WithArgs(streamerID, 10).
+		WillReturnRows(llmDecisionRows().AddRow(
+			"log-1", streamerID, "cs2_mode", "llm_1",
+			[]byte(inputJSON), []byte(outputJSON), 111, 22,
+			int64(1234), createdAt,
+		))
+
+	repo := NewPostgresDecisionRepository(db)
+	items, err := repo.ListLLMDecisions(context.Background(), streamerID, 10)
+	if err != nil {
+		t.Fatalf("ListLLMDecisions() error = %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "llm_1" || items[0].StreamerID != streamerID || items[0].TokensIn != 111 {
+		t.Fatalf("unexpected decisions: %#v", items)
+	}
+	if items[0].CreatedAt != "2026-05-07T10:00:01Z" || items[0].ChunkCapturedAt != "2026-05-07T10:00:00Z" {
+		t.Fatalf("unexpected timestamps: %#v", items[0])
+	}
+	if items[0].RunID != "run-1" || items[0].Label != "competitive" || items[0].UpdatedStateJSON != `{\"mode\":\"competitive\"}` {
+		t.Fatalf("unexpected reconstructed decision: %#v", items[0])
+	}
+
+	mock.ExpectExec("DELETE FROM llm_request_logs").
+		WithArgs(streamerID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	deleted, err := repo.DeleteAllLLMDecisions(context.Background(), streamerID)
+	if err != nil {
+		t.Fatalf("DeleteAllLLMDecisions() error = %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func llmDecisionRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id", "streamer_id", "request_type", "provider_request_id",
+		"input_json", "output_json", "prompt_tokens", "completion_tokens",
+		"latency_ms", "created_at",
+	})
 }


### PR DESCRIPTION
### Motivation

- Record compact, sanitized LLM decision/request audit data in PostgreSQL for durable history and easier inspection without storing video bytes in DB.
- Expose CRUD operations for decision history so the app can persist, list and purge LLM decisions per streamer.
- Align metadata storage and docs with new `streamer_uploaded_videos` and `llm_request_logs` usage.

### Description

- Added `internal/streamers/decision_postgres_repository.go` which implements `PostgresDecisionRepository` with `RecordLLMDecision`, `ListLLMDecisions`, `ListAllLLMDecisions`, and `DeleteAllLLMDecisions` and helpers to marshal/scan JSON payloads into the existing `llm_request_logs` table.
- Wired the decision repository into the server startup by calling `streamersService.SetDecisionRepository(streamers.NewPostgresDecisionRepository(db))` in `cmd/server/main.go` when `db != nil`.
- Updated `internal/media/video_store_postgres.go` to include `provider` and `status` columns in the `INSERT` and to use `ON CONFLICT (provider, video_id)` with updated columns so uploaded-video metadata is stored consistently (provider set to `'bunny'`).
- Updated documentation `docs/erd.md` to describe `streamer_uploaded_videos`, revised `media_clips` schema, and the `llm_request_logs` retention/usage notes.
- Added unit tests in `internal/streamers/postgres_repository_test.go` covering recording a decision, listing decisions, and deleting history, and extended existing streamers tests accordingly.

### Testing

- Ran the new unit tests in the `streamers` package, including `TestPostgresDecisionRepositoryRecordsDecisionAndRequestLog` and `TestPostgresDecisionRepositoryListsAndDeletesHistory`, and they passed against `sqlmock`.
- Existing `streamers` repository tests (e.g. streamer persistence/mapping tests) were run and remained green.
- Ran `go test ./...` locally and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc87eee0b4832c80b6378356d51a5c)