### PR TITLE
Add admin event settlement endpoint and settlement processing (win/draw) with WS and docs

### DIFF
--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -31,16 +31,21 @@
 - **Profile**: 2k vu, spike 200 rps for 60 seconds.
 - **Assertions**: No >1% rate-limit errors under configured thresholds, ledger consistency checks post-run.
 
-### S5 – Payments Lifecycle
+### S5 – Event Settlement Payouts
+- **Endpoint**: `POST /api/admin/events/{eventId}/settle` after a seeded burst of `POST /api/events/{eventId}/vote` calls.
+- **Profile**: 100 concurrent admin settlement replays against 10 events with 1k votes each, mixing `result=win` and `result=draw`.
+- **Assertions**: each payout idempotency key credits at most once; total credited winners equals `(totalContributed - platformFeeINT)` for win settlements and original vote amounts for draw settlements; p95 < 350 ms for settlement response with Redis active-state cleanup enabled.
+
+### S6 – Payments Lifecycle
 - **Endpoints**: `POST /api/payments/stars/createInvoice` followed by webhook simulation.
 - **Profile**: 200 vu, 5 rps invoice creation, webhook replay tests.
 - **Assertions**: Ledger balance increases exactly once per invoice.
 
-### S6 – WebSocket Fan-out
+### S7 – WebSocket Fan-out
 - **Setup**: 10k simulated connections per node; publish `EVENT_UPDATED` at 2 Hz.
 - **Assertions**: 99% of clients receive updates within 1 s; dropped message rate < 0.5%.
 
-### S7 – Streamlink Capture Cadence & Idempotency
+### S8 – Streamlink Capture Cadence & Idempotency
 - **Path**: background `streamlink -> source segment files -> assembled LLM chunk` scheduler for active streamers.
 - **Profile**: 100 active streamers across 15 minutes with mixed Scenario Package v2 `segmentCount` values (for example 10, 15, and 30 source segments).
 - **Assertions**: no streamer executes more than one capture cycle per configured step window; duplicate scheduler starts do not increase chunk volume; worker busy skips remain below 1% after warm-up; assembled LLM chunks advance through contiguous segment indexes with no gaps or duplicates; consumed source segments, analyzed/uploaded local videos, and stale interrupted-session artifacts do not accumulate on disk.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -217,7 +217,8 @@ On startup the server listens on `FUNPOT_SERVER_ADDRESS` and provides:
 - `GET /api/admin/streamers/{streamerId}/llm-history?page=1&pageSize=20` – admin timeline endpoint with paginated LLM decision history (step name, LLM response, global state delta, event timestamps). Each LLM event now carries its own Bunny video fragment URL in `videoData`, plus the endpoint returns uploaded Bunny video metadata for the streamer.
 - `DELETE /api/admin/streamers/{streamerId}/llm-history` – admin cleanup endpoint that deletes persisted LLM decision history and removes tracked Bunny videos for the streamer.
 - `GET /api/events/live` – returns live events for a required `streamerId` query parameter.
-- `GET /realtime?streamerId=<id>` – WebSocket upgrade endpoint (JWT required in `Authorization: Bearer <token>`), streams streamer updates (`EVENT_UPDATED`, `EVENT_VOTE_FEED_UPDATED`) and user-scoped updates (`BALANCE_UPDATED`, `USER_BET_UPDATED`).
+- `POST /api/admin/events/{eventId}/settle` – admin-only settlement endpoint. Send `result=win` with `winningOptionId` to credit winners from the distributable pool after the admin-configured platform fee, or `result=draw` to refund original vote amounts.
+- `GET /realtime?streamerId=<id>` – WebSocket upgrade endpoint (JWT required in `Authorization: Bearer <token>`), streams streamer updates (`EVENT_UPDATED`, `EVENT_VOTE_FEED_UPDATED`, `EVENT_SETTLED`) and user-scoped updates (`BALANCE_UPDATED`, `USER_BET_UPDATED`).
 - `GET /api/admin/games` – admin-only endpoint listing all configured games.
 - `POST /api/admin/games` – admin-only endpoint creating a game definition.
 - `PUT /api/admin/games/{gameId}` – admin-only endpoint updating a game definition.
@@ -248,6 +249,7 @@ Authorization: Bearer <jwt>
    - `EVENT_VOTE_FEED_UPDATED` (nickname + option + amount),
    - `BALANCE_UPDATED` (your new balance),
    - `USER_BET_UPDATED` (your cumulative stake, coefficient, potential payout).
+6. Settle as admin via `POST /api/admin/events/{eventId}/settle` and verify `EVENT_SETTLED` plus winner/refund `BALANCE_UPDATED` messages.
 
 When database connection fields are unset the server falls back to the in-memory
 repository for user profiles. This is useful for quick smoke tests but bypasses

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -425,6 +425,38 @@ paths:
         default:
           $ref: '#/components/responses/Error'
 
+  /api/admin/events/{eventId}/settle:
+    post:
+      summary: Settle live event outcome and credit winner/draw payouts (admin)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: eventId
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminEventSettleRequest'
+      responses:
+        '200':
+          description: Settled event and credited payouts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventSettlement'
+        default:
+          $ref: '#/components/responses/Error'
+
 
   /api/rewards/weekly/claim:
     post:
@@ -2136,6 +2168,57 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ScenarioGraphGroup'
+
+    AdminEventSettleRequest:
+      type: object
+      required: [streamerId, result]
+      properties:
+        streamerId:
+          type: string
+        winningOptionId:
+          type: string
+          description: Required when result is win; omitted for draw/refund settlement.
+        result:
+          type: string
+          enum: [win, draw]
+    EventSettlementPayout:
+      type: object
+      properties:
+        userId:
+          type: string
+        optionId:
+          type: string
+        amountINT:
+          type: integer
+        winAmountINT:
+          type: integer
+        resultStatus:
+          type: string
+          enum: [won, lost, draw]
+        idempotencyKey:
+          type: string
+    EventSettlement:
+      type: object
+      properties:
+        event:
+          $ref: '#/components/schemas/LiveEvent'
+        winningOptionId:
+          type: string
+        result:
+          type: string
+          enum: [win, draw]
+        payouts:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventSettlementPayout'
+        totalPayoutINT:
+          type: integer
+        platformFeeINT:
+          type: integer
+          description: Admin-configured platform fee already withheld from the distributable winner pool.
+        distributableINT:
+          type: integer
+
     LiveEvent:
       type: object
       properties:
@@ -2251,7 +2334,7 @@ components:
           nullable: true
         resultStatus:
           type: string
-          enum: [pending, won, lost]
+          enum: [pending, won, lost, draw]
     UserEventHistoryStreamerItem:
       type: object
       properties:

--- a/docs/ws_messages.md
+++ b/docs/ws_messages.md
@@ -70,6 +70,31 @@ Payload schema:
 ```
 Real-time feed of participant votes for the mini-game, including who placed the vote, selected option, current option share, current coefficient, and potential win for that vote amount. Frontend should append `items` to the vote tape and reconcile by `eventId + userId + createdAt`.
 
+
+### EVENT_SETTLED
+Payload schema:
+```json
+{
+  "event": { "id": "uuid", "status": "settled" },
+  "winningOptionId": "ct",
+  "result": "win",
+  "payouts": [
+    {
+      "userId": "uuid",
+      "optionId": "ct",
+      "amountINT": 100,
+      "winAmountINT": 180,
+      "resultStatus": "won",
+      "idempotencyKey": "event_settlement:event:user:vote"
+    }
+  ],
+  "totalPayoutINT": 180,
+  "platformFeeINT": 20,
+  "distributableINT": 180
+}
+```
+Sent after an admin settles a mini-game. `result=win` pays winning-option voters from the distributable pool after the admin platform fee; `result=draw` refunds original vote amounts and marks history as `draw`.
+
 ### EVENT_CLOSED
 Payload schema:
 ```json

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -346,6 +346,12 @@ type eventVoteRequest struct {
 	AmountINT  int64  `json:"amountINT"`
 }
 
+type adminEventSettleRequest struct {
+	StreamerID      string              `json:"streamerId"`
+	WinningOptionID string              `json:"winningOptionId,omitempty"`
+	Result          events.SettleResult `json:"result"`
+}
+
 type adminUsersResponse struct {
 	Page     int             `json:"page"`
 	PageSize int             `json:"pageSize"`
@@ -1123,6 +1129,87 @@ func NewHandler(
 			})))
 		}
 
+		if walletService != nil && eventsService != nil {
+			mux.Handle("/api/admin/events/", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !requireAdmin(w, r, adminService) {
+					writeError(w, http.StatusForbidden, "admin role is required")
+					return
+				}
+				if r.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				path := strings.TrimPrefix(r.URL.Path, "/api/admin/events/")
+				if !strings.HasSuffix(path, "/settle") {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				eventID := strings.TrimSpace(strings.TrimSuffix(strings.TrimSuffix(path, "/settle"), "/"))
+				if eventID == "" {
+					writeError(w, http.StatusBadRequest, "event id is required")
+					return
+				}
+				claims, ok := auth.ClaimsFromContext(r.Context())
+				if !ok {
+					writeError(w, http.StatusUnauthorized, "missing auth claims")
+					return
+				}
+				idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+				if idempotencyKey == "" {
+					writeError(w, http.StatusBadRequest, wallet.ErrIdempotencyRequired.Error())
+					return
+				}
+				defer r.Body.Close() //nolint:errcheck
+				body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+				if err != nil {
+					writeError(w, http.StatusBadRequest, "failed to read request body")
+					return
+				}
+				var req adminEventSettleRequest
+				if err := decodeJSONStrict(body, &req); err != nil {
+					writeError(w, http.StatusBadRequest, "invalid request body")
+					return
+				}
+				settlement, err := eventsService.SettleEvent(r.Context(), events.SettleRequest{
+					EventID:         eventID,
+					StreamerID:      req.StreamerID,
+					WinningOptionID: req.WinningOptionID,
+					Result:          req.Result,
+					IdempotencyKey:  idempotencyKey,
+					ActorID:         claims.Subject,
+				})
+				if err != nil {
+					writeEventSettlementError(w, logger, eventID, err)
+					return
+				}
+				for _, payout := range settlement.Payouts {
+					if payout.WinAmountINT <= 0 {
+						continue
+					}
+					reason := "event_win"
+					if payout.ResultStatus == events.ResultStatusDraw {
+						reason = "event_draw_refund"
+					}
+					_, balance, err := walletService.Post(wallet.PostRequest{
+						UserID:         payout.UserID,
+						Type:           wallet.EntryTypeCredit,
+						Amount:         payout.WinAmountINT,
+						Reason:         reason,
+						IdempotencyKey: payout.IdempotencyKey,
+						ActorID:        claims.Subject,
+					})
+					if err != nil {
+						logger.Error("failed to credit event settlement payout", zap.String("eventID", eventID), zap.String("userID", payout.UserID), zap.Error(err))
+						writeError(w, http.StatusInternalServerError, "failed to credit event settlement payout")
+						return
+					}
+					rtHub.PublishToUser(payout.UserID, realtime.Envelope{Type: "BALANCE_UPDATED", Payload: map[string]int64{"balance": balance}})
+				}
+				rtHub.PublishToStreamer(req.StreamerID, realtime.Envelope{Type: "EVENT_SETTLED", Payload: settlement})
+				writeJSON(w, http.StatusOK, settlement)
+			})))
+		}
+
 		if streamersService != nil {
 			mux.Handle("/api/streamers", authed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.Method {
@@ -1845,6 +1932,7 @@ func NewHandler(
 							StreamerNickname: item.StreamerID,
 							Details:          []events.UserEventHistoryItem{},
 						}
+
 						if streamersService != nil {
 							if streamer, found := streamersService.GetByID(r.Context(), item.StreamerID); found {
 								entry.StreamerNickname = streamer.TwitchNickname
@@ -2028,6 +2116,20 @@ func writeEventVoteError(w http.ResponseWriter, logger *zap.Logger, eventID stri
 	default:
 		logger.Error("failed to process event vote", zap.String("eventID", eventID), zap.Error(err))
 		writeError(w, http.StatusInternalServerError, "failed to process vote")
+	}
+}
+
+func writeEventSettlementError(w http.ResponseWriter, logger *zap.Logger, eventID string, err error) {
+	switch {
+	case errors.Is(err, events.ErrInvalidSettlement):
+		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, events.ErrEventNotFound):
+		writeError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, events.ErrEventClosed), errors.Is(err, events.ErrEventSettled):
+		writeError(w, http.StatusConflict, err.Error())
+	default:
+		logger.Error("failed to settle event", zap.String("eventID", eventID), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to settle event")
 	}
 }
 

--- a/internal/app/router_events_test.go
+++ b/internal/app/router_events_test.go
@@ -448,3 +448,103 @@ func TestWeeklyRewardClaimCreditsWalletAndRespects24h(t *testing.T) {
 		t.Fatalf("expected wallet balance 10, got %d", walletPayload.Balance)
 	}
 }
+
+func TestAdminEventSettlementCreditsWinnerWithPlatformFee(t *testing.T) {
+	eventsService := events.NewService([]events.LiveEvent{{
+		ID:              "event-settle",
+		TemplateID:      "streamer-1:terminal-1",
+		StreamerID:      "streamer-1",
+		ScenarioID:      "scenario-1",
+		TerminalID:      "terminal-1",
+		Title:           map[string]string{"ru": "Победитель карты"},
+		DefaultLanguage: "ru",
+		Options: []events.Option{
+			{ID: "ct", Title: map[string]string{"ru": "CT"}},
+			{ID: "t", Title: map[string]string{"ru": "T"}},
+		},
+		ClosesAt:  time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+		CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		Status:    "open",
+		Totals:    map[string]int64{"ct": 0, "t": 0},
+	}})
+	userService := users.NewService(users.NewInMemoryRepository())
+	created, err := userService.SyncTelegramProfile(context.Background(), users.TelegramProfile{ID: 1, Username: "u1"})
+	if err != nil {
+		t.Fatalf("SyncTelegramProfile() error = %v", err)
+	}
+	handler := NewHandler(
+		zap.NewNop(),
+		func() bool { return true },
+		nil,
+		buildAuthService(t),
+		admin.NewService([]string{"admin-1"}),
+		userService,
+		nil,
+		nil,
+		nil,
+		nil,
+		eventsService,
+		ClientConfigResponse{},
+	)
+	adminToken := buildToken(t, "admin-1")
+	userToken := buildToken(t, created.ID)
+
+	settingsReq := httptest.NewRequest(http.MethodPut, "/api/admin/settings/general", bytes.NewReader([]byte(`{"votePlatformFeePercent":15}`)))
+	settingsReq.Header.Set("Authorization", "Bearer "+adminToken)
+	settingsRes := httptest.NewRecorder()
+	handler.ServeHTTP(settingsRes, settingsReq)
+	if settingsRes.Code != http.StatusOK {
+		t.Fatalf("settings status=%d body=%s", settingsRes.Code, settingsRes.Body.String())
+	}
+
+	adjustReq := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+created.ID, bytes.NewReader([]byte(`{"balanceDeltaINT":100,"balanceReason":"seed"}`)))
+	adjustReq.Header.Set("Authorization", "Bearer "+adminToken)
+	adjustReq.Header.Set("Idempotency-Key", "settle-adj-seed")
+	adjustRes := httptest.NewRecorder()
+	handler.ServeHTTP(adjustRes, adjustReq)
+	if adjustRes.Code != http.StatusOK {
+		t.Fatalf("seed wallet status=%d body=%s", adjustRes.Code, adjustRes.Body.String())
+	}
+
+	voteReq := httptest.NewRequest(http.MethodPost, "/api/events/event-settle/vote", bytes.NewReader([]byte(`{"streamerId":"streamer-1","optionId":"ct","amountINT":100}`)))
+	voteReq.Header.Set("Authorization", "Bearer "+userToken)
+	voteReq.Header.Set("Idempotency-Key", "settle-vote-1")
+	voteRes := httptest.NewRecorder()
+	handler.ServeHTTP(voteRes, voteReq)
+	if voteRes.Code != http.StatusOK {
+		t.Fatalf("vote status=%d body=%s", voteRes.Code, voteRes.Body.String())
+	}
+
+	settleReq := httptest.NewRequest(http.MethodPost, "/api/admin/events/event-settle/settle", bytes.NewReader([]byte(`{"streamerId":"streamer-1","winningOptionId":"ct","result":"win"}`)))
+	settleReq.Header.Set("Authorization", "Bearer "+adminToken)
+	settleReq.Header.Set("Idempotency-Key", "settle-event-1")
+	settleRes := httptest.NewRecorder()
+	handler.ServeHTTP(settleRes, settleReq)
+	if settleRes.Code != http.StatusOK {
+		t.Fatalf("settle status=%d body=%s", settleRes.Code, settleRes.Body.String())
+	}
+	var settlement events.Settlement
+	if err := json.Unmarshal(settleRes.Body.Bytes(), &settlement); err != nil {
+		t.Fatalf("unmarshal settlement: %v", err)
+	}
+	if settlement.TotalPayoutINT != 85 || settlement.PlatformFeeINT != 15 || settlement.DistributableINT != 85 {
+		t.Fatalf("unexpected settlement: %+v", settlement)
+	}
+
+	walletReq := httptest.NewRequest(http.MethodGet, "/api/wallet", nil)
+	walletReq.Header.Set("Authorization", "Bearer "+userToken)
+	walletRes := httptest.NewRecorder()
+	handler.ServeHTTP(walletRes, walletReq)
+	if walletRes.Code != http.StatusOK {
+		t.Fatalf("wallet status=%d body=%s", walletRes.Code, walletRes.Body.String())
+	}
+	var walletPayload struct {
+		Balance int64 `json:"balance"`
+	}
+	if err := json.Unmarshal(walletRes.Body.Bytes(), &walletPayload); err != nil {
+		t.Fatalf("unmarshal wallet response: %v", err)
+	}
+	if walletPayload.Balance != 85 {
+		t.Fatalf("expected wallet balance 85 after platform-fee settlement, got %d", walletPayload.Balance)
+	}
+}

--- a/internal/events/model.go
+++ b/internal/events/model.go
@@ -22,6 +22,13 @@ type LiveEventMarket struct {
 	Options map[string]OptionMarket `json:"options"`
 }
 
+const (
+	ResultStatusPending = "pending"
+	ResultStatusWon     = "won"
+	ResultStatusLost    = "lost"
+	ResultStatusDraw    = "draw"
+)
+
 type UserEventHistoryItem struct {
 	EventID          string            `json:"eventId"`
 	StreamerID       string            `json:"streamerId"`
@@ -83,4 +90,39 @@ type VoteRequest struct {
 	Amount         int64
 	IdempotencyKey string
 	WalletLedgerID string
+}
+
+type SettleResult string
+
+const (
+	SettleResultWin  SettleResult = "win"
+	SettleResultDraw SettleResult = "draw"
+)
+
+type SettleRequest struct {
+	EventID         string       `json:"-"`
+	StreamerID      string       `json:"streamerId"`
+	WinningOptionID string       `json:"winningOptionId,omitempty"`
+	Result          SettleResult `json:"result"`
+	IdempotencyKey  string       `json:"-"`
+	ActorID         string       `json:"-"`
+}
+
+type SettlementPayout struct {
+	UserID         string `json:"userId"`
+	OptionID       string `json:"optionId"`
+	AmountINT      int64  `json:"amountINT"`
+	WinAmountINT   int64  `json:"winAmountINT"`
+	ResultStatus   string `json:"resultStatus"`
+	IdempotencyKey string `json:"idempotencyKey"`
+}
+
+type Settlement struct {
+	Event            LiveEvent          `json:"event"`
+	WinningOptionID  string             `json:"winningOptionId,omitempty"`
+	Result           SettleResult       `json:"result"`
+	Payouts          []SettlementPayout `json:"payouts"`
+	TotalPayoutINT   int64              `json:"totalPayoutINT"`
+	PlatformFeeINT   int64              `json:"platformFeeINT"`
+	DistributableINT int64              `json:"distributableINT"`
 }

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -17,11 +17,13 @@ import (
 )
 
 var (
-	ErrInvalidEvent  = errors.New("event payload is invalid")
-	ErrEventNotFound = errors.New("event not found")
-	ErrEventClosed   = errors.New("event is closed")
-	ErrInvalidVote   = errors.New("vote payload is invalid")
-	ErrAlreadyActive = errors.New("active event already exists for template")
+	ErrInvalidEvent      = errors.New("event payload is invalid")
+	ErrEventNotFound     = errors.New("event not found")
+	ErrEventClosed       = errors.New("event is closed")
+	ErrInvalidVote       = errors.New("vote payload is invalid")
+	ErrAlreadyActive     = errors.New("active event already exists for template")
+	ErrInvalidSettlement = errors.New("event settlement payload is invalid")
+	ErrEventSettled      = errors.New("event is already settled")
 )
 
 type voteRecord struct {
@@ -42,6 +44,7 @@ type Service struct {
 	liveTTL            time.Duration
 	items              map[string]*liveEventState
 	historyByUser      map[string][]UserEventHistoryItem
+	settlementsByEvent map[string]Settlement
 	votePlatformFeeBPS int64
 	nicknameChangeCost int64
 	weeklyRewardByDay  [7]int64
@@ -90,6 +93,7 @@ func NewService(seed []LiveEvent) *Service {
 	return &Service{
 		items:              items,
 		historyByUser:      map[string][]UserEventHistoryItem{},
+		settlementsByEvent: map[string]Settlement{},
 		weeklyClaimsByUser: map[string]weeklyClaimState{},
 	}
 }
@@ -616,12 +620,267 @@ func (s *Service) Vote(ctx context.Context, req VoteRequest) (LiveEvent, error) 
 		OptionPoolINT:    optionPool,
 		Coefficient:      coefficient,
 		PotentialWinINT:  potentialWin,
-		ResultStatus:     "pending",
+		ResultStatus:     ResultStatusPending,
 	}
 	s.historyByUser[userID] = append(s.historyByUser[userID], historyItem)
 	event := item.event
 	event.UserVote = &UserVote{OptionID: userVote.OptionID, TotalAmount: userVote.Amount}
 	return event, nil
+}
+
+func (s *Service) SettleEvent(ctx context.Context, req SettleRequest) (Settlement, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	prepared, err := normalizeSettleRequest(req)
+	if err != nil {
+		return Settlement{}, err
+	}
+	if s.db != nil {
+		if s.redis != nil {
+			if err := s.ensureLiveEventLoadedFromRedis(ctx, prepared.EventID, prepared.StreamerID); err != nil {
+				return Settlement{}, err
+			}
+		} else if err := s.ensureLiveEventLoaded(ctx, prepared.EventID, prepared.StreamerID); err != nil {
+			return Settlement{}, err
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if settlement, ok := s.settlementsByEvent[prepared.EventID]; ok {
+		return cloneSettlement(settlement), nil
+	}
+	item, ok := s.items[prepared.EventID]
+	if !ok || item.event.StreamerID != prepared.StreamerID {
+		return Settlement{}, ErrEventNotFound
+	}
+	if strings.EqualFold(item.event.Status, "settled") {
+		return Settlement{}, ErrEventSettled
+	}
+	if strings.EqualFold(item.event.Status, "cancelled") {
+		return Settlement{}, ErrEventClosed
+	}
+	if prepared.Result == SettleResultWin {
+		if _, ok := item.event.Totals[prepared.WinningOptionID]; !ok {
+			return Settlement{}, ErrInvalidSettlement
+		}
+	}
+
+	event := cloneLiveEvent(item.event)
+	event.Status = "settled"
+	if event.Totals == nil {
+		event.Totals = map[string]int64{}
+	}
+	payouts, totalPayout := s.applySettlementToHistoryLocked(event, prepared)
+	settlement := Settlement{
+		Event:            event,
+		WinningOptionID:  prepared.WinningOptionID,
+		Result:           prepared.Result,
+		Payouts:          payouts,
+		TotalPayoutINT:   totalPayout,
+		PlatformFeeINT:   event.PlatformFeeINT,
+		DistributableINT: event.DistributableINT,
+	}
+	if s.db != nil {
+		dbPayouts, dbTotalPayout, err := s.persistSettlementDB(ctx, event, prepared)
+		if err != nil {
+			return Settlement{}, err
+		}
+		if len(dbPayouts) > 0 || dbTotalPayout > 0 {
+			settlement.Payouts = dbPayouts
+			settlement.TotalPayoutINT = dbTotalPayout
+		}
+	}
+	item.event = event
+	if s.redis != nil {
+		_ = s.deleteLiveState(ctx, item.event)
+	}
+	s.settlementsByEvent[prepared.EventID] = settlement
+	return cloneSettlement(settlement), nil
+}
+
+func normalizeSettleRequest(req SettleRequest) (SettleRequest, error) {
+	prepared := SettleRequest{
+		EventID:         strings.TrimSpace(req.EventID),
+		StreamerID:      strings.TrimSpace(req.StreamerID),
+		WinningOptionID: strings.TrimSpace(req.WinningOptionID),
+		Result:          req.Result,
+		IdempotencyKey:  strings.TrimSpace(req.IdempotencyKey),
+		ActorID:         strings.TrimSpace(req.ActorID),
+	}
+	if prepared.EventID == "" || prepared.StreamerID == "" {
+		return SettleRequest{}, ErrInvalidSettlement
+	}
+	if prepared.Result == "" {
+		if prepared.WinningOptionID != "" {
+			prepared.Result = SettleResultWin
+		} else {
+			return SettleRequest{}, ErrInvalidSettlement
+		}
+	}
+	switch prepared.Result {
+	case SettleResultWin:
+		if prepared.WinningOptionID == "" {
+			return SettleRequest{}, ErrInvalidSettlement
+		}
+	case SettleResultDraw:
+		prepared.WinningOptionID = ""
+	default:
+		return SettleRequest{}, ErrInvalidSettlement
+	}
+	return prepared, nil
+}
+
+func (s *Service) applySettlementToHistoryLocked(event LiveEvent, req SettleRequest) ([]SettlementPayout, int64) {
+	payouts := make([]SettlementPayout, 0)
+	totalPayout := int64(0)
+	winningContributionINT := int64(0)
+	if req.Result == SettleResultWin {
+		for _, items := range s.historyByUser {
+			for _, item := range items {
+				if item.EventID == event.ID && strings.TrimSpace(item.OptionID) == strings.TrimSpace(req.WinningOptionID) {
+					winningContributionINT += item.AmountINT
+				}
+			}
+		}
+	}
+	for userID, items := range s.historyByUser {
+		for idx := range items {
+			if items[idx].EventID != event.ID {
+				continue
+			}
+			winAmount, resultStatus := settlementAmountAndStatus(event, req, items[idx].OptionID, items[idx].AmountINT, winningContributionINT)
+			items[idx].WinAmountINT = int64Ptr(winAmount)
+			items[idx].ResultStatus = resultStatus
+			if winAmount <= 0 {
+				continue
+			}
+			payouts = append(payouts, SettlementPayout{
+				UserID:         userID,
+				OptionID:       items[idx].OptionID,
+				AmountINT:      items[idx].AmountINT,
+				WinAmountINT:   winAmount,
+				ResultStatus:   resultStatus,
+				IdempotencyKey: settlementPayoutIdempotencyKey(event.ID, userID, strconv.Itoa(idx)),
+			})
+			totalPayout += winAmount
+		}
+		s.historyByUser[userID] = items
+	}
+	return payouts, totalPayout
+}
+
+func settlementAmountAndStatus(event LiveEvent, req SettleRequest, optionID string, amountINT, winningContributionINT int64) (int64, string) {
+	if amountINT <= 0 {
+		return 0, ResultStatusLost
+	}
+	if req.Result == SettleResultDraw {
+		return amountINT, ResultStatusDraw
+	}
+	if strings.TrimSpace(optionID) != strings.TrimSpace(req.WinningOptionID) {
+		return 0, ResultStatusLost
+	}
+	if event.DistributableINT <= 0 || winningContributionINT <= 0 {
+		return 0, ResultStatusWon
+	}
+	return (event.DistributableINT * amountINT) / winningContributionINT, ResultStatusWon
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
+}
+
+func settlementPayoutIdempotencyKey(eventID, userID, voteRef string) string {
+	return "event_settlement:" + strings.TrimSpace(eventID) + ":" + strings.TrimSpace(userID) + ":" + strings.TrimSpace(voteRef)
+}
+
+type settlementVoteRow struct {
+	ID       string
+	UserID   string
+	OptionID string
+	Amount   int64
+}
+
+func (s *Service) persistSettlementDB(ctx context.Context, event LiveEvent, req SettleRequest) ([]SettlementPayout, int64, error) {
+	metadataJSON, err := json.Marshal(map[string]any{
+		"settlementResult":  req.Result,
+		"winningOptionId":   req.WinningOptionID,
+		"settlementActorId": strings.TrimSpace(req.ActorID),
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE live_event_history SET status = 'settled', closed_at = COALESCE(closed_at, NOW()), metadata = metadata || $2::jsonb, updated_at = NOW() WHERE id = $1 AND streamer_id = $3 AND status <> 'settled'`, event.ID, string(metadataJSON), event.StreamerID)
+	if err != nil {
+		return nil, 0, err
+	}
+	if rowsAffected, _ := result.RowsAffected(); rowsAffected == 0 {
+		return nil, 0, ErrEventSettled
+	}
+
+	rows, err := s.db.QueryContext(ctx, `SELECT id, user_id, option_id, amount_int FROM live_event_vote_history WHERE event_id = $1 ORDER BY created_at ASC, id ASC`, event.ID)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close() //nolint:errcheck
+	votes := make([]settlementVoteRow, 0)
+	for rows.Next() {
+		var vote settlementVoteRow
+		if err := rows.Scan(&vote.ID, &vote.UserID, &vote.OptionID, &vote.Amount); err != nil {
+			return nil, 0, err
+		}
+		votes = append(votes, vote)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	winningContributionINT := int64(0)
+	if req.Result == SettleResultWin {
+		for _, vote := range votes {
+			if strings.TrimSpace(vote.OptionID) == strings.TrimSpace(req.WinningOptionID) {
+				winningContributionINT += vote.Amount
+			}
+		}
+	}
+	payouts := make([]SettlementPayout, 0, len(votes))
+	totalPayout := int64(0)
+	for _, vote := range votes {
+		winAmount, resultStatus := settlementAmountAndStatus(event, req, vote.OptionID, vote.Amount, winningContributionINT)
+		voteMetadataJSON, err := json.Marshal(map[string]any{
+			"settlementResult": req.Result,
+			"winningOptionId":  req.WinningOptionID,
+			"resultStatus":     resultStatus,
+			"winAmountINT":     winAmount,
+		})
+		if err != nil {
+			return nil, 0, err
+		}
+		if _, err := s.db.ExecContext(ctx, `UPDATE live_event_vote_history SET metadata = metadata || $2::jsonb WHERE id = $1`, vote.ID, string(voteMetadataJSON)); err != nil {
+			return nil, 0, err
+		}
+		if winAmount <= 0 {
+			continue
+		}
+		payouts = append(payouts, SettlementPayout{
+			UserID:         vote.UserID,
+			OptionID:       vote.OptionID,
+			AmountINT:      vote.Amount,
+			WinAmountINT:   winAmount,
+			ResultStatus:   resultStatus,
+			IdempotencyKey: settlementPayoutIdempotencyKey(event.ID, vote.UserID, vote.ID),
+		})
+		totalPayout += winAmount
+	}
+	return payouts, totalPayout, nil
+}
+
+func cloneSettlement(settlement Settlement) Settlement {
+	copySettlement := settlement
+	copySettlement.Event = cloneLiveEvent(settlement.Event)
+	copySettlement.Payouts = append([]SettlementPayout(nil), settlement.Payouts...)
+	return copySettlement
 }
 
 func (s *Service) persistLiveState(ctx context.Context, event LiveEvent) error {

--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -397,3 +397,89 @@ func TestListLiveByStreamerUsesRedisAsActiveSourceWhenPostgresExists(t *testing.
 		t.Fatalf("unexpected db calls: %v", err)
 	}
 }
+
+func TestSettleEventMarksWinLossAndUsesPlatformFee(t *testing.T) {
+	svc := NewService([]LiveEvent{{
+		ID:              "event-1",
+		TemplateID:      "streamer-1:terminal-1",
+		StreamerID:      "streamer-1",
+		ScenarioID:      "scenario-1",
+		TerminalID:      "terminal-1",
+		Title:           map[string]string{"ru": "Победитель"},
+		DefaultLanguage: "ru",
+		Options:         []Option{{ID: "ct", Title: map[string]string{"ru": "CT"}}, {ID: "t", Title: map[string]string{"ru": "T"}}},
+		ClosesAt:        time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+		Status:          "open",
+		Totals:          map[string]int64{"ct": 0, "t": 0},
+	}})
+	if _, err := svc.UpdateSettings(Settings{VotePlatformFeePercent: 10}); err != nil {
+		t.Fatalf("UpdateSettings() error = %v", err)
+	}
+	if _, err := svc.Vote(context.Background(), VoteRequest{EventID: "event-1", StreamerID: "streamer-1", UserID: "winner", OptionID: "ct", Amount: 100, IdempotencyKey: "vote-win"}); err != nil {
+		t.Fatalf("winner Vote() error = %v", err)
+	}
+	if _, err := svc.Vote(context.Background(), VoteRequest{EventID: "event-1", StreamerID: "streamer-1", UserID: "loser", OptionID: "t", Amount: 100, IdempotencyKey: "vote-lose"}); err != nil {
+		t.Fatalf("loser Vote() error = %v", err)
+	}
+
+	settlement, err := svc.SettleEvent(context.Background(), SettleRequest{EventID: "event-1", StreamerID: "streamer-1", WinningOptionID: "ct", Result: SettleResultWin, ActorID: "admin"})
+	if err != nil {
+		t.Fatalf("SettleEvent() error = %v", err)
+	}
+	if settlement.Event.Status != "settled" || settlement.PlatformFeeINT != 20 || settlement.DistributableINT != 180 || settlement.TotalPayoutINT != 180 {
+		t.Fatalf("unexpected settlement totals: %+v", settlement)
+	}
+	if len(settlement.Payouts) != 1 || settlement.Payouts[0].UserID != "winner" || settlement.Payouts[0].WinAmountINT != 180 || settlement.Payouts[0].ResultStatus != ResultStatusWon {
+		t.Fatalf("unexpected payouts: %+v", settlement.Payouts)
+	}
+
+	winnerHistory := svc.ListUserHistory(context.Background(), "winner")
+	if len(winnerHistory) != 1 || winnerHistory[0].WinAmountINT == nil || *winnerHistory[0].WinAmountINT != 180 || winnerHistory[0].ResultStatus != ResultStatusWon {
+		t.Fatalf("unexpected winner history: %+v", winnerHistory)
+	}
+	loserHistory := svc.ListUserHistory(context.Background(), "loser")
+	if len(loserHistory) != 1 || loserHistory[0].WinAmountINT == nil || *loserHistory[0].WinAmountINT != 0 || loserHistory[0].ResultStatus != ResultStatusLost {
+		t.Fatalf("unexpected loser history: %+v", loserHistory)
+	}
+}
+
+func TestSettleEventDrawRefundsOriginalAmounts(t *testing.T) {
+	svc := NewService([]LiveEvent{{
+		ID:              "event-draw",
+		TemplateID:      "streamer-1:terminal-1",
+		StreamerID:      "streamer-1",
+		ScenarioID:      "scenario-1",
+		TerminalID:      "terminal-1",
+		Title:           map[string]string{"ru": "Победитель"},
+		DefaultLanguage: "ru",
+		Options:         []Option{{ID: "ct", Title: map[string]string{"ru": "CT"}}, {ID: "t", Title: map[string]string{"ru": "T"}}},
+		ClosesAt:        time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+		Status:          "open",
+		Totals:          map[string]int64{"ct": 0, "t": 0},
+	}})
+	if _, err := svc.UpdateSettings(Settings{VotePlatformFeePercent: 25}); err != nil {
+		t.Fatalf("UpdateSettings() error = %v", err)
+	}
+	if _, err := svc.Vote(context.Background(), VoteRequest{EventID: "event-draw", StreamerID: "streamer-1", UserID: "u1", OptionID: "ct", Amount: 80, IdempotencyKey: "draw-vote-1"}); err != nil {
+		t.Fatalf("u1 Vote() error = %v", err)
+	}
+	if _, err := svc.Vote(context.Background(), VoteRequest{EventID: "event-draw", StreamerID: "streamer-1", UserID: "u2", OptionID: "t", Amount: 20, IdempotencyKey: "draw-vote-2"}); err != nil {
+		t.Fatalf("u2 Vote() error = %v", err)
+	}
+
+	settlement, err := svc.SettleEvent(context.Background(), SettleRequest{EventID: "event-draw", StreamerID: "streamer-1", Result: SettleResultDraw, ActorID: "admin"})
+	if err != nil {
+		t.Fatalf("SettleEvent(draw) error = %v", err)
+	}
+	if settlement.Result != SettleResultDraw || settlement.WinningOptionID != "" || settlement.TotalPayoutINT != 100 || len(settlement.Payouts) != 2 {
+		t.Fatalf("unexpected draw settlement: %+v", settlement)
+	}
+	for _, userID := range []string{"u1", "u2"} {
+		history := svc.ListUserHistory(context.Background(), userID)
+		if len(history) != 1 || history[0].ResultStatus != ResultStatusDraw || history[0].WinAmountINT == nil || *history[0].WinAmountINT != history[0].AmountINT {
+			t.Fatalf("unexpected draw history for %s: %+v", userID, history)
+		}
+	}
+}

--- a/internal/wallet/service.go
+++ b/internal/wallet/service.go
@@ -302,5 +302,5 @@ func (s *Service) ensureAccountLocked(userID string) *account {
 
 func isGameRelatedReason(reason string) bool {
 	reason = strings.TrimSpace(reason)
-	return reason == "event_vote"
+	return reason == "event_vote" || reason == "event_win" || reason == "event_draw_refund" || reason == "event_vote_rollback"
 }


### PR DESCRIPTION
### Motivation
- Provide an admin API to settle live mini-game events with `win` or `draw` results and ensure payouts are calculated and credited correctly.
- Ensure settlement is idempotent, persisted to DB when available, and removes/cleans live-state (Redis) to prevent double-processing.
- Notify clients of final outcome via realtime messages and expose the new operation in OpenAPI and developer docs.

### Description
- Added `POST /api/admin/events/{eventId}/settle` handler in `internal/app/router.go` with strict JSON decoding, idempotency-key requirement, admin authorization, wallet crediting for settlement payouts, and realtime `EVENT_SETTLED` publication via `rtHub.PublishToStreamer` and `rtHub.PublishToUser`.
- Implemented settlement domain types and logic in `internal/events` including `SettleRequest`, `Settlement`, `SettlementPayout`, `SettleResult` enums, `SettleEvent` workflow, in-memory and DB persistence (`persistSettlementDB`), idempotency key generation for payout ledger entries, and Redis live-state cleanup; added related errors and helpers (`normalizeSettleRequest`, `applySettlementToHistoryLocked`, `settlementAmountAndStatus`).
- Extended models and histories with `draw` result handling and result-status constants, and added `writeEventSettlementError` for unified error mapping in the router.
- Updated wallet reason detection in `internal/wallet/service.go` to treat `event_win` / `event_draw_refund` (and rollback) as game-related reasons so those entries get handled by account locks and idempotency logic.
- Documentation and API changes: updated `docs/load_testing.md`, `docs/local_setup.md`, `docs/ws_messages.md` to describe settlement scenario and `EVENT_SETTLED` message, and extended `docs/openapi.yaml` with the new endpoint and request/response schemas.
- Added unit tests covering settlement behavior: `internal/events/service_test.go` tests for win/distributable and draw/refund flows and `internal/app/router_events_test.go` router-level test to verify admin settlement credits wallet with platform fee.

### Testing
- Ran unit tests for events and app HTTP behavior targeting the new functionality with `go test ./internal/events -run TestSettleEvent*` and `go test ./internal/app -run TestAdminEventSettlementCreditsWinnerWithPlatformFee`, and they passed locally.
- Executed the repository test suite with `go test ./...` to validate integrations and the new API wiring, and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd0bc1b1c832cb8a0fbf69905584e)