### PR TITLE
ci: make registry pushes resilient

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 **/*_test.go
 **/*.md
 **/*.log
+*.zip
 
 bin/
 dist/

--- a/.gitea/workflows/cd.yml
+++ b/.gitea/workflows/cd.yml
@@ -98,13 +98,13 @@ jobs:
             exit 1
           fi
           cat <<EOF >payload.json
-{
-  "environment": "${ENVIRONMENT}",
-  "branch": "${BRANCH}",
-  "image": "${IMAGE_REF}",
-  "sha": "${HEAD_SHA}"
-}
-EOF
+          {
+            "environment": "${ENVIRONMENT}",
+            "branch": "${BRANCH}",
+            "image": "${IMAGE_REF}",
+            "sha": "${HEAD_SHA}"
+          }
+          EOF
           curl -fsSL -X POST -H 'Content-Type: application/json' --data @payload.json "$WEBHOOK_URL"
 
       - name: Resolve healthcheck target

--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -139,26 +139,59 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Build & Push immutable SHA tag
+      - name: Build immutable SHA image locally
         if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.image_ref != '' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          pull: true
-          push: true
-          tags: ${{ steps.meta.outputs.image_ref }}
-          provenance: false
-          sbom: false
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            BUILD_DATE=${{ steps.meta.outputs.build_date }}
-          labels: |
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ steps.meta.outputs.build_date }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-          cache-from: type=registry,ref=${{ steps.meta.outputs.image }}:buildcache
-          cache-to: type=registry,ref=${{ steps.meta.outputs.image }}:buildcache,mode=max
+        run: |
+          set -euo pipefail
+
+          CACHE_DIR="${RUNNER_TEMP:-/tmp}/funpot-buildx-cache"
+          CACHE_NEXT="${RUNNER_TEMP:-/tmp}/funpot-buildx-cache-next"
+          rm -rf "$CACHE_NEXT"
+
+          cache_args=()
+          if [ -d "$CACHE_DIR" ]; then
+            cache_args+=(--cache-from "type=local,src=${CACHE_DIR}")
+          fi
+
+          docker buildx build \
+            --file ./Dockerfile \
+            --pull \
+            --load \
+            --provenance=false \
+            --sbom=false \
+            --tag "${{ steps.meta.outputs.image_ref }}" \
+            --build-arg "VCS_REF=${{ github.sha }}" \
+            --build-arg "BUILD_DATE=${{ steps.meta.outputs.build_date }}" \
+            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            --label "org.opencontainers.image.created=${{ steps.meta.outputs.build_date }}" \
+            --label "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+            "${cache_args[@]}" \
+            --cache-to "type=local,dest=${CACHE_NEXT},mode=max" \
+            .
+
+          rm -rf "$CACHE_DIR"
+          mv "$CACHE_NEXT" "$CACHE_DIR"
+
+      - name: Push immutable SHA tag with retries
+        if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.image_ref != '' }}
+        run: |
+          set -euo pipefail
+
+          SHA_IMAGE="${{ steps.meta.outputs.image_ref }}"
+          for attempt in 1 2 3; do
+            if docker push "$SHA_IMAGE"; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to push $SHA_IMAGE after $attempt attempts" >&2
+              exit 1
+            fi
+
+            sleep_seconds=$((attempt * 20))
+            echo "docker push failed; retrying in ${sleep_seconds}s (attempt $((attempt + 1))/3)" >&2
+            sleep "$sleep_seconds"
+          done
 
       - name: Tag SHA image as rolling branch tag
         if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.branch_tag != '' }}
@@ -169,9 +202,21 @@ jobs:
           SHA_IMAGE="${{ steps.meta.outputs.image_ref }}"
           ROLLING_IMAGE="${IMAGE}:${{ steps.meta.outputs.branch_tag }}"
 
-          docker pull "$SHA_IMAGE"
           docker tag "$SHA_IMAGE" "$ROLLING_IMAGE"
-          docker push "$ROLLING_IMAGE"
+          for attempt in 1 2 3; do
+            if docker push "$ROLLING_IMAGE"; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to push $ROLLING_IMAGE after $attempt attempts" >&2
+              exit 1
+            fi
+
+            sleep_seconds=$((attempt * 20))
+            echo "docker push failed; retrying in ${sleep_seconds}s (attempt $((attempt + 1))/3)" >&2
+            sleep "$sleep_seconds"
+          done
 
       - name: Verify pushed tags
         if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.image_ref != '' }}


### PR DESCRIPTION
### Motivation
- The CI build failed due to transient registry `500 Internal Server Error` while uploading layer blobs, so the pipeline must be more resilient to registry-side failures.
- Exporting Buildx cache to the registry increased CI uploads and exposure to registry errors, so caching should be local to the runner where possible.
- Tagging and pushing images must tolerate transient failures and avoid unnecessary extra registry pulls during the pipeline.

### Description
- Replace the single `Build & Push immutable SHA tag` step with a local `docker buildx build --load` followed by a separate `docker push` that retries up to 3 times using exponential-ish backoff, implemented in `.gitea/workflows/ci.yml`.
- Switch build cache usage from `cache-to: type=registry` to a local runner cache using `--cache-from type=local` / `--cache-to type=local` to avoid extra registry cache blobs.
- Remove the unnecessary `docker pull` before tagging the rolling branch image and add a 3-attempt retry loop for pushing the rolling tag to avoid failing on transient registry errors.
- Add `*.zip` to `.dockerignore` to prevent accidental inclusion of archives in `COPY . .`, and fix the heredoc indentation in `.gitea/workflows/cd.yml` so the payload JSON is valid YAML.

### Testing
- Ran `go test ./...` and unit/integration tests completed successfully (tests reported `ok` for packages run in CI simulation).
- Ran `git diff --check` with no problems, and validated both workflow files parse with `ruby -e 'require "yaml"; YAML.load_file(...)'` which succeeded.
- Verified the CI changes by linting the modified YAML and checking diffs locally; `docker` is not installed in this execution environment so `docker buildx version` could not be executed here.
- Checklist (aligned with repo agent expectations):
  - [x] Make registry pushes resilient with retried `docker push` for immutable SHA.
  - [x] Use local Buildx cache on runner instead of exporting cache blobs to the registry.
  - [x] Retry rolling branch tag pushes and avoid unnecessary `docker pull`.
  - [x] Exclude `*.zip` from Docker build context.
  - [x] Fix CD workflow heredoc indentation so YAML parses cleanly.
  - [ ] `docs/implementation_plan.md` milestone **M2.1**: business-logic milestone not modified by this hotfix.
  - [ ] `docs/llm_stream_orchestration_plan.md` alignment: orchestration/behavior work remains for a separate change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc90b572bc832c815d19fe3373237f)