### PR TITLE
Fix game scenario terminal condition decoding

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -126,15 +126,16 @@ func gameScenarioRequestToCreateRequest(req gameScenarioCreateRequest, actorID s
 		nodes = append(nodes, prompts.GameScenarioNode{
 			ID:                node.ID,
 			Alias:             node.Alias,
-			ScenarioPackageID: node.ScenarioPackageID,
+			ScenarioPackageID: node.scenarioPackageID(),
 		})
 	}
 	transitions := make([]prompts.GameScenarioTransition, 0, len(req.Transitions))
 	for _, tr := range req.Transitions {
 		terminalConditions := make([]prompts.GameScenarioTerminalCondition, 0, len(tr.TerminalConditions))
-		for _, item := range tr.TerminalConditions {
-			outcomeTemplates := make([]prompts.GameScenarioOutcomeTemplate, 0, len(item.OutcomeTemplates))
-			for _, outcome := range item.OutcomeTemplates {
+		for _, item := range tr.terminalConditions() {
+			inputOutcomes := item.outcomeTemplates()
+			outcomeTemplates := make([]prompts.GameScenarioOutcomeTemplate, 0, len(inputOutcomes))
+			for _, outcome := range inputOutcomes {
 				outcomeTemplates = append(outcomeTemplates, prompts.GameScenarioOutcomeTemplate{
 					ID:        outcome.ID,
 					Title:     outcome.Title,
@@ -144,16 +145,16 @@ func gameScenarioRequestToCreateRequest(req gameScenarioCreateRequest, actorID s
 			}
 			terminalConditions = append(terminalConditions, prompts.GameScenarioTerminalCondition{
 				ID:               item.ID,
-				GameTitle:        item.GameTitle,
-				DefaultLanguage:  item.DefaultLanguage,
+				GameTitle:        item.gameTitle(),
+				DefaultLanguage:  item.defaultLanguage(),
 				OutcomeTemplates: outcomeTemplates,
 				Priority:         item.Priority,
 			})
 		}
 		transitions = append(transitions, prompts.GameScenarioTransition{
 			ID:                 tr.ID,
-			FromNodeID:         tr.FromNodeID,
-			ToNodeID:           tr.ToNodeID,
+			FromNodeID:         tr.fromNodeID(),
+			ToNodeID:           tr.toNodeID(),
 			Condition:          tr.Condition,
 			Priority:           tr.Priority,
 			TerminalConditions: terminalConditions,
@@ -236,26 +237,70 @@ type scenarioPackageCreateRequest struct {
 }
 
 type gameScenarioNodeRequest struct {
-	ID                string `json:"id"`
-	Alias             string `json:"alias"`
-	ScenarioPackageID string `json:"scenarioPackageId"`
+	ID                     string `json:"id"`
+	Alias                  string `json:"alias"`
+	ScenarioPackageID      string `json:"scenarioPackageId"`
+	ScenarioPackageIDSnake string `json:"scenario_package_id"`
+}
+
+func (r gameScenarioNodeRequest) scenarioPackageID() string {
+	return firstNonEmpty(r.ScenarioPackageID, r.ScenarioPackageIDSnake)
 }
 
 type gameScenarioTransitionRequest struct {
-	ID                 string                                 `json:"id"`
-	FromNodeID         string                                 `json:"fromNodeId"`
-	ToNodeID           string                                 `json:"toNodeId"`
-	Condition          string                                 `json:"condition"`
-	Priority           int                                    `json:"priority"`
-	TerminalConditions []gameScenarioTerminalConditionRequest `json:"terminalConditions"`
+	ID                      string                                 `json:"id"`
+	FromNodeID              string                                 `json:"fromNodeId"`
+	FromNodeIDSnake         string                                 `json:"from_node_id"`
+	ToNodeID                string                                 `json:"toNodeId"`
+	ToNodeIDSnake           string                                 `json:"to_node_id"`
+	Condition               string                                 `json:"condition"`
+	Priority                int                                    `json:"priority"`
+	TerminalConditions      []gameScenarioTerminalConditionRequest `json:"terminalConditions"`
+	TerminalConditionsSnake []gameScenarioTerminalConditionRequest `json:"terminal_conditions"`
 }
 
 type gameScenarioTerminalConditionRequest struct {
-	ID               string                                     `json:"id"`
-	GameTitle        map[string]string                          `json:"gameTitle"`
-	DefaultLanguage  string                                     `json:"defaultLanguage"`
-	OutcomeTemplates []gameScenarioTerminalOutcomeTemplateInput `json:"outcomeTemplates"`
-	Priority         int                                        `json:"priority"`
+	ID                    string                                     `json:"id"`
+	GameTitle             map[string]string                          `json:"gameTitle"`
+	GameTitleSnake        map[string]string                          `json:"game_title"`
+	DefaultLanguage       string                                     `json:"defaultLanguage"`
+	DefaultLanguageSnake  string                                     `json:"default_language"`
+	OutcomeTemplates      []gameScenarioTerminalOutcomeTemplateInput `json:"outcomeTemplates"`
+	OutcomeTemplatesSnake []gameScenarioTerminalOutcomeTemplateInput `json:"outcome_templates"`
+	Priority              int                                        `json:"priority"`
+}
+
+func (r gameScenarioTransitionRequest) fromNodeID() string {
+	return firstNonEmpty(r.FromNodeID, r.FromNodeIDSnake)
+}
+
+func (r gameScenarioTransitionRequest) toNodeID() string {
+	return firstNonEmpty(r.ToNodeID, r.ToNodeIDSnake)
+}
+
+func (r gameScenarioTransitionRequest) terminalConditions() []gameScenarioTerminalConditionRequest {
+	if len(r.TerminalConditions) > 0 {
+		return r.TerminalConditions
+	}
+	return r.TerminalConditionsSnake
+}
+
+func (r gameScenarioTerminalConditionRequest) gameTitle() map[string]string {
+	if len(r.GameTitle) > 0 {
+		return r.GameTitle
+	}
+	return r.GameTitleSnake
+}
+
+func (r gameScenarioTerminalConditionRequest) defaultLanguage() string {
+	return firstNonEmpty(r.DefaultLanguage, r.DefaultLanguageSnake)
+}
+
+func (r gameScenarioTerminalConditionRequest) outcomeTemplates() []gameScenarioTerminalOutcomeTemplateInput {
+	if len(r.OutcomeTemplates) > 0 {
+		return r.OutcomeTemplates
+	}
+	return r.OutcomeTemplatesSnake
 }
 
 type gameScenarioTerminalOutcomeTemplateInput struct {

--- a/internal/app/router_admin_llm_test.go
+++ b/internal/app/router_admin_llm_test.go
@@ -329,6 +329,15 @@ func TestAdminLLMGameScenarioRoutes(t *testing.T) {
 	if loaded["name"] != "cs2 game scenario" {
 		t.Fatalf("expected original name, got %#v", loaded["name"])
 	}
+	loadedTransitions, _ := loaded["transitions"].([]any)
+	if len(loadedTransitions) != 1 {
+		t.Fatalf("expected one loaded transition, got %#v", loaded["transitions"])
+	}
+	loadedTransition, _ := loadedTransitions[0].(map[string]any)
+	loadedTerminals, _ := loadedTransition["terminalConditions"].([]any)
+	if len(loadedTerminals) != 1 {
+		t.Fatalf("expected terminal conditions in loaded game scenario, got %#v", loadedTransition["terminalConditions"])
+	}
 
 	updateBody, _ := json.Marshal(map[string]any{
 		"name":          "cs2 game scenario updated",

--- a/internal/prompts/game_scenario.go
+++ b/internal/prompts/game_scenario.go
@@ -46,6 +46,86 @@ type GameScenarioOutcomeTemplate struct {
 	Priority  int               `json:"priority"`
 }
 
+func (n *GameScenarioNode) UnmarshalJSON(data []byte) error {
+	type nodeAlias GameScenarioNode
+	var aux struct {
+		nodeAlias
+		ScenarioPackageIDSnake string `json:"scenario_package_id"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*n = GameScenarioNode(aux.nodeAlias)
+	if strings.TrimSpace(n.ScenarioPackageID) == "" {
+		n.ScenarioPackageID = aux.ScenarioPackageIDSnake
+	}
+	return nil
+}
+
+func (t *GameScenarioTransition) UnmarshalJSON(data []byte) error {
+	type transitionAlias GameScenarioTransition
+	var aux struct {
+		transitionAlias
+		FromNodeIDSnake         string                          `json:"from_node_id"`
+		ToNodeIDSnake           string                          `json:"to_node_id"`
+		TerminalConditionsSnake []GameScenarioTerminalCondition `json:"terminal_conditions"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*t = GameScenarioTransition(aux.transitionAlias)
+	if strings.TrimSpace(t.FromNodeID) == "" {
+		t.FromNodeID = aux.FromNodeIDSnake
+	}
+	if strings.TrimSpace(t.ToNodeID) == "" {
+		t.ToNodeID = aux.ToNodeIDSnake
+	}
+	if len(t.TerminalConditions) == 0 {
+		t.TerminalConditions = aux.TerminalConditionsSnake
+	}
+	return nil
+}
+
+func (t *GameScenarioTerminalCondition) UnmarshalJSON(data []byte) error {
+	type terminalAlias GameScenarioTerminalCondition
+	var aux struct {
+		terminalAlias
+		TransitionIDSnake     string                        `json:"transition_id"`
+		GameTitleSnake        map[string]string             `json:"game_title"`
+		DefaultLanguageSnake  string                        `json:"default_language"`
+		OutcomeTemplatesSnake []GameScenarioOutcomeTemplate `json:"outcome_templates"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*t = GameScenarioTerminalCondition(aux.terminalAlias)
+	if strings.TrimSpace(t.TransitionID) == "" {
+		t.TransitionID = aux.TransitionIDSnake
+	}
+	if len(t.GameTitle) == 0 {
+		t.GameTitle = aux.GameTitleSnake
+	}
+	if strings.TrimSpace(t.DefaultLanguage) == "" {
+		t.DefaultLanguage = aux.DefaultLanguageSnake
+	}
+	if len(t.OutcomeTemplates) == 0 {
+		t.OutcomeTemplates = aux.OutcomeTemplatesSnake
+	}
+	return nil
+}
+
+func (o *GameScenarioOutcomeTemplate) UnmarshalJSON(data []byte) error {
+	type outcomeAlias GameScenarioOutcomeTemplate
+	var aux struct {
+		outcomeAlias
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*o = GameScenarioOutcomeTemplate(aux.outcomeAlias)
+	return nil
+}
+
 type GameScenario struct {
 	ID            string                   `json:"id"`
 	Name          string                   `json:"name"`

--- a/internal/prompts/game_scenario_postgres_test.go
+++ b/internal/prompts/game_scenario_postgres_test.go
@@ -107,6 +107,52 @@ ORDER BY COALESCE(metadata->>'gameSlug', game_slug) ASC, version DESC, created_a
 	}
 }
 
+func TestPostgresGameScenarioStoreListDecodesSnakeCaseTerminalConditions(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	store := NewPostgresGameScenarioStore(db)
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	nodes := `[{"id":"n1","scenario_package_id":"pkg-1"}]`
+	transitions := `[{"id":"tr-1","from_node_id":"n1","to_node_id":"n1","condition":"winner == \"ct\"","priority":1,"terminal_conditions":[{"id":"tm-1","game_title":{"ru":"Победа"},"default_language":"ru","outcome_templates":[{"id":"ct","title":{"ru":"CT"},"condition":"winner == \"ct\"","priority":10}],"priority":20}]}]`
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, name, version, game_slug, is_active, initial_node_id,
+       nodes_json, transitions_json, metadata, created_by, activated_by, created_at, activated_at
+FROM llm_scenarios
+WHERE metadata->>'kind' = 'game_scenario'
+ORDER BY COALESCE(metadata->>'gameSlug', game_slug) ASC, version DESC, created_at DESC`)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "version", "game_slug", "is_active", "initial_node_id",
+			"nodes_json", "transitions_json", "metadata", "created_by", "activated_by", "created_at", "activated_at",
+		}).AddRow("game-scenario-1", "scenario", 1, "game_scenario:cs2", true, "n1", []byte(nodes), []byte(transitions), []byte(`{"gameSlug":"cs2","kind":"game_scenario"}`), "admin", "admin", now, now))
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("store.List: %v", err)
+	}
+	if len(items) != 1 || len(items[0].Transitions) != 1 {
+		t.Fatalf("expected one scenario transition, got %#v", items)
+	}
+	transition := items[0].Transitions[0]
+	if transition.FromNodeID != "n1" || transition.ToNodeID != "n1" {
+		t.Fatalf("expected snake_case node ids to decode, got %#v", transition)
+	}
+	if len(transition.TerminalConditions) != 1 {
+		t.Fatalf("expected snake_case terminal conditions to decode, got %#v", transition.TerminalConditions)
+	}
+	terminal := transition.TerminalConditions[0]
+	if terminal.DefaultLanguage != "ru" || terminal.GameTitle["ru"] != "Победа" || len(terminal.OutcomeTemplates) != 1 {
+		t.Fatalf("unexpected terminal condition: %#v", terminal)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestPostgresGameScenarioStoreUpdateUsesStorageSlugAndReloads(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {


### PR DESCRIPTION
### Motivation
- Admin UI showed empty/missing `terminalConditions` for Game Scenarios when DB payloads used snake_case keys after migrations; backend must accept legacy/new snake_case JSON stored in `llm_scenarios.*_json` and also accept snake_case admin payloads.
- Preserve backwards compatibility between persisted scenario JSON (snake_case) and API (camelCase) so terminal outcomes remain visible and editable in the admin flow.

### Description
- Added robust decoding for snake_case fields when reading scenario payloads by implementing `UnmarshalJSON` on `GameScenarioNode`, `GameScenarioTransition`, `GameScenarioTerminalCondition` and `GameScenarioOutcomeTemplate` to map `scenario_package_id`, `from_node_id`, `terminal_conditions`, `game_title`, `default_language`, `outcome_templates` etc. into existing camelCase Go fields (file: `internal/prompts/game_scenario.go`).
- Extended admin request types to accept both camelCase and snake_case input shapes and added accessor helpers to normalize values (`gameScenarioNodeRequest`, `gameScenarioTransitionRequest`, `gameScenarioTerminalConditionRequest` and helpers in `internal/app/router.go`).
- Updated admin request->domain conversion (`gameScenarioRequestToCreateRequest`) to use the new accessors so terminal conditions and outcome templates are preserved during create/update flows (file: `internal/app/router.go`).
- Added regression tests: check that admin GET includes `terminalConditions` after load (`internal/app/router_admin_llm_test.go`) and that Postgres-backed store decodes snake_case terminal payloads (`internal/prompts/game_scenario_postgres_test.go`).
- Committed changes as: "Fix game scenario terminal condition decoding" (modified files include `internal/prompts/game_scenario.go`, `internal/app/router.go`, `internal/app/router_admin_llm_test.go`, `internal/prompts/game_scenario_postgres_test.go`).

### Testing
- Ran unit tests with `go test ./...` and all tests passed successfully.
- Executed package-level tests `go test ./internal/prompts` and `go test ./internal/app` which passed and cover the new decoding and admin route assertions.
- Added and executed regression tests that verify snake_case decoding and admin visibility of `terminalConditions`, and they succeeded.

Checklist (aligned with M2.1 and scenario-graph v2)
- [x] Terminal conditions preserved and visible in admin GET/PUT flow for Game Scenarios.
- [x] Postgres store decodes legacy/new snake_case `transitions_json` terminal payloads.
- [x] Admin API accepts both camelCase and snake_case payload shapes for nodes/transitions/terminals/outcomes.
- [ ] Remaining: implement full Game Scenario orchestration guard validation and additional runtime wiring for package-level transitions (further M2.1 work).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8cb26008832c899bf488559e0a17)