### PR TITLE
Add realtime market data to event messages and harden vote/payment flow with idempotency and rollback

### DIFF
--- a/docs/ws_messages.md
+++ b/docs/ws_messages.md
@@ -37,10 +37,16 @@ Payload schema:
 {
   "eventId": "uuid",
   "totals": { "optionId": 123 },
+  "totalContributed": 1000,
+  "platformFeeINT": 100,
+  "distributableINT": 900,
+  "options": {
+    "ct": { "poolINT": 450, "sharePct": 50.0, "coefficient": 2.0 }
+  },
   "closesAt": "ISO-8601|null"
 }
 ```
-Broadcast every 250–500 ms at most, optionally batching multiple events per frame.
+Broadcast every 250–500 ms at most, optionally batching multiple events per frame. `options` lets the frontend render live pool percentages and current payout coefficients per outcome.
 
 ### EVENT_VOTE_FEED_UPDATED
 Payload schema:
@@ -53,13 +59,16 @@ Payload schema:
       "nickname": "BraveFox123",
       "optionId": "ct",
       "amountINT": 150,
+      "optionPoolSharePct": 50.0,
+      "coefficient": 2.0,
+      "potentialWinINT": 300,
       "createdAt": "ISO-8601"
     }
   ],
   "snapshotAt": "ISO-8601"
 }
 ```
-Real-time feed of participant votes for the mini-game. Frontend should append `items` to the vote tape and reconcile by `eventId + userId + createdAt`.
+Real-time feed of participant votes for the mini-game, including who placed the vote, selected option, current option share, current coefficient, and potential win for that vote amount. Frontend should append `items` to the vote tape and reconcile by `eventId + userId + createdAt`.
 
 ### EVENT_CLOSED
 Payload schema:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -1903,6 +1903,23 @@ func NewHandler(
 					writeError(w, http.StatusBadRequest, "invalid request body")
 					return
 				}
+				vote := events.VoteRequest{
+					EventID:        eventID,
+					StreamerID:     req.StreamerID,
+					UserID:         claims.Subject,
+					OptionID:       req.OptionID,
+					Amount:         req.AmountINT,
+					IdempotencyKey: idempotencyKey,
+				}
+				refundKey := voteRefundIdempotencyKey(idempotencyKey)
+				if walletService.HasProcessed(claims.Subject, refundKey) {
+					writeError(w, http.StatusConflict, "vote payment was rolled back; retry with a new Idempotency-Key")
+					return
+				}
+				if err := eventsService.ValidateVote(r.Context(), vote); err != nil {
+					writeEventVoteError(w, logger, eventID, err)
+					return
+				}
 				walletEntry, balanceAfterVote, err := walletService.Post(wallet.PostRequest{
 					UserID:         claims.Subject,
 					Type:           wallet.EntryTypeDebit,
@@ -1912,38 +1929,23 @@ func NewHandler(
 					ActorID:        claims.Subject,
 				})
 				if err != nil {
-					switch {
-					case errors.Is(err, wallet.ErrInvalidAmount), errors.Is(err, wallet.ErrIdempotencyRequired):
-						writeError(w, http.StatusBadRequest, err.Error())
-					case errors.Is(err, wallet.ErrInsufficientFunds):
-						writeError(w, http.StatusConflict, err.Error())
-					default:
-						logger.Error("failed to debit wallet for vote", zap.String("userID", claims.Subject), zap.Error(err))
-						writeError(w, http.StatusInternalServerError, "failed to process vote")
-					}
+					writeWalletPostError(w, logger, claims.Subject, err)
 					return
 				}
-				event, err := eventsService.Vote(r.Context(), events.VoteRequest{
-					EventID:        eventID,
-					StreamerID:     req.StreamerID,
-					UserID:         claims.Subject,
-					OptionID:       req.OptionID,
-					Amount:         req.AmountINT,
-					IdempotencyKey: idempotencyKey,
-					WalletLedgerID: strings.TrimSpace(walletEntry.ID),
-				})
+				vote.WalletLedgerID = strings.TrimSpace(walletEntry.ID)
+				event, err := eventsService.Vote(r.Context(), vote)
 				if err != nil {
-					switch {
-					case errors.Is(err, events.ErrInvalidVote):
-						writeError(w, http.StatusBadRequest, err.Error())
-					case errors.Is(err, events.ErrEventNotFound):
-						writeError(w, http.StatusNotFound, err.Error())
-					case errors.Is(err, events.ErrEventClosed):
-						writeError(w, http.StatusConflict, err.Error())
-					default:
-						logger.Error("failed to process event vote", zap.String("eventID", eventID), zap.Error(err))
-						writeError(w, http.StatusInternalServerError, "failed to process vote")
+					if _, _, refundErr := walletService.Post(wallet.PostRequest{
+						UserID:         claims.Subject,
+						Type:           wallet.EntryTypeCredit,
+						Amount:         req.AmountINT,
+						Reason:         "event_vote_rollback",
+						IdempotencyKey: refundKey,
+						ActorID:        claims.Subject,
+					}); refundErr != nil {
+						logger.Error("failed to roll back wallet debit after vote failure", zap.String("userID", claims.Subject), zap.String("eventID", eventID), zap.String("idempotencyKey", idempotencyKey), zap.Error(refundErr))
 					}
+					writeEventVoteError(w, logger, eventID, err)
 					return
 				}
 				nickname := claims.Subject
@@ -1952,25 +1954,16 @@ func NewHandler(
 						nickname = profile.Nickname
 					}
 				}
+				market := event.Market()
 				rtHub.PublishToStreamer(req.StreamerID, realtime.Envelope{
-					Type: "EVENT_UPDATED",
-					Payload: realtime.EventUpdatedPayload{
-						EventID:  event.ID,
-						Totals:   event.Totals,
-						ClosesAt: event.ClosesAt,
-					},
+					Type:    "EVENT_UPDATED",
+					Payload: buildEventUpdatedPayload(event, market),
 				})
 				rtHub.PublishToStreamer(req.StreamerID, realtime.Envelope{
 					Type: "EVENT_VOTE_FEED_UPDATED",
 					Payload: realtime.VoteFeedPayload{
-						EventID: event.ID,
-						Items: []realtime.VoteFeedItem{{
-							UserID:    claims.Subject,
-							Nickname:  nickname,
-							OptionID:  req.OptionID,
-							AmountINT: req.AmountINT,
-							CreatedAt: realtime.NowRFC3339(),
-						}},
+						EventID:    event.ID,
+						Items:      []realtime.VoteFeedItem{buildVoteFeedItem(claims.Subject, nickname, req.OptionID, req.AmountINT, event, market)},
 						SnapshotAt: realtime.NowRFC3339(),
 					},
 				})
@@ -2006,6 +1999,70 @@ func NewHandler(
 	}
 
 	return mux
+}
+
+func voteRefundIdempotencyKey(idempotencyKey string) string {
+	return strings.TrimSpace(idempotencyKey) + ":rollback"
+}
+
+func writeWalletPostError(w http.ResponseWriter, logger *zap.Logger, userID string, err error) {
+	switch {
+	case errors.Is(err, wallet.ErrInvalidAmount), errors.Is(err, wallet.ErrIdempotencyRequired):
+		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, wallet.ErrInsufficientFunds):
+		writeError(w, http.StatusConflict, err.Error())
+	default:
+		logger.Error("failed to debit wallet for vote", zap.String("userID", userID), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to process vote")
+	}
+}
+
+func writeEventVoteError(w http.ResponseWriter, logger *zap.Logger, eventID string, err error) {
+	switch {
+	case errors.Is(err, events.ErrInvalidVote):
+		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, events.ErrEventNotFound):
+		writeError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, events.ErrEventClosed):
+		writeError(w, http.StatusConflict, err.Error())
+	default:
+		logger.Error("failed to process event vote", zap.String("eventID", eventID), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to process vote")
+	}
+}
+
+func buildEventUpdatedPayload(event events.LiveEvent, market events.LiveEventMarket) realtime.EventUpdatedPayload {
+	options := make(map[string]realtime.EventOptionMarket, len(market.Options))
+	for optionID, item := range market.Options {
+		options[optionID] = realtime.EventOptionMarket{
+			PoolINT:     item.PoolINT,
+			SharePct:    item.SharePct,
+			Coefficient: item.Coefficient,
+		}
+	}
+	return realtime.EventUpdatedPayload{
+		EventID:          event.ID,
+		Totals:           event.Totals,
+		TotalContributed: event.TotalContributed,
+		PlatformFeeINT:   event.PlatformFeeINT,
+		DistributableINT: event.DistributableINT,
+		Options:          options,
+		ClosesAt:         event.ClosesAt,
+	}
+}
+
+func buildVoteFeedItem(userID, nickname, optionID string, amountINT int64, event events.LiveEvent, market events.LiveEventMarket) realtime.VoteFeedItem {
+	optionMarket := market.Options[strings.TrimSpace(optionID)]
+	return realtime.VoteFeedItem{
+		UserID:             userID,
+		Nickname:           nickname,
+		OptionID:           optionID,
+		AmountINT:          amountINT,
+		OptionPoolSharePct: optionMarket.SharePct,
+		Coefficient:        optionMarket.Coefficient,
+		PotentialWinINT:    event.PotentialWinINT(optionID, amountINT),
+		CreatedAt:          realtime.NowRFC3339(),
+	}
 }
 
 func requireAdmin(w http.ResponseWriter, r *http.Request, adminService *admin.Service) bool {

--- a/internal/app/router_events_test.go
+++ b/internal/app/router_events_test.go
@@ -309,6 +309,98 @@ func TestEventsHistoryReturnsUserEventVotes(t *testing.T) {
 	}
 }
 
+func TestEventsVoteDoesNotDebitWalletWhenEventClosed(t *testing.T) {
+	eventsService := events.NewService([]events.LiveEvent{
+		{
+			ID:              "event-closed",
+			TemplateID:      "streamer-1:terminal-1",
+			StreamerID:      "streamer-1",
+			ScenarioID:      "scenario-1",
+			TerminalID:      "terminal-1",
+			Title:           map[string]string{"ru": "Победитель карты"},
+			DefaultLanguage: "ru",
+			Options: []events.Option{
+				{ID: "ct", Title: map[string]string{"ru": "CT"}},
+			},
+			ClosesAt:  time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+			CreatedAt: time.Now().UTC().Add(-2 * time.Minute).Format(time.RFC3339Nano),
+			Status:    "open",
+			Totals:    map[string]int64{"ct": 0},
+		},
+	})
+	userService := users.NewService(users.NewInMemoryRepository())
+	created, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"})
+	if err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
+	handler := NewHandler(zap.NewNop(), func() bool { return true }, nil, buildAuthService(t), admin.NewService([]string{"admin-1"}), userService, nil, nil, nil, nil, eventsService, ClientConfigResponse{})
+	adminToken := buildToken(t, "admin-1")
+	userToken := buildToken(t, created.ID)
+
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID, bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
+	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
+	adjustReq.Header.Set("Idempotency-Key", "adj-seed")
+	adjustRes := httptest.NewRecorder()
+	handler.ServeHTTP(adjustRes, adjustReq)
+	if adjustRes.Code != http.StatusOK {
+		t.Fatalf("seed wallet status=%d body=%s", adjustRes.Code, adjustRes.Body.String())
+	}
+
+	voteReq := httptest.NewRequest(http.MethodPost, "/api/events/event-closed/vote", bytes.NewReader([]byte(`{"streamerId":"streamer-1","optionId":"ct","amountINT":10}`)))
+	voteReq.Header.Set("Authorization", "Bearer "+userToken)
+	voteReq.Header.Set("Idempotency-Key", "vote-closed")
+	voteRes := httptest.NewRecorder()
+	handler.ServeHTTP(voteRes, voteReq)
+	if voteRes.Code != http.StatusConflict {
+		t.Fatalf("closed vote status=%d body=%s", voteRes.Code, voteRes.Body.String())
+	}
+
+	walletReq := httptest.NewRequest(http.MethodGet, "/api/wallet", nil)
+	walletReq.Header.Set("Authorization", "Bearer "+userToken)
+	walletRes := httptest.NewRecorder()
+	handler.ServeHTTP(walletRes, walletReq)
+	if walletRes.Code != http.StatusOK {
+		t.Fatalf("wallet status=%d body=%s", walletRes.Code, walletRes.Body.String())
+	}
+	var walletPayload struct {
+		Balance int64 `json:"balance"`
+	}
+	if err := json.Unmarshal(walletRes.Body.Bytes(), &walletPayload); err != nil {
+		t.Fatalf("unmarshal wallet response: %v", err)
+	}
+	if walletPayload.Balance != 100 {
+		t.Fatalf("expected closed vote to keep wallet balance 100, got %d", walletPayload.Balance)
+	}
+}
+
+func TestBuildEventUpdatedPayloadIncludesRealtimeMarket(t *testing.T) {
+	event := events.LiveEvent{
+		ID:               "event-1",
+		ClosesAt:         time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+		Totals:           map[string]int64{"ct": 90, "t": 10},
+		TotalContributed: 100,
+		PlatformFeeINT:   0,
+		DistributableINT: 100,
+	}
+	payload := buildEventUpdatedPayload(event, event.Market())
+	if payload.TotalContributed != 100 || payload.DistributableINT != 100 || payload.PlatformFeeINT != 0 {
+		t.Fatalf("unexpected pool values: %+v", payload)
+	}
+	if payload.Options["ct"].SharePct != 90 || payload.Options["t"].SharePct != 10 {
+		t.Fatalf("unexpected market shares: %+v", payload.Options)
+	}
+	if payload.Options["ct"].Coefficient <= 0 || payload.Options["t"].Coefficient <= 0 {
+		t.Fatalf("expected positive coefficients: %+v", payload.Options)
+	}
+	feed := buildVoteFeedItem("user-1", "BraveFox123", "ct", 10, event, event.Market())
+	if feed.UserID != "user-1" || feed.Nickname != "BraveFox123" || feed.OptionID != "ct" || feed.AmountINT != 10 {
+		t.Fatalf("unexpected vote feed identity fields: %+v", feed)
+	}
+	if feed.OptionPoolSharePct != 90 || feed.Coefficient <= 0 || feed.PotentialWinINT <= 0 {
+		t.Fatalf("expected realtime market fields on vote feed item: %+v", feed)
+	}
+}
+
 func TestWeeklyRewardClaimCreditsWalletAndRespects24h(t *testing.T) {
 	eventsService := events.NewService(nil)
 	_, err := eventsService.UpdateSettings(events.Settings{WeeklyRewardByDayINT: [7]int64{10, 20, 30, 40, 50, 60, 70}})

--- a/internal/events/model.go
+++ b/internal/events/model.go
@@ -12,6 +12,16 @@ type UserVote struct {
 	TotalAmount int64  `json:"totalAmount"`
 }
 
+type OptionMarket struct {
+	PoolINT     int64   `json:"poolINT"`
+	SharePct    float64 `json:"sharePct"`
+	Coefficient float64 `json:"coefficient"`
+}
+
+type LiveEventMarket struct {
+	Options map[string]OptionMarket `json:"options"`
+}
+
 type UserEventHistoryItem struct {
 	EventID          string            `json:"eventId"`
 	StreamerID       string            `json:"streamerId"`

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -445,6 +445,51 @@ func (s *Service) ListLiveByStreamer(ctx context.Context, streamerID string) []L
 	return result
 }
 
+func (s *Service) ValidateVote(ctx context.Context, req VoteRequest) error {
+	if strings.TrimSpace(req.EventID) == "" || strings.TrimSpace(req.StreamerID) == "" || strings.TrimSpace(req.UserID) == "" || strings.TrimSpace(req.OptionID) == "" || req.Amount <= 0 || strings.TrimSpace(req.IdempotencyKey) == "" {
+		return ErrInvalidVote
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s.db != nil {
+		if existing, ok, err := s.findVoteByIdempotencyDB(ctx, strings.TrimSpace(req.IdempotencyKey)); err != nil {
+			return err
+		} else if ok {
+			if strings.TrimSpace(existing.EventID) == strings.TrimSpace(req.EventID) {
+				return nil
+			}
+			return ErrInvalidVote
+		}
+		if s.redis != nil {
+			if err := s.ensureLiveEventLoadedFromRedis(ctx, strings.TrimSpace(req.EventID), strings.TrimSpace(req.StreamerID)); err != nil {
+				return err
+			}
+		} else if err := s.ensureLiveEventLoaded(ctx, strings.TrimSpace(req.EventID), strings.TrimSpace(req.StreamerID)); err != nil {
+			return err
+		}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	item, ok := s.items[strings.TrimSpace(req.EventID)]
+	if !ok || item.event.StreamerID != strings.TrimSpace(req.StreamerID) {
+		return ErrEventNotFound
+	}
+	if !isOpen(item.event, time.Now().UTC()) {
+		return ErrEventClosed
+	}
+	if existing, ok := item.processedVotes[strings.TrimSpace(req.IdempotencyKey)]; ok {
+		if strings.TrimSpace(existing.OptionID) == strings.TrimSpace(req.OptionID) {
+			return nil
+		}
+		return ErrInvalidVote
+	}
+	if _, ok := item.event.Totals[strings.TrimSpace(req.OptionID)]; !ok {
+		return ErrInvalidVote
+	}
+	return nil
+}
+
 func (s *Service) Vote(ctx context.Context, req VoteRequest) (LiveEvent, error) {
 	if strings.TrimSpace(req.EventID) == "" || strings.TrimSpace(req.StreamerID) == "" || strings.TrimSpace(req.UserID) == "" || strings.TrimSpace(req.OptionID) == "" || req.Amount <= 0 || strings.TrimSpace(req.IdempotencyKey) == "" {
 		return LiveEvent{}, ErrInvalidVote
@@ -497,13 +542,28 @@ func (s *Service) Vote(ctx context.Context, req VoteRequest) (LiveEvent, error) 
 	if _, ok := item.event.Totals[optionID]; !ok {
 		return LiveEvent{}, ErrInvalidVote
 	}
+	userID := strings.TrimSpace(req.UserID)
+	previousEvent := cloneLiveEvent(item.event)
+	previousUserVote, hadPreviousUserVote := item.userVotes[userID]
+	rollbackVoteMutation := func() {
+		item.event = previousEvent
+		if hadPreviousUserVote {
+			item.userVotes[userID] = previousUserVote
+		} else {
+			delete(item.userVotes, userID)
+		}
+		delete(item.processedVotes, strings.TrimSpace(req.IdempotencyKey))
+		if s.redis != nil {
+			_ = s.persistLiveState(ctx, previousEvent)
+		}
+	}
 	fee := calculateFee(req.Amount, s.votePlatformFeeBPS)
 	netAmount := req.Amount - fee
 	item.event.Totals[optionID] += netAmount
 	item.event.TotalContributed += req.Amount
 	item.event.PlatformFeeINT += fee
 	item.event.DistributableINT = item.event.TotalContributed - item.event.PlatformFeeINT
-	userVote := item.userVotes[strings.TrimSpace(req.UserID)]
+	userVote := item.userVotes[userID]
 	if userVote.OptionID == "" {
 		userVote.OptionID = optionID
 	}
@@ -511,10 +571,11 @@ func (s *Service) Vote(ctx context.Context, req VoteRequest) (LiveEvent, error) 
 		userVote.OptionID = optionID
 	}
 	userVote.Amount += req.Amount
-	item.userVotes[strings.TrimSpace(req.UserID)] = userVote
+	item.userVotes[userID] = userVote
 	item.processedVotes[strings.TrimSpace(req.IdempotencyKey)] = voteRecord{OptionID: optionID, Amount: req.Amount}
 	if s.redis != nil {
 		if err := s.persistLiveState(ctx, item.event); err != nil {
+			rollbackVoteMutation()
 			return LiveEvent{}, err
 		}
 	}
@@ -526,6 +587,7 @@ func (s *Service) Vote(ctx context.Context, req VoteRequest) (LiveEvent, error) 
 			}
 		}
 		if err := s.persistVoteDB(ctx, eventForHistory, req, optionID); err != nil {
+			rollbackVoteMutation()
 			return LiveEvent{}, err
 		}
 	}
@@ -537,7 +599,6 @@ func (s *Service) Vote(ctx context.Context, req VoteRequest) (LiveEvent, error) 
 		optionPool,
 		req.Amount,
 	)
-	userID := strings.TrimSpace(req.UserID)
 	historyItem := UserEventHistoryItem{
 		EventID:          item.event.ID,
 		StreamerID:       item.event.StreamerID,
@@ -997,6 +1058,23 @@ func calculateCoefficient(distributableINT, optionPoolINT int64) float64 {
 	return float64(distributableINT) / float64(optionPoolINT)
 }
 
+func cloneLiveEvent(event LiveEvent) LiveEvent {
+	copyEvent := event
+	copyEvent.Title = cloneStringsMap(event.Title)
+	copyEvent.Options = append([]Option(nil), event.Options...)
+	if event.Totals != nil {
+		copyEvent.Totals = make(map[string]int64, len(event.Totals))
+		for key, value := range event.Totals {
+			copyEvent.Totals[key] = value
+		}
+	}
+	if event.UserVote != nil {
+		userVote := *event.UserVote
+		copyEvent.UserVote = &userVote
+	}
+	return copyEvent
+}
+
 func cloneStringsMap(src map[string]string) map[string]string {
 	if src == nil {
 		return nil
@@ -1016,6 +1094,30 @@ func calculateFee(amount int64, feeBPS int64) int64 {
 		return amount
 	}
 	return (amount * feeBPS) / 10000
+}
+
+func (event LiveEvent) Market() LiveEventMarket {
+	options := make(map[string]OptionMarket, len(event.Totals))
+	for optionID, pool := range event.Totals {
+		sharePct := 0.0
+		if event.DistributableINT > 0 && pool > 0 {
+			sharePct = (float64(pool) / float64(event.DistributableINT)) * 100
+		}
+		options[optionID] = OptionMarket{
+			PoolINT:     pool,
+			SharePct:    roundMarketFloat(sharePct),
+			Coefficient: roundMarketFloat(calculateCoefficient(event.DistributableINT, pool)),
+		}
+	}
+	return LiveEventMarket{Options: options}
+}
+
+func (event LiveEvent) PotentialWinINT(optionID string, amountINT int64) int64 {
+	return CalculateAccrualINT(event.TotalContributed, event.PlatformFeeINT, event.Totals[strings.TrimSpace(optionID)], amountINT)
+}
+
+func roundMarketFloat(value float64) float64 {
+	return math.Round(value*10000) / 10000
 }
 
 // CalculateAccrualINT calculates user's accrual from the distributable event pool.

--- a/internal/realtime/hub.go
+++ b/internal/realtime/hub.go
@@ -11,11 +11,14 @@ type Envelope struct {
 }
 
 type VoteFeedItem struct {
-	UserID    string `json:"userId"`
-	Nickname  string `json:"nickname"`
-	OptionID  string `json:"optionId"`
-	AmountINT int64  `json:"amountINT"`
-	CreatedAt string `json:"createdAt"`
+	UserID             string  `json:"userId"`
+	Nickname           string  `json:"nickname"`
+	OptionID           string  `json:"optionId"`
+	AmountINT          int64   `json:"amountINT"`
+	OptionPoolSharePct float64 `json:"optionPoolSharePct"`
+	Coefficient        float64 `json:"coefficient"`
+	PotentialWinINT    int64   `json:"potentialWinINT"`
+	CreatedAt          string  `json:"createdAt"`
 }
 
 type VoteFeedPayload struct {
@@ -24,10 +27,20 @@ type VoteFeedPayload struct {
 	SnapshotAt string         `json:"snapshotAt"`
 }
 
+type EventOptionMarket struct {
+	PoolINT     int64   `json:"poolINT"`
+	SharePct    float64 `json:"sharePct"`
+	Coefficient float64 `json:"coefficient"`
+}
+
 type EventUpdatedPayload struct {
-	EventID  string           `json:"eventId"`
-	Totals   map[string]int64 `json:"totals"`
-	ClosesAt string           `json:"closesAt"`
+	EventID          string                       `json:"eventId"`
+	Totals           map[string]int64             `json:"totals"`
+	TotalContributed int64                        `json:"totalContributed"`
+	PlatformFeeINT   int64                        `json:"platformFeeINT"`
+	DistributableINT int64                        `json:"distributableINT"`
+	Options          map[string]EventOptionMarket `json:"options"`
+	ClosesAt         string                       `json:"closesAt"`
 }
 
 type ScenarioStepPayload struct {

--- a/internal/wallet/service.go
+++ b/internal/wallet/service.go
@@ -200,6 +200,27 @@ FROM wallet_ledger WHERE idempotency_key = $1
 	return entry, balance, nil
 }
 
+func (s *Service) HasProcessed(userID, idempotencyKey string) bool {
+	userID = strings.TrimSpace(userID)
+	idempotencyKey = strings.TrimSpace(idempotencyKey)
+	if userID == "" || idempotencyKey == "" {
+		return false
+	}
+	if s.db != nil {
+		var exists bool
+		err := s.db.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM wallet_ledger WHERE user_id = $1 AND idempotency_key = $2)`, userID, idempotencyKey).Scan(&exists)
+		return err == nil && exists
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	acct, ok := s.accounts[userID]
+	if !ok {
+		return false
+	}
+	_, ok = acct.ProcessedByIdemID[idempotencyKey]
+	return ok
+}
+
 func (s *Service) Adjust(req AdjustRequest) (Entry, int64, error) {
 	if req.Delta == 0 {
 		return Entry{}, 0, ErrInvalidDelta


### PR DESCRIPTION
### Motivation

- Enrich realtime WebSocket messages so the frontend can render live pool percentages and payout coefficients per outcome. 
- Prevent users from losing funds by ensuring the wallet debit/credit flow around event votes is validated, idempotent, and rolled back on failures. 
- Centralize error handling and payload construction for clearer, consistent runtime behavior.

### Description

- Updated `docs/ws_messages.md` to document additional fields in `EVENT_UPDATED` and `EVENT_VOTE_FEED_UPDATED` payloads for market pools, shares, coefficients, and potential wins. 
- Added realtime market types and fields in `internal/realtime/hub.go` (`EventOptionMarket`, expanded `EventUpdatedPayload`, and extended `VoteFeedItem`).
- Introduced market modeling and helpers in `internal/events` including `OptionMarket`, `LiveEventMarket`, `LiveEvent.Market()`, `LiveEvent.PotentialWinINT()`, `cloneLiveEvent()`, and `roundMarketFloat()` plus `ValidateVote()` to pre-validate vote requests. 
- Made `Vote` robust by snapshotting previous state and rolling back in case persistence or DB operations fail, and by computing market coefficients and potential wins consistently. 
- Hardened the HTTP vote handler in `internal/app/router.go` to validate votes before debiting, check existing idempotency via the wallet service (`HasProcessed`), construct structured payloads via `buildEventUpdatedPayload` and `buildVoteFeedItem`, and attempt to refund (credit) the wallet if event processing fails; factored out `writeWalletPostError` and `writeEventVoteError`. 
- Added `HasProcessed` to `internal/wallet/service.go` to allow checking whether an idempotency key was already recorded for a user. 
- Added unit tests `TestEventsVoteDoesNotDebitWalletWhenEventClosed` and `TestBuildEventUpdatedPayloadIncludesRealtimeMarket` in `internal/app/router_events_test.go` to cover closed-event behavior and payload construction.

### Testing

- Ran `go test ./...` which executed unit tests including the new `TestEventsVoteDoesNotDebitWalletWhenEventClosed` and `TestBuildEventUpdatedPayloadIncludesRealtimeMarket`, and all tests passed. 
- Verified WebSocket payload changes are reflected in `docs/ws_messages.md` and correspond to the updated structs used in code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc69d5290832cb8e0d9f3be55b4d8)